### PR TITLE
Make decrypted Extra content selectable

### DIFF
--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -101,6 +101,7 @@
                     android:text="Extra content: "/>
                 <TextView
                     android:id="@+id/crypto_extra_show"
+                    android:textIsSelectable="true"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textColor="@android:color/black"


### PR DESCRIPTION
Previously this was not the case, which sucked for situations where you e.g. store a complicated username in the extra content and wanted to copy&paste that into a login form.
