### PR TITLE
Update password list after potential modifications

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
@@ -446,9 +446,13 @@ public class PasswordStore extends ActionBarActivity  {
                             git.add().addFilepattern("."),
                             git.commit().setMessage("[ANDROID PwdStore] Add " + data.getExtras().getString("NAME") + " from store.")
                     );
+                    updateListAdapter();
                     break;
                 case GitHandler.REQUEST_INIT:
                     initRepository(getCurrentFocus());
+                    break;
+                case GitHandler.REQUEST_PULL:
+                    updateListAdapter();
                     break;
             }
 


### PR DESCRIPTION
Previously, when you added a new password or pulled from a remote repository, you had to manually refresh the list of passwords to see the modifications.
This PR makes it so that this happens automatically when a new password is added or a pull from a remote repository was completed.
