### PR TITLE
Fix issue with servers that have GSSAPI authentication enabled.

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/config/SshConfigSessionFactory.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/SshConfigSessionFactory.java
@@ -38,6 +38,7 @@ public class SshConfigSessionFactory extends GitConfigSessionFactory {
     @Override
     protected void configure(OpenSshConfig.Host hc, Session session) {
         session.setConfig("StrictHostKeyChecking", "no");
+        session.setConfig("PreferredAuthentications", "publickey,password");
 
         CredentialsProvider provider = new CredentialsProvider() {
             @Override


### PR DESCRIPTION
Force SSH client to only try publickey and password authentication modes (in that order).