### PR TITLE
Added the ability to make an invisible password visible

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpHandler.java
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpHandler.java
@@ -17,11 +17,14 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
+import android.text.method.PasswordTransformationMethod;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -471,6 +474,7 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
             switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
                 case OpenPgpApi.RESULT_CODE_SUCCESS: {
                     // encrypt/decrypt/sign/verify
+                    final TextView textViewPassword = (TextView) findViewById(R.id.crypto_password_show);
                     if (requestCode == REQUEST_CODE_DECRYPT_AND_VERIFY && os != null) {
                         try {
                             if (returnToCiphertextField) {
@@ -481,11 +485,21 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
                                 findViewById(R.id.crypto_container).setVisibility(View.VISIBLE);
 
                                 Typeface monoTypeface = Typeface.createFromAsset(getAssets(), "fonts/sourcecodepro.ttf");
-                                String[] passContent = os.toString("UTF-8").split("\n");
-                                ((TextView) findViewById(R.id.crypto_password_show))
+                                final String[] passContent = os.toString("UTF-8").split("\n");
+                                textViewPassword
                                         .setTypeface(monoTypeface);
-                                ((TextView) findViewById(R.id.crypto_password_show))
-                                        .setText(showPassword?passContent[0]:"********");
+                                textViewPassword
+                                        .setText(passContent[0]);
+
+                                Button toggleVisibilityButton = (Button) findViewById(R.id.crypto_password_toggle_show);
+                                toggleVisibilityButton.setVisibility(showPassword?View.GONE:View.VISIBLE);
+                                textViewPassword.setTransformationMethod(showPassword?null:new HoldToShowPasswordTransformation(toggleVisibilityButton, new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        textViewPassword
+                                                .setText(passContent[0]);
+                                    }
+                                }));
                                 decodedPassword = passContent[0];
 
                                 String extraContent = os.toString("UTF-8").replaceFirst(".*\n", "");
@@ -560,9 +574,9 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
 
                                 Typeface monoTypeface = Typeface.createFromAsset(getAssets(), "fonts/sourcecodepro.ttf");
                                 String[] passContent = os.toString("UTF-8").split("\n");
-                                ((TextView) findViewById(R.id.crypto_password_show))
+                                textViewPassword
                                         .setTypeface(monoTypeface);
-                                ((TextView) findViewById(R.id.crypto_password_show))
+                                textViewPassword
                                         .setText(passContent[0]);
                                 decodedPassword = passContent[0];
 
@@ -758,4 +772,33 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
 
     }
 
+    private class HoldToShowPasswordTransformation extends PasswordTransformationMethod implements View.OnTouchListener {
+        private final Runnable onToggle;
+        private boolean shown = false;
+
+        private HoldToShowPasswordTransformation(Button button, Runnable onToggle) {
+            this.onToggle = onToggle;
+            button.setOnTouchListener(this);
+        }
+
+        @Override
+        public CharSequence getTransformation(CharSequence charSequence, View view) {
+            return shown?charSequence:super.getTransformation("12345", view);
+        }
+
+        @Override
+        public boolean onTouch(View view, MotionEvent motionEvent) {
+            switch ( motionEvent.getAction() ) {
+                case MotionEvent.ACTION_DOWN:
+                    shown = true;
+                    onToggle.run();
+                    break;
+                case MotionEvent.ACTION_UP:
+                    shown = false;
+                    onToggle.run();
+                    break;
+            }
+            return false;
+        }
+    }
 }

--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -105,6 +105,15 @@
                     android:layout_row="1"
                     android:layout_column="0"
                     android:layout_columnSpan="3"/>
+
+                <Button
+                    android:id="@+id/crypto_password_toggle_show"
+                    android:layout_width="match_parent"
+                    android:text="@string/show_password"
+                    android:layout_height="wrap_content"
+                    android:layout_row="2"
+                    android:layout_column="0"
+                    android:layout_columnSpan="3"/>
             </GridLayout>
 
             <LinearLayout

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -182,4 +182,5 @@
     <string name="no_repo_selected">Nebyl vybrát externí repozitář</string>
     <string name="no_repo_selected2">Nebyl vybrát externí repozitář</string>
     <string name="send_plaintext_password_to">Odeslat heslo jako plaintext za použití…</string>
+    <string name="show_password">Pokaż hasło</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -178,4 +178,9 @@
     <string name="autofill_apps_never">Niemals abgleichen</string>
     <string name="autofill_apps_delete">Löschen</string>
     <string name="no_repo_selected">Kein externes Repository ausgewählt</string>
+    <string name="no_repo_selected2">Kein externes Repository ausgewählt</string>
+    <string name="edit_commit_text">[ANDROID PwdStore] Edit &#160;</string>
+    <string name="send_plaintext_password_to">Passwort senden als Nur-Text mit behilfe von…</string>
+    <string name="settings">Einstellungen</string>
+    <string name="show_password">Password wiedergeben</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,4 +182,5 @@
     <string name="no_repo_selected">No external repository selected</string>
     <string name="no_repo_selected2">No external repository selected</string>
     <string name="send_plaintext_password_to">Send password as plaintext using…</string>
+    <string name="show_password">Show password</string>
 </resources>


### PR DESCRIPTION
Added the ability to make an invisible password visible using a button, and added some rough translations.

This allows you to hold down a button to see the password while it's being hidden. From personal experience, when using the password store in combination with https://github.com/danielvandenberg95/BluetoothToPc and with passwords set to invisible, this can be very convenient.