### PR TITLE
Handle jgit errors

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 import com.zeapo.pwdstore.crypto.PgpHandler;
 import com.zeapo.pwdstore.git.GitActivity;
 import com.zeapo.pwdstore.git.GitAsyncTask;
+import com.zeapo.pwdstore.git.GitTaskHandler;
 import com.zeapo.pwdstore.pwgen.PRNGFixes;
 import com.zeapo.pwdstore.utils.PasswordItem;
 import com.zeapo.pwdstore.utils.PasswordRecyclerAdapter;
@@ -44,7 +45,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-public class PasswordStore extends AppCompatActivity {
+public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
     private static final String TAG = "PwdStrAct";
     private File currentDir;
     private SharedPreferences settings;
@@ -447,7 +448,7 @@ public class PasswordStore extends AppCompatActivity {
                         setResult(RESULT_CANCELED);
                         Repository repo = PasswordRepository.getRepository(PasswordRepository.getRepositoryDirectory(activity));
                         Git git = new Git(repo);
-                        GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class);
+                        GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, (PasswordStore) activity);
                         tasks.execute(
                                 git.rm().addFilepattern(path.replace(PasswordRepository.getWorkTree() + "/", "")),
                                 git.commit().setMessage("[ANDROID PwdStore] Remove " + item + " from store.")
@@ -509,7 +510,7 @@ public class PasswordStore extends AppCompatActivity {
 
     private void commit(String message) {
         Git git = new Git(PasswordRepository.getRepository(new File("")));
-        GitAsyncTask tasks = new GitAsyncTask(this, false, false, CommitCommand.class);
+        GitAsyncTask tasks = new GitAsyncTask(this, false, false, CommitCommand.class, this);
         tasks.execute(
                 git.add().addFilepattern("."),
                 git.commit().setMessage(message)
@@ -583,7 +584,7 @@ public class PasswordStore extends AppCompatActivity {
 
                     Repository repo = PasswordRepository.getRepository(PasswordRepository.getRepositoryDirectory(activity));
                     Git git = new Git(repo);
-                    GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class);
+                    GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, this);
 
                     for (String string : data.getStringArrayListExtra("Files")){
                         File source = new File(string);
@@ -680,5 +681,10 @@ public class PasswordStore extends AppCompatActivity {
         data.putExtra("path", path);
         setResult(RESULT_OK, data);
         finish();
+    }
+
+    @Override
+    public void onTaskEnded(String result) {
+
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
@@ -35,7 +35,6 @@ import com.zeapo.pwdstore.utils.PasswordRecyclerAdapter;
 import com.zeapo.pwdstore.utils.PasswordRepository;
 
 import org.apache.commons.io.FileUtils;
-import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 
@@ -505,7 +504,7 @@ public class PasswordStore extends AppCompatActivity {
             @Override
             public void execute() {
                 Git git = new Git(this.repository);
-                GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, this);
+                GitAsyncTask tasks = new GitAsyncTask(activity, false, true, this);
                 tasks.execute(
                         git.add().addFilepattern("."),
                         git.commit().setMessage(message)

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.java
@@ -28,7 +28,7 @@ import android.widget.TextView;
 import com.zeapo.pwdstore.crypto.PgpHandler;
 import com.zeapo.pwdstore.git.GitActivity;
 import com.zeapo.pwdstore.git.GitAsyncTask;
-import com.zeapo.pwdstore.git.GitTaskHandler;
+import com.zeapo.pwdstore.git.GitOperation;
 import com.zeapo.pwdstore.pwgen.PRNGFixes;
 import com.zeapo.pwdstore.utils.PasswordItem;
 import com.zeapo.pwdstore.utils.PasswordRecyclerAdapter;
@@ -45,7 +45,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
+public class PasswordStore extends AppCompatActivity {
     private static final String TAG = "PwdStrAct";
     private File currentDir;
     private SharedPreferences settings;
@@ -58,6 +58,7 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
     private final static int HOME = 403;
 
     private final static int REQUEST_EXTERNAL_STORAGE = 50;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         settings = PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext());
@@ -75,7 +76,7 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
     }
 
     @Override
-    public void onResume(){
+    public void onResume() {
         super.onResume();
         // do not attempt to checkLocalRepository() if no storage permission: immediate crash
         if (settings.getBoolean("git_external", false)) {
@@ -374,10 +375,9 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
     }
 
 
-
     @Override
     public void onBackPressed() {
-        if  ((null != plist) && plist.isNotEmpty()) {
+        if ((null != plist) && plist.isNotEmpty()) {
             plist.popBack();
         } else {
             super.onBackPressed();
@@ -439,20 +439,12 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
                 .setPositiveButton(this.getResources().getString(R.string.dialog_yes), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        String path = item.getFile().getAbsolutePath();
                         item.getFile().delete();
                         adapter.remove(position);
                         it.remove();
                         adapter.updateSelectedItems(position, selectedItems);
 
-                        setResult(RESULT_CANCELED);
-                        Repository repo = PasswordRepository.getRepository(PasswordRepository.getRepositoryDirectory(activity));
-                        Git git = new Git(repo);
-                        GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, (PasswordStore) activity);
-                        tasks.execute(
-                                git.rm().addFilepattern(path.replace(PasswordRepository.getWorkTree() + "/", "")),
-                                git.commit().setMessage("[ANDROID PwdStore] Remove " + item + " from store.")
-                        );
+                        commit("[ANDROID PwdStore] Remove " + item + " from store.");
                         deletePasswords(adapter, selectedItems);
                     }
                 })
@@ -469,10 +461,10 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
     public void movePasswords(ArrayList<PasswordItem> values) {
         Intent intent = new Intent(this, PgpHandler.class);
         ArrayList<String> fileLocations = new ArrayList<>();
-        for (PasswordItem passwordItem : values){
+        for (PasswordItem passwordItem : values) {
             fileLocations.add(passwordItem.getFile().getAbsolutePath());
         }
-        intent.putExtra("Files",fileLocations);
+        intent.putExtra("Files", fileLocations);
         intent.putExtra("Operation", "SELECTFOLDER");
         startActivityForResult(intent, PgpHandler.REQUEST_CODE_SELECT_FOLDER);
     }
@@ -481,7 +473,7 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
      * clears adapter's content and updates it with a fresh list of passwords from the root
      */
     public void updateListAdapter() {
-        if  ((null != plist)) {
+        if ((null != plist)) {
             plist.updateAdapter();
         }
     }
@@ -490,31 +482,36 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
      * Updates the adapter with the current view of passwords
      */
     public void refreshListAdapter() {
-        if  ((null != plist)) {
+        if ((null != plist)) {
             plist.refreshAdapter();
         }
     }
 
     public void filterListAdapter(String filter) {
-        if  ((null != plist)) {
+        if ((null != plist)) {
             plist.filterAdapter(filter);
         }
     }
 
     private File getCurrentDir() {
-        if  ((null != plist)) {
+        if ((null != plist)) {
             return plist.getCurrentDir();
         }
         return PasswordRepository.getWorkTree();
     }
 
-    private void commit(String message) {
-        Git git = new Git(PasswordRepository.getRepository(new File("")));
-        GitAsyncTask tasks = new GitAsyncTask(this, false, false, CommitCommand.class, this);
-        tasks.execute(
-                git.add().addFilepattern("."),
-                git.commit().setMessage(message)
-        );
+    private void commit(final String message) {
+        new GitOperation(PasswordRepository.getRepositoryDirectory(activity), activity) {
+            @Override
+            public void execute() {
+                Git git = new Git(this.repository);
+                GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, this);
+                tasks.execute(
+                        git.add().addFilepattern("."),
+                        git.commit().setMessage(message)
+                );
+            }
+        };
     }
 
     protected void onActivityResult(int requestCode, int resultCode,
@@ -574,31 +571,29 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
                     startActivityForResult(intent, GitActivity.REQUEST_CLONE);
                     break;
                 case PgpHandler.REQUEST_CODE_SELECT_FOLDER:
-                    Log.d("Moving","Moving passwords to "+data.getStringExtra("SELECTED_FOLDER_PATH"));
+                    Log.d("Moving", "Moving passwords to " + data.getStringExtra("SELECTED_FOLDER_PATH"));
                     Log.d("Moving", TextUtils.join(", ", data.getStringArrayListExtra("Files")));
                     File target = new File(data.getStringExtra("SELECTED_FOLDER_PATH"));
-                    if (!target.isDirectory()){
-                        Log.e("Moving","Tried moving passwords to a non-existing folder.");
+                    if (!target.isDirectory()) {
+                        Log.e("Moving", "Tried moving passwords to a non-existing folder.");
                         break;
                     }
 
-                    Repository repo = PasswordRepository.getRepository(PasswordRepository.getRepositoryDirectory(activity));
-                    Git git = new Git(repo);
-                    GitAsyncTask tasks = new GitAsyncTask(activity, false, true, CommitCommand.class, this);
-
-                    for (String string : data.getStringArrayListExtra("Files")){
+                    for (String string : data.getStringArrayListExtra("Files")) {
                         File source = new File(string);
-                        if (!source.exists()){
-                            Log.e("Moving","Tried moving something that appears non-existent.");
+                        if (!source.exists()) {
+                            Log.e("Moving", "Tried moving something that appears non-existent.");
                             continue;
                         }
-                        if (!source.renameTo(new File(target.getAbsolutePath()+"/"+source.getName()))){
-                            Log.e("Moving","Something went wrong while moving.");
-                        }else{
-                            tasks.execute(
-                                    git.add().addFilepattern(source.getAbsolutePath().replace(PasswordRepository.getWorkTree() + "/", "")),
-                                    git.commit().setMessage("[ANDROID PwdStore] Moved "+string.replace(PasswordRepository.getWorkTree() + "/", "")+" to "+target.getAbsolutePath().replace(PasswordRepository.getWorkTree() + "/","")+target.getAbsolutePath()+"/"+source.getName()+".")
-                            );
+                        if (!source.renameTo(new File(target.getAbsolutePath() + "/" + source.getName()))) {
+                            // TODO this should show a warning to the user
+                            Log.e("Moving", "Something went wrong while moving.");
+                        } else {
+                            commit("[ANDROID PwdStore] Moved "
+                                    + string.replace(PasswordRepository.getWorkTree() + "/", "")
+                                    + " to "
+                                    + target.getAbsolutePath().replace(PasswordRepository.getWorkTree() + "/", "")
+                                    + target.getAbsolutePath() + "/" + source.getName() + ".");
                         }
                     }
                     updateListAdapter();
@@ -681,10 +676,5 @@ public class PasswordStore extends AppCompatActivity implements GitTaskHandler {
         data.putExtra("path", path);
         setResult(RESULT_OK, data);
         finish();
-    }
-
-    @Override
-    public void onTaskEnded(String result) {
-
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
@@ -13,7 +13,7 @@ import org.eclipse.jgit.api.Git;
 
 import java.io.File;
 
-public class CloneOperation extends GitOperation implements GitTaskHandler {
+public class CloneOperation extends GitOperation {
     private static final String TAG = "CLONEOPT";
 
     /**
@@ -72,7 +72,7 @@ public class CloneOperation extends GitOperation implements GitTaskHandler {
         if (this.provider != null) {
             ((CloneCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, CloneCommand.class, this).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, this).execute(this.command);
     }
 
     @Override

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
@@ -1,18 +1,25 @@
 package com.zeapo.pwdstore.git;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 
+import com.zeapo.pwdstore.R;
+import com.zeapo.pwdstore.utils.PasswordRepository;
+
+import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 
 import java.io.File;
 
-public class CloneOperation extends GitOperation {
+public class CloneOperation extends GitOperation implements GitTaskHandler {
     private static final String TAG = "CLONEOPT";
 
     /**
      * Creates a new clone operation
-     * @param fileDir the git working tree directory
+     *
+     * @param fileDir         the git working tree directory
      * @param callingActivity the calling activity
      */
     public CloneOperation(File fileDir, Activity callingActivity) {
@@ -21,6 +28,7 @@ public class CloneOperation extends GitOperation {
 
     /**
      * Sets the command using the repository uri
+     *
      * @param uri the uri of the repository
      * @return the current object
      */
@@ -34,6 +42,7 @@ public class CloneOperation extends GitOperation {
 
     /**
      * sets the authentication for user/pwd scheme
+     *
      * @param username the username
      * @param password the password
      * @return the current object
@@ -46,6 +55,7 @@ public class CloneOperation extends GitOperation {
 
     /**
      * sets the authentication for the ssh-key scheme
+     *
      * @param sshKey     the ssh-key file
      * @param username   the username
      * @param passphrase the passphrase
@@ -58,10 +68,31 @@ public class CloneOperation extends GitOperation {
     }
 
     @Override
-    public void execute() throws Exception  {
+    public void execute() throws Exception {
         if (this.provider != null) {
             ((CloneCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, CloneCommand.class).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, CloneCommand.class, this).execute(this.command);
+    }
+
+    @Override
+    public void onTaskEnded(String result) {
+        new AlertDialog.Builder(callingActivity).
+                setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
+                setMessage("Error occured during the clone operation, "
+                        + callingActivity.getResources().getString(R.string.jgit_error_dialog_text)
+                        + result
+                        + "\nPlease check the FAQ for possible reasons why this error might occur.").
+                setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        // if we were unable to finish the job
+                        try {
+                            FileUtils.deleteDirectory(PasswordRepository.getWorkTree());
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }).show();
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.java
@@ -68,7 +68,7 @@ public class CloneOperation extends GitOperation implements GitTaskHandler {
     }
 
     @Override
-    public void execute() throws Exception {
+    public void execute() {
         if (this.provider != null) {
             ((CloneCommand) this.command).setCredentialsProvider(this.provider);
         }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.java
@@ -15,15 +15,13 @@ public class GitAsyncTask extends AsyncTask<GitCommand, Integer, String> {
     private boolean finishOnEnd;
     private boolean refreshListOnEnd;
     private ProgressDialog dialog;
-    private Class operation;
-    private GitTaskHandler handler;
+    private GitOperation operation;
 
-    public GitAsyncTask(Activity activity, boolean finishOnEnd, boolean refreshListOnEnd, Class operation, GitTaskHandler handler) {
+    public GitAsyncTask(Activity activity, boolean finishOnEnd, boolean refreshListOnEnd, GitOperation operation) {
         this.activity = activity;
         this.finishOnEnd = finishOnEnd;
         this.refreshListOnEnd = refreshListOnEnd;
         this.operation = operation;
-        this.handler = handler;
 
         dialog = new ProgressDialog(this.activity);
     }
@@ -60,7 +58,7 @@ public class GitAsyncTask extends AsyncTask<GitCommand, Integer, String> {
             result = "Unexpected error";
 
         if (!result.isEmpty()) {
-            this.handler.onTaskEnded(result);
+            this.operation.onTaskEnded(result);
         } else {
             if (finishOnEnd) {
                 this.activity.setResult(Activity.RESULT_OK);

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
@@ -26,7 +26,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 import java.io.File;
 
-public abstract class GitOperation implements GitTaskHandler {
+public abstract class GitOperation {
     private static final String TAG = "GitOpt";
     public static final int GET_SSH_KEY_FROM_CLONE = 201;
 
@@ -211,7 +211,6 @@ public abstract class GitOperation implements GitTaskHandler {
         }
     }
 
-    @Override
     public void onTaskEnded(String result) {
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
@@ -18,8 +18,6 @@ import com.zeapo.pwdstore.git.config.GitConfigSessionFactory;
 import com.zeapo.pwdstore.git.config.SshConfigSessionFactory;
 import com.zeapo.pwdstore.utils.PasswordRepository;
 
-import org.apache.commons.io.FileUtils;
-import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
@@ -213,26 +211,19 @@ public abstract class GitOperation implements GitTaskHandler {
         }
     }
 
-    //TODO remove this once implemented in subclasses
     @Override
     public void onTaskEnded(String result) {
         new AlertDialog.Builder(callingActivity).
                 setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
-                setMessage(callingActivity.getResources().getString(R.string.jgit_error_dialog_text) + result).
+                setMessage("Error occurred during a Git operation, "
+                        + callingActivity.getResources().getString(R.string.jgit_error_dialog_text)
+                        + result
+                        + "\nPlease check the FAQ for possible reasons why this error might occur.").
                 setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        if (this.getClass().equals(CloneCommand.class)) {
-                            // if we were unable to finish the job
-                            try {
-                                FileUtils.deleteDirectory(PasswordRepository.getWorkTree());
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                        } else {
-                            callingActivity.setResult(Activity.RESULT_CANCELED);
-                            callingActivity.finish();
-                        }
+                        callingActivity.setResult(Activity.RESULT_CANCELED);
+                        callingActivity.finish();
                     }
                 }).show();
     }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitTaskHandler.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitTaskHandler.java
@@ -1,0 +1,5 @@
+package com.zeapo.pwdstore.git;
+
+public interface GitTaskHandler {
+    void onTaskEnded(String result);
+}

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitTaskHandler.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitTaskHandler.java
@@ -1,5 +1,0 @@
-package com.zeapo.pwdstore.git;
-
-public interface GitTaskHandler {
-    void onTaskEnded(String result);
-}

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
@@ -7,7 +7,7 @@ import org.eclipse.jgit.api.PullCommand;
 
 import java.io.File;
 
-public class PullOperation extends GitOperation {
+public class PullOperation extends GitOperation implements GitTaskHandler {
 
     /**
      * Creates a new git operation
@@ -36,6 +36,6 @@ public class PullOperation extends GitOperation {
         if (this.provider != null) {
             ((PullCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PullCommand.class).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, PullCommand.class, this).execute(this.command);
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
@@ -1,6 +1,10 @@
 package com.zeapo.pwdstore.git;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import com.zeapo.pwdstore.R;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
@@ -37,5 +41,21 @@ public class PullOperation extends GitOperation {
             ((PullCommand) this.command).setCredentialsProvider(this.provider);
         }
         new GitAsyncTask(callingActivity, true, false, this).execute(this.command);
+    }
+
+    @Override
+    public void onTaskEnded(String result) {
+        new AlertDialog.Builder(callingActivity).
+                setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
+                setMessage("Error occured during the pull operation, "
+                        + callingActivity.getResources().getString(R.string.jgit_error_dialog_text)
+                        + result
+                        + "\nPlease check the FAQ for possible reasons why this error might occur.").
+                setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        callingActivity.finish();
+                    }
+                }).show();
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
@@ -7,7 +7,7 @@ import org.eclipse.jgit.api.PullCommand;
 
 import java.io.File;
 
-public class PullOperation extends GitOperation implements GitTaskHandler {
+public class PullOperation extends GitOperation {
 
     /**
      * Creates a new git operation
@@ -36,6 +36,6 @@ public class PullOperation extends GitOperation implements GitTaskHandler {
         if (this.provider != null) {
             ((PullCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PullCommand.class, this).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, this).execute(this.command);
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.java
@@ -32,7 +32,7 @@ public class PullOperation extends GitOperation implements GitTaskHandler {
     }
 
     @Override
-    public void execute() throws Exception  {
+    public void execute() {
         if (this.provider != null) {
             ((PullCommand) this.command).setCredentialsProvider(this.provider);
         }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
@@ -1,6 +1,10 @@
 package com.zeapo.pwdstore.git;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import com.zeapo.pwdstore.R;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PushCommand;
@@ -37,5 +41,22 @@ public class PushOperation extends GitOperation {
             ((PushCommand) this.command).setCredentialsProvider(this.provider);
         }
         new GitAsyncTask(callingActivity, true, false, this).execute(this.command);
+    }
+
+    @Override
+    public void onTaskEnded(String result) {
+        // TODO handle the "Nothing to push" case
+        new AlertDialog.Builder(callingActivity).
+                setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
+                setMessage("Error occured during the push operation, "
+                        + callingActivity.getResources().getString(R.string.jgit_error_dialog_text)
+                        + result
+                        + "\nPlease check the FAQ for possible reasons why this error might occur.").
+                setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        callingActivity.finish();
+                    }
+                }).show();
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
@@ -7,7 +7,7 @@ import org.eclipse.jgit.api.PushCommand;
 
 import java.io.File;
 
-public class PushOperation extends GitOperation {
+public class PushOperation extends GitOperation implements GitTaskHandler {
 
     /**
      * Creates a new git operation
@@ -36,6 +36,6 @@ public class PushOperation extends GitOperation {
         if (this.provider != null) {
             ((PushCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PushCommand.class).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, PushCommand.class, this).execute(this.command);
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
@@ -7,7 +7,7 @@ import org.eclipse.jgit.api.PushCommand;
 
 import java.io.File;
 
-public class PushOperation extends GitOperation implements GitTaskHandler {
+public class PushOperation extends GitOperation {
 
     /**
      * Creates a new git operation
@@ -36,6 +36,6 @@ public class PushOperation extends GitOperation implements GitTaskHandler {
         if (this.provider != null) {
             ((PushCommand) this.command).setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PushCommand.class, this).execute(this.command);
+        new GitAsyncTask(callingActivity, true, false, this).execute(this.command);
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.java
@@ -32,7 +32,7 @@ public class PushOperation extends GitOperation implements GitTaskHandler {
     }
 
     @Override
-    public void execute() throws Exception  {
+    public void execute() {
         if (this.provider != null) {
             ((PushCommand) this.command).setCredentialsProvider(this.provider);
         }

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
@@ -39,8 +39,7 @@ public class SyncOperation extends GitOperation implements GitTaskHandler {
     }
 
     @Override
-    public void execute() throws Exception  {
-
+    public void execute() {
         if (this.provider != null) {
             this.pullCommand.setCredentialsProvider(this.provider);
             this.pushCommand.setCredentialsProvider(this.provider);

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
@@ -1,6 +1,10 @@
 package com.zeapo.pwdstore.git;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import com.zeapo.pwdstore.R;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
@@ -45,5 +49,21 @@ public class SyncOperation extends GitOperation {
             this.pushCommand.setCredentialsProvider(this.provider);
         }
         new GitAsyncTask(callingActivity, true, false, this).execute(this.pullCommand, this.pushCommand);
+    }
+
+    @Override
+    public void onTaskEnded(String result) {
+        new AlertDialog.Builder(callingActivity).
+                setTitle(callingActivity.getResources().getString(R.string.jgit_error_dialog_title)).
+                setMessage("Error occured during the sync operation, "
+                        + callingActivity.getResources().getString(R.string.jgit_error_dialog_text)
+                        + result
+                        + "\nPlease check the FAQ for possible reasons why this error might occur.").
+                setPositiveButton(callingActivity.getResources().getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        callingActivity.finish();
+                    }
+                }).show();
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.api.PushCommand;
 
 import java.io.File;
 
-public class SyncOperation extends GitOperation implements GitTaskHandler {
+public class SyncOperation extends GitOperation {
     protected PullCommand pullCommand;
     protected PushCommand pushCommand;
 
@@ -44,6 +44,6 @@ public class SyncOperation extends GitOperation implements GitTaskHandler {
             this.pullCommand.setCredentialsProvider(this.provider);
             this.pushCommand.setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PullCommand.class, this).execute(this.pullCommand, this.pushCommand);
+        new GitAsyncTask(callingActivity, true, false, this).execute(this.pullCommand, this.pushCommand);
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.java
@@ -8,7 +8,7 @@ import org.eclipse.jgit.api.PushCommand;
 
 import java.io.File;
 
-public class SyncOperation extends GitOperation {
+public class SyncOperation extends GitOperation implements GitTaskHandler {
     protected PullCommand pullCommand;
     protected PushCommand pushCommand;
 
@@ -45,6 +45,6 @@ public class SyncOperation extends GitOperation {
             this.pullCommand.setCredentialsProvider(this.provider);
             this.pushCommand.setCredentialsProvider(this.provider);
         }
-        new GitAsyncTask(callingActivity, true, false, PullCommand.class).execute(this.pullCommand, this.pushCommand);
+        new GitAsyncTask(callingActivity, true, false, PullCommand.class, this).execute(this.pullCommand, this.pushCommand);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
 
     <!-- Git Async Task -->
     <string name="running_dialog_text">Running command...</string>
-    <string name="jgit_error_dialog_title">Internal exception occurred</string>
+    <string name="jgit_error_dialog_title">An error occurred during a Git operation</string>
     <string name="jgit_error_dialog_text">Message from jgit: \n</string>
 
     <!-- Git Handler -->


### PR DESCRIPTION
This PR is a followup on #219 

- [x] Extract the exception handling outside of the AsyncTask
- [ ] Handle the clone operation
- [ ] Handle the pull operation
- [ ] Handle the push operation
- [ ] Handle the sync operation
- [x] Create an operation for Commit. This is missing, as we're just creating an AsyncTask from the main activity. This should also remove the `GitTaskHandler` from `PasswordStore` activity.