### PR TITLE
Make passwords sort case insensitive

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordItem.java
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordItem.java
@@ -104,6 +104,6 @@ public class PasswordItem implements Comparable{
         PasswordItem other = (PasswordItem) o;
         // Appending the type will make the sort type dependent
         return (this.getType() + this.getName())
-                .compareTo(other.getType() + other.getName());
+                .compareToIgnoreCase(other.getType() + other.getName());
     }
 }


### PR DESCRIPTION
This makes the sort order behave like when using the `pass` command.

Before:

- BB
- aa

After:

- aa
- BB