### PR TITLE
Show extra content w/o copy password, fixes #288

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpHandler.java
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpHandler.java
@@ -487,15 +487,18 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
                     if (requestCode == REQUEST_CODE_DECRYPT_AND_VERIFY && os != null) {
                         try {
                             if (returnToCiphertextField) {
-                                boolean showPassword = settings.getBoolean("show_password", true);
+                                final boolean showPassword = settings.getBoolean("show_password", true);
+                                final boolean showExtraContent = settings.getBoolean("show_extra_content", true);
                                 findViewById(R.id.crypto_container).setVisibility(View.VISIBLE);
 
                                 Typeface monoTypeface = Typeface.createFromAsset(getAssets(), "fonts/sourcecodepro.ttf");
-                                final String[] passContent = os.toString("UTF-8").split("\n");
+                                final String[] passContent = os.toString("UTF-8").split("\n", 2);
+                                final String decodedPassword = passContent[0];
+                                final String extraContent = passContent.length > 1 ? passContent[1] : "";
                                 textViewPassword
                                         .setTypeface(monoTypeface);
                                 textViewPassword
-                                        .setText(passContent[0]);
+                                        .setText(decodedPassword);
 
                                 Button toggleVisibilityButton = (Button) findViewById(R.id.crypto_password_toggle_show);
                                 toggleVisibilityButton.setVisibility(showPassword?View.GONE:View.VISIBLE);
@@ -503,13 +506,12 @@ public class PgpHandler extends AppCompatActivity implements OpenPgpServiceConne
                                     @Override
                                     public void run() {
                                         textViewPassword
-                                                .setText(passContent[0]);
+                                                .setText(decodedPassword);
                                     }
                                 }));
-                                decodedPassword = passContent[0];
 
-                                String extraContent = os.toString("UTF-8").replaceFirst(".*\n", "");
                                 if (extraContent.length() != 0) {
+                                    findViewById(R.id.crypto_extra_show_layout).setVisibility(showExtraContent ? View.VISIBLE : View.GONE);
                                     ((TextView) findViewById(R.id.crypto_extra_show))
                                             .setTypeface(monoTypeface);
                                     ((TextView) findViewById(R.id.crypto_extra_show))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -170,6 +170,8 @@
     <string name="refresh_list">Aktualisieren</string>
     <string name="show_password_pref_title">Zeige das Password</string>
     <string name="show_password_pref_summary">Soll das entschlüsselte Passwort sichtbar sein? Dies deaktiviert nicht das Kopieren.</string>
+    <string name="show_extra_content_pref_title">Zeige weiteren Inhalt</string>
+    <string name="show_extra_content_pref_summary">Soll weiterer Inhalt sichtbar sein?</string>
     <string name="toast_password_copied">Passwort befindet sich zum Einfügen in der Zwischenablage</string>
     <string name="pwd_generate_button">Generieren</string>
     <string name="category_string">"Kategorie: "</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,8 @@
     <string name="git_push">Push to remote</string>
     <string name="show_password_pref_title">Show the password</string>
     <string name="show_password_pref_summary">Control the visibility of the passwords once decrypted, this does not disable the password copy</string>
+    <string name="show_extra_content_pref_title">Show extra content</string>
+    <string name="show_extra_content_pref_summary">Control the visibility of the extra content once decrypted</string>
     <string name="toast_password_copied">Password copied into the clipboard</string>
     <string name="pwd_generate_button">Generate</string>
     <string name="category_string">"Category: "</string>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -54,6 +54,11 @@
             android:key="show_password" />
         <CheckBoxPreference
             android:defaultValue="true"
+            android:title="@string/show_extra_content_pref_title"
+            android:summary="@string/show_extra_content_pref_summary"
+            android:key="show_extra_content" />
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:dialogTitle="@string/pref_copy_dialog_title"
             android:key="copy_on_decrypt"
             android:summary="@string/pref_copy_dialog_title"


### PR DESCRIPTION
Show extra content even if password is not copied to clipboard.
Add toggle to preferences as well.