### PR TITLE
show age for passwords in detail view

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -12,6 +12,7 @@ import android.os.SystemClock
 import android.preference.PreferenceManager
 import android.support.v7.app.AppCompatActivity
 import android.text.TextUtils
+import android.text.format.DateUtils
 import android.text.method.PasswordTransformationMethod
 import android.util.Log
 import android.view.*
@@ -20,10 +21,12 @@ import com.zeapo.pwdstore.PasswordEntry
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.pwgenDialogFragment
+import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.Totp
 import kotlinx.android.synthetic.main.decrypt_layout.*
 import kotlinx.android.synthetic.main.encrypt_layout.*
 import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.api.Git
 import org.openintents.openpgp.IOpenPgpService2
 import org.openintents.openpgp.OpenPgpError
 import org.openintents.openpgp.util.OpenPgpApi
@@ -47,6 +50,7 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
 
     private val fullPath: String by lazy { intent.getStringExtra("FILE_PATH") }
     private val name: String by lazy { getName(fullPath, repoPath) }
+    private val lastChangedString: CharSequence by lazy { getLastChanged(fullPath, repoPath) }
     private val relativeParentPath: String by lazy { getParentPath(fullPath, repoPath) }
 
     private val settings: SharedPreferences by lazy { PreferenceManager.getDefaultSharedPreferences(this) }
@@ -76,6 +80,14 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                 setContentView(R.layout.decrypt_layout)
                 crypto_password_category_decrypt.text = relativeParentPath
                 crypto_password_file.text = name
+
+                val lastChanged: String = try {
+                    this.resources.getString(R.string.last_changed, lastChangedString)
+                } catch (e: RuntimeException) {
+                    ""
+                }
+
+                crypto_password_last_changed.text = lastChanged
             }
             "ENCRYPT" -> {
                 setContentView(R.layout.encrypt_layout)
@@ -512,6 +524,21 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
         // launch a new one
         delayTask = DelayShow(this)
         delayTask?.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
+    }
+
+    /**
+     * Gets a relative string describing when this shape was last changed
+     * (e.g. "one hour ago")
+     */
+    private fun getLastChanged(fullPath: String, repositoryPath: String): CharSequence {
+        val repository = PasswordRepository.getRepository(File(repositoryPath))
+        val git = Git(repository)
+        val relativePath = getRelativePath(fullPath, repositoryPath).substring(1)
+        val iterable = git.log().addPath(relativePath).call()
+        val latestCommit = iterable.iterator().next() ?: throw RuntimeException()
+
+        val timeStamp = latestCommit.commitTime
+        return DateUtils.getRelativeTimeSpanString(this, timeStamp.toLong() * 1000, true)
     }
 
     @SuppressLint("StaticFieldLeak")

--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -43,6 +43,19 @@
                 android:textSize="24sp"
                 android:textStyle="bold"
                 tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/crypto_password_last_changed"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:text="LAST CHANGED HERE"
+                android:textColor="@color/grey_500"
+                android:textIsSelectable="false"
+                android:textSize="18sp"
+                tools:ignore="HardcodedText" />
         </LinearLayout>
 
         <ImageView

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -153,4 +153,5 @@
     <string name="no_repo_selected">Nebyl vybrát externí repozitář</string>
     <string name="send_plaintext_password_to">Odeslat heslo jako plaintext za použití…</string>
     <string name="show_password">Pokaż hasło</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -195,4 +195,5 @@
     <string name="autofill_ins_2_hint">Bildschirmfoto des Schalters in Accessibility Services</string>
     <string name="autofill_ins_3_hint">Bildschirmfoto von Autofill in Aktion</string>
     <string name="last_changed">Zuletzt geändert %s</string>
+    <string name="get_last_changed_failed">Das Abrufen des letzten Änderungsdatums ist fehlgeschlagen.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -194,4 +194,5 @@
     <string name="autofill_ins_1_hint">Bildschirmfoto Accessibility Services</string>
     <string name="autofill_ins_2_hint">Bildschirmfoto des Schalters in Accessibility Services</string>
     <string name="autofill_ins_3_hint">Bildschirmfoto von Autofill in Aktion</string>
+    <string name="last_changed">Zuletzt geändert %s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -186,4 +186,5 @@
     <string name="show_extra_content_pref_title">Afficher le contenu supplémentaire</string>
     <string name="username">Nom d\'utilisateur</string>
     <string name="ssh_key_does_not_exist">Impossible d\'ouvrir la clef ssh, merci de vérifier que le ficher existe</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -157,4 +157,5 @@
     <string name="no_repo_selected">外部リポジトリが選択されていません</string>
     <string name="send_plaintext_password_to">パスワードをプレーンテキストとして送信…</string>
     <string name="show_password">パスワードを表示</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -188,4 +188,5 @@
     <string name="autofill_paste">Вставить</string>
     <string name="autofill_paste_username">Вставить имя пользователя?\n\n%s</string>
     <string name="autofill_toast_username">Выберите поле ввода для вставки имени пользователя.\nИмя пользователя можно вставить в течение %d секунд.</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -121,4 +121,5 @@
     <string name="server_resulting_url">生成的 URL</string>
     <string name="autofill_apps_match_ellipsis">匹配…</string>
     <string name="pref_crypto_title">加密</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -121,4 +121,5 @@
     <string name="server_resulting_url">生成的 URL</string>
     <string name="autofill_apps_match_ellipsis">匹配…</string>
     <string name="pref_crypto_title">加密</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,4 +218,5 @@
     <string name="commit_hash">Commit hash</string>
     <string name="crypto_password_edit_hint">p@ssw0rd!</string>
     <string name="crypto_extra_edit_hint">username: something other extra content</string>
+    <string name="get_last_changed_failed">Failed to get last changed date</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="copy_password">Copy password</string>
     <string name="copy_username">Copy username</string>
     <string name="share_as_plaintext">Share as plaintext</string>
+    <string name="last_changed">Last changed %s</string>
 
     <!-- Preferences -->
     <string name="pref_git_title">Git</string>


### PR DESCRIPTION
Implements #330.
This fetches the latest commit where the respective password file was
changed from the current HEAD and outputs the relative time since
the last change on the decrypt page.

NOTE: translations are incomplete because I only speak so many languages :)
If someone hits me up with other translations I'll be happy to include them
in this PR.