### PR TITLE
Display TOTP code if password contains OTP secret

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     }
     compile 'com.jcraft:jsch:0.1.54'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
     compile 'com.jayway.android.robotium:robotium-solo:5.3.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     compile 'com.android.support.constraint:constraint-layout:1.0.2'

--- a/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.java
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/PasswordEntryTest.java
@@ -41,4 +41,22 @@ public class PasswordEntryTest extends TestCase {
         assertFalse(new PasswordEntry("\n").hasUsername());
         assertFalse(new PasswordEntry("").hasUsername());
     }
+
+    public void testNoTotpUriPresent() {
+        PasswordEntry entry = new PasswordEntry("secret\nextra\nlogin: username\ncontent");
+        assertFalse(entry.hasTotp());
+        assertNull(entry.getTotpSecret());
+    }
+
+    public void testTotpUriInPassword() {
+        PasswordEntry entry = new PasswordEntry("otpauth://totp/test?secret=JBSWY3DPEHPK3PXP");
+        assertTrue(entry.hasTotp());
+        assertEquals("JBSWY3DPEHPK3PXP", entry.getTotpSecret());
+    }
+
+    public void testTotpUriInContent() {
+        PasswordEntry entry = new PasswordEntry("secret\nusername: test\notpauth://totp/test?secret=JBSWY3DPEHPK3PXP");
+        assertTrue(entry.hasTotp());
+        assertEquals("JBSWY3DPEHPK3PXP", entry.getTotpSecret());
+    }
 }

--- a/app/src/androidTest/java/com/zeapo/pwdstore/TotpTest.java
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/TotpTest.java
@@ -1,0 +1,12 @@
+package com.zeapo.pwdstore;
+
+import com.zeapo.pwdstore.utils.Totp;
+
+import junit.framework.TestCase;
+
+public class TotpTest extends TestCase {
+    public void testTotp() {
+        String code = Totp.calculateCode("JBSWY3DPEHPK3PXP", 0L);
+        assertEquals("282760", code);
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -20,6 +20,7 @@ import com.zeapo.pwdstore.PasswordEntry
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.pwgenDialogFragment
+import com.zeapo.pwdstore.utils.Totp
 import kotlinx.android.synthetic.main.decrypt_layout.*
 import kotlinx.android.synthetic.main.encrypt_layout.*
 import org.apache.commons.io.FileUtils
@@ -32,6 +33,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.charset.Charset
+import java.util.Date
 
 class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
     private val clipboard: ClipboardManager by lazy {
@@ -229,6 +231,20 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
                                 crypto_username_show_label.visibility = View.GONE
                                 crypto_copy_username.visibility = View.GONE
                             }
+                        }
+
+                        if (entry.hasTotp()) {
+                            crypto_totp_show.visibility = View.VISIBLE
+                            crypto_totp_show_label.visibility = View.VISIBLE
+                            crypto_copy_totp.visibility = View.VISIBLE
+
+                            crypto_copy_totp.setOnClickListener { copyTotpToClipBoard(Totp.calculateCode(entry.totpSecret, Date().time / 1000)) }
+                            crypto_totp_show.typeface = monoTypeface
+                            crypto_totp_show.text = Totp.calculateCode(entry.totpSecret, Date().time / 1000);
+                        } else {
+                            crypto_totp_show.visibility = View.GONE
+                            crypto_totp_show_label.visibility = View.GONE
+                            crypto_copy_totp.visibility = View.GONE
                         }
 
                         if (settings.getBoolean("copy_on_decrypt", true)) {
@@ -458,6 +474,12 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
         val clip = ClipData.newPlainText("pgp_handler_result_pm", username)
         clipboard.primaryClip = clip
         showToast(resources.getString(R.string.clipboard_username_toast_text))
+    }
+
+    private fun copyTotpToClipBoard(code: String) {
+        val clip = ClipData.newPlainText("pgp_handler_result_pm", code)
+        clipboard.primaryClip = clip
+        showToast(resources.getString(R.string.clipboard_totp_toast_text))
     }
 
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Totp.java
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Totp.java
@@ -1,0 +1,50 @@
+package com.zeapo.pwdstore.utils;
+
+import android.util.Log;
+
+import org.apache.commons.codec.binary.Base32;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class Totp {
+
+    private static final String ALGORITHM = "HmacSHA1";
+    private static final int TIME_WINDOW = 30;
+    private static final int CODE_DIGITS = 6;
+
+    private static final Base32 BASE_32 = new Base32();
+
+    private Totp() {
+    }
+
+    public static String calculateCode(String secret, long epochSeconds) {
+        SecretKeySpec signingKey = new SecretKeySpec(BASE_32.decode(secret), ALGORITHM);
+
+        Mac mac = null;
+        try {
+            mac = Mac.getInstance(ALGORITHM);
+            mac.init(signingKey);
+        } catch (NoSuchAlgorithmException e) {
+            Log.e("TOTP", ALGORITHM + " unavailable - should never happen", e);
+            return null;
+        } catch (InvalidKeyException e) {
+            Log.e("TOTP", "Key is malformed", e);
+            return null;
+        }
+
+        long time = epochSeconds / TIME_WINDOW;
+        byte[] digest = mac.doFinal(ByteBuffer.allocate(8).putLong(time).array());
+        int offset = digest[digest.length - 1] & 0xf;
+        byte[] code = Arrays.copyOfRange(digest, offset, offset + 4);
+        code[0] = (byte) (0x7f & code[0]);
+        String strCode = new BigInteger(code).toString();
+        return strCode.substring(strCode.length() - CODE_DIGITS);
+    }
+}

--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -148,13 +148,50 @@
                     android:textIsSelectable="true"
                     android:typeface="monospace" />
 
+                <ImageButton
+                    android:id="@+id/crypto_copy_totp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignParentTop="true"
+                    android:contentDescription="@string/copy_username"
+                    android:background="@color/background"
+                    android:src="@drawable/ic_content_copy"/>
+
+                <TextView
+                    android:id="@+id/crypto_totp_show_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_toLeftOf="@id/crypto_copy_totp"
+                    android:layout_toStartOf="@id/crypto_copy_totp"
+                    android:text="@string/totp"
+                    android:textColor="@android:color/black"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/crypto_totp_show"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_below="@id/crypto_totp_show_label"
+                    android:layout_toLeftOf="@id/crypto_copy_totp"
+                    android:layout_toStartOf="@id/crypto_copy_totp"
+                    android:textColor="@android:color/black"
+                    android:textIsSelectable="true"
+                    android:typeface="monospace" />
+
                 <TextView
                     android:id="@+id/crypto_extra_show_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentLeft="true"
                     android:layout_alignParentStart="true"
-                    android:layout_below="@id/crypto_username_show"
+                    android:layout_below="@id/crypto_totp_show"
                     android:text="@string/extra_content"
                     android:textColor="@android:color/black"
                     android:textStyle="bold" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="provider_toast_text">No OpenPGP Provider selected!</string>
     <string name="clipboard_password_toast_text">Password copied to clipboard, you have %d seconds to paste it somewhere.</string>
     <string name="clipboard_username_toast_text">Username copied to clipboard</string>
+    <string name="clipboard_totp_toast_text">TOTP code copied to clipboard</string>
     <string name="file_toast_text">Please provide a file name</string>
     <string name="empty_toast_text">You cannot use an empty password or empty extra content</string>
 
@@ -92,6 +93,7 @@
     <string name="password">Password:</string>
     <string name="extra_content">Extra content:</string>
     <string name="username">Username:</string>
+    <string name="totp">TOTP:</string>
     <string name="edit_password">Edit password</string>
     <string name="copy_password">Copy password</string>
     <string name="copy_username">Copy username</string>


### PR DESCRIPTION
This is a work in progress implementation of issue https://github.com/zeapo/Android-Password-Store/issues/326.

If a password is a specially formatted TOTP URI then a number is calculated from the secret and displayed below the username. If the password is not a TOTP URI then the entire line is hidden (similarly to username/login).

It looks like this:

![totp](https://user-images.githubusercontent.com/1718963/32439818-bcb01946-c2f0-11e7-83c4-7326faed6a0e.PNG)

Open questions:

- [x] Which base32 library to use, I attached something that uses BSD licence, there is a snippet from Google with Apache licence (https://github.com/aerogear/aerogear-otp-java/blob/master/src/main/java/org/jboss/aerogear/security/otp/api/Base32.java) or we could use Apache Codec but that's importing entire lib just for one simple class.
