### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/fragment_ssh_keygen.xml
+++ b/app/src/main/res/layout/fragment_ssh_keygen.xml
@@ -35,6 +35,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/ssh_keygen_passphrase"
+                android:importantForAccessibility="no"
                 android:inputType="textPassword" />
         </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/git_passphrase_layout.xml
+++ b/app/src/main/res/layout/git_passphrase_layout.xml
@@ -15,6 +15,7 @@
         android:layout_marginTop="8dp"
         android:ems="10"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service, can capture all user inputs. In this case, password, should be ignored for the accessibility service, so such attacks can not be happened in this app.