### PR TITLE
Allow installation to external media (SD card)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
-	package="com.zeapo.pwdstore">
+	package="com.zeapo.pwdstore"
+	android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
This change will enable installation of the app to external as well as internal flash memory which is important for devices where internal memory is limited but external memory is cheap and abundant in form of micro SD cards.  Thank you for your consideration.

More information at https://developer.android.com/guide/topics/data/install-location