### PR TITLE
Clear clipboard 20 times fix

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.java
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.java
@@ -620,7 +620,7 @@ public class AutofillService extends AccessibilityService {
             clip = ClipData.newPlainText("autofill_pm", "");
             clipboard.setPrimaryClip(clip);
             if (settings.getBoolean("clear_clipboard_20x", false)) {
-                for (int i = 0; i < 19; i++) {
+                for (int i = 0; i < 20; i++) {
                     clip = ClipData.newPlainText(String.valueOf(i), String.valueOf(i));
                     clipboard.setPrimaryClip(clip);
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,7 +138,7 @@
     <string name="pref_autofill_always_title">Always show dialog</string>
     <string name="pref_misc_title">Misc</string>
     <string name="pref_clear_clipboard_title">Clear clipboard 20 times</string>
-    <string name="pref_clear_clipboard_hint">Store nonsense in the clipboard 20 times instead of just once. Useful on Samsung phones that feature clipboard history.</string>
+    <string name="pref_clear_clipboard_hint">Store consecutive numbers in the clipboard 20 times. Useful on Samsung phones that feature clipboard history.</string>
     <string name="pref_git_delete_repo_summary">Deletes local (hidden) repository</string>
     <string name="pref_external_repository">External repository</string>
     <string name="pref_external_repository_summary">Use an external password repository</string>


### PR DESCRIPTION
As described in issue #419 there was a bug when the preference meant to clear clipboard history, specially on Samsung phones, was selected, actually clearing the clipboard one time less than the needed amount (19 times vs 20 times).