### PR TITLE
Ignore gopass-directory .public-keys

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.java
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.java
@@ -386,14 +386,13 @@ public class AutofillService extends AccessibilityService {
 
         for (File file : passList) {
             if (file.isFile()) {
-                if (appName.toLowerCase().contains(file.getName().toLowerCase().replace(".gpg", ""))) {
+                if (!file.isHidden() && appName.toLowerCase().contains(file.getName().toLowerCase().replace(".gpg", ""))) {
                     items.add(file);
                 }
             } else {
-                // ignore .git and .extensions directory
-                if (file.getName().equals(".git") || file.getName().equals(".extensions"))
-                    continue;
-                items.addAll(searchPasswords(file, appName));
+                if (!file.isHidden()) {
+                    items.addAll(searchPasswords(file, appName));
+                }
             }
         }
         return items;

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.java
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.java
@@ -195,12 +195,13 @@ public class PasswordRepository {
 
         for (File file : passList) {
             if (file.isFile()) {
-                passwordList.add(PasswordItem.newPassword(file.getName(), file, rootDir));
+                if (!file.isHidden()) {
+                    passwordList.add(PasswordItem.newPassword(file.getName(), file, rootDir));
+                }
             } else {
-                // ignore .git and .extensions directory
-                if (file.getName().equals(".git") || file.getName().equals(".extensions"))
-                    continue;
-                passwordList.add(PasswordItem.newCategory(file.getName(), file, rootDir));
+                if (!file.isHidden()) {
+                    passwordList.add(PasswordItem.newCategory(file.getName(), file, rootDir));
+                }
             }
         }
         sort(passwordList, sortOrder.comparator);


### PR DESCRIPTION
By default gopass (www.gopass.pw) maintains a list of encryption keys in the folder .public-keys.
Ignoring this folder improves the user experience for gopass users.