### PR TITLE
Clean paths

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/EntryRecyclerAdapter.java
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/EntryRecyclerAdapter.java
@@ -101,13 +101,12 @@ public abstract class EntryRecyclerAdapter extends RecyclerView.Adapter<EntryRec
         holder.name.setText(pass.toString());
         if (pass.getType() == PasswordItem.TYPE_CATEGORY) {
             holder.typeImage.setImageResource(R.drawable.ic_folder_grey600_24dp);
-            holder.name.setText(pass.toString() + "/");
         } else {
             holder.typeImage.setImageResource(R.drawable.ic_action_secure);
             holder.name.setText(pass.toString());
         }
 
-        holder.type.setText(pass.getFullPathToParent());
+        holder.type.setText(pass.getFullPathToParent().replaceAll("(^/)|(/$)", ""));
 
         holder.view.setOnClickListener(getOnClickListener(holder, pass));
 

--- a/app/src/main/res/layout/password_row_layout.xml
+++ b/app/src/main/res/layout/password_row_layout.xml
@@ -14,46 +14,56 @@
         android:paddingRight="16dp"
         android:gravity="start">
 
-        <ImageView
-            android:layout_width="40dp"
-            android:layout_height="32dp"
-            android:id="@+id/type_image"
-            android:src="@drawable/ic_folder_grey600_24dp"
-            android:contentDescription="@string/folder_icon_hint"
-            android:alpha="0.5"
-            android:layout_centerVertical="true"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:paddingRight="8dp"
-            android:paddingEnd="8dp"
-            tools:ignore="RtlSymmetry" />
-
-        <TextView
-            android:id="@+id/type"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="start"
-            android:text="TYPE"
-            android:textSize="14sp"
-            android:textColor="@color/grey_500"
-            android:layout_alignTop="@+id/type_image"
-            android:layout_toRightOf="@+id/type_image"
-            android:layout_toEndOf="@+id/type_image"
-            android:singleLine="true"
-            tools:ignore="HardcodedText" />
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:text="FILE_NAME"
-            android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:layout_below="@+id/type"
-            android:layout_alignLeft="@+id/type"
-            android:layout_alignStart="@+id/type"
-            tools:ignore="HardcodedText" />
+            <ImageView
+                android:id="@+id/type_image"
+                android:layout_width="80dp"
+                android:layout_height="32dp"
+                android:layout_gravity="bottom"
+                android:layout_weight="1"
+                android:alpha="0.5"
+                android:contentDescription="@string/folder_icon_hint"
+                android:paddingEnd="8dp"
+                android:paddingRight="8dp"
+                android:src="@drawable/ic_folder_grey600_24dp"
+                tools:ignore="RtlSymmetry" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="bottom"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="start"
+                    android:singleLine="true"
+                    android:text="TYPE"
+                    android:textColor="@color/grey_500"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:text="FILE_NAME"
+                    android:textColor="@android:color/black"
+                    android:textSize="18sp"
+                    tools:ignore="HardcodedText" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
     </RelativeLayout>
 
 </LinearLayout>


### PR DESCRIPTION
This changes display of paths in password listings, so only necessary ones are shown. Slash is stripped from the end of folders (they already have an icon), and from start and end of paths. I think this gives the app a cleaner appearance. 

I am not entirely sure about the item layout, what I did here looks better imo, but it could be easier to do if converted to a ConstraintLayout, but I don't know what is the preference in this project.