### PR TITLE
Update gradle and external dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'eclipse'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.zeapo.pwdstore"
         minSdkVersion 16
@@ -56,36 +55,33 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:27.1.0'
-    compile 'com.android.support:recyclerview-v7:27.1.0'
-    compile 'com.android.support:cardview-v7:27.1.0'
-    compile 'com.android.support:design:27.1.0'
-    compile 'com.android.support:support-annotations:27.1.0'
-    compile 'org.sufficientlysecure:openpgp-api:11.0'
-    compile 'com.nononsenseapps:filepicker:2.4.2'
-    compile('org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r') {
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.android.support:cardview-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'org.sufficientlysecure:openpgp-api:11.0'
+    implementation 'com.nononsenseapps:filepicker:2.4.2'
+    implementation('org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r') {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
-    compile 'com.jcraft:jsch:0.1.54'
-    compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
-    compile 'com.jayway.android.robotium:robotium-solo:5.3.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.jcraft:jsch:0.1.54'
+    implementation 'commons-io:commons-io:2.5'
+    implementation 'commons-codec:commons-codec:1.11'
+    implementation 'com.jayway.android.robotium:robotium-solo:5.3.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     // Testing-only dependencies
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'org.mockito:mockito-core:2.8.47'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test:rules:1.0.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-intents:3.0.1'
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:2.18.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.2'
 
 
 }
 repositories {
     mavenCentral()
-
-    // temp. solution until we use use gradle 4.0
-    maven { url 'https://maven.google.com' }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
@@ -11,7 +11,7 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 // TODO more work needed, this is just an extraction from PgpHandler
 
 class SelectFolderActivity : AppCompatActivity() {
-    internal var passwordList: SelectFolderFragment? = null
+    private lateinit var passwordList: SelectFolderFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,7 +26,7 @@ class SelectFolderActivity : AppCompatActivity() {
         val args = Bundle()
         args.putString("Path", PasswordRepository.getRepositoryDirectory(applicationContext).absolutePath)
 
-        passwordList?.arguments = args
+        passwordList.arguments = args
 
         supportActionBar?.show()
 
@@ -55,7 +55,7 @@ class SelectFolderActivity : AppCompatActivity() {
     }
 
     private fun selectFolder() {
-        intent.putExtra("SELECTED_FOLDER_PATH", passwordList?.currentDir?.absolutePath)
+        intent.putExtra("SELECTED_FOLDER_PATH", passwordList.currentDir?.absolutePath)
         setResult(Activity.RESULT_OK, intent)
         finish()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.2.71'
     repositories {
+        google()
         jcenter()
         mavenCentral()
-        maven {
-            url "https://maven.google.com"
-        }
-        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -21,6 +18,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha12'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 28 22:40:58 CEST 2018
+#Tue Oct 02 13:51:59 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
- Switch away from deprecated compile directive
- Remove explicit buildToolsVersion, is defined by the gradle plugin now
- Fix build in SelectFolderActivity

Signed-off-by: Harsh Shandilya <harsh@prjkt.io>