### PR TITLE
GitOperation: Dismiss activity on cancel

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.java
@@ -203,9 +203,8 @@ public abstract class GitOperation {
                         // authenticate using the user/pwd and then execute the command
                         setAuthentication(username, password.getText().toString()).execute();
 
-                    }).setNegativeButton(callingActivity.getResources().getString(R.string.dialog_cancel), (dialog, whichButton) -> {
-                // Do nothing.
-            }).show();
+                    })
+                    .setNegativeButton(callingActivity.getResources().getString(R.string.dialog_cancel), (dialog, whichButton) -> callingActivity.finish()).show();
         }
     }
 


### PR DESCRIPTION
Fixes the issue where starting a repository sync and then
hitting cancel in the password dialog leaves you with an empty activity
which needs to be dismissed to get back to where you were.