### PR TITLE
Use storage access framework

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,6 @@ dependencies {
     implementation("com.google.android.material:material:1.0.0")
     implementation("androidx.annotation:annotation:1.0.2")
     implementation("org.sufficientlysecure:openpgp-api:12.0")
-    implementation("com.nononsenseapps:filepicker:2.4.2")
     implementation("org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r") {
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,15 +68,6 @@
             <meta-data android:name="android.support.PARENT_ACTIVITY" android:value="com.zeapo.pwdstore.PasswordStore" />
         </activity>
 
-        <activity
-            android:name="com.nononsenseapps.filepicker.FilePickerActivity"
-            android:label="@string/app_name"
-            android:theme="@style/FilePickerTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.GET_CONTENT" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity>
         <activity android:name=".crypto.PgpActivity"
             android:parentActivityName=".PasswordStore"/>
         <activity android:name=".SelectFolderActivity" />

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -377,7 +377,15 @@ class UserPreference : AppCompatActivity() {
                     Log.d(TAG, "Selected repository path is $repoPath")
 
                     if (Environment.getExternalStorageDirectory().path == repoPath) {
-                        TODO("Assert that we haven't selected root directory")
+                        AlertDialog.Builder(this)
+                                .setTitle(getString(R.string.sdcard_root_warning_title))
+                                .setMessage(getString(R.string.sdcard_root_warning_message))
+                                .setPositiveButton("Remove everything") { _, _ ->
+                                    PreferenceManager.getDefaultSharedPreferences(applicationContext)
+                                            .edit()
+                                            .putString("git_external_repo", uri?.path)
+                                            .apply()
+                                }.setNegativeButton(R.string.dialog_cancel, null).show()
                     }
 
                     PreferenceManager.getDefaultSharedPreferences(applicationContext)
@@ -386,9 +394,9 @@ class UserPreference : AppCompatActivity() {
                             .apply()
                 }
                 EXPORT_PASSWORDS -> {
-                    var uri = data.data
+                    val uri = data.data
 
-                    val targetDirectory = DocumentFile.fromTreeUri(applicationContext, uri);
+                    val targetDirectory = DocumentFile.fromTreeUri(applicationContext, uri)
 
                     if (targetDirectory != null) {
                         exportPasswords(targetDirectory)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,4 +256,6 @@
     <string name="no_ssh_api_provider">No SSH API provider found. Is OpenKeychain installed?</string>
     <string name="ssh_api_pending_intent_failed">SSH API pending intent failed</string>
     <string name="ssh_api_unknown_error">Unknown SSH API Error</string>
+    <string name="sdcard_root_warning_title">SD-Card root selected</string>
+    <string name="sdcard_root_warning_message">You have selected the root of your sdcard for the store. This is extremely dangerous and you will lose your data as its content will, eventually, be deleted</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,17 +14,6 @@
         <item name="background">@color/blue_grey_700</item>
     </style>
 
-    <!-- You can also inherit from NNF_BaseTheme.Light -->
-    <style name="FilePickerTheme" parent="NNF_BaseTheme">
-        <!-- Set these to match your theme -->
-        <item name="colorPrimary">@color/blue_grey_500</item>
-        <item name="colorPrimaryDark">@color/blue_grey_700</item>
-        <item name="colorAccent">@color/teal_A700</item>
-
-        <!-- Need to set this also to style create folder dialog -->
-        <item name="alertDialogTheme">@style/FilePickerAlertDialogTheme</item>
-    </style>
-
     <style name="FilePickerAlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorPrimary">@color/blue_grey_500</item>
         <item name="colorPrimaryDark">@color/blue_grey_700</item>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     resolutionStrategy {
         componentSelection {
             all {
-                val blacklistedGroups = listOf("com.nononsenseapps", "commons-io", "org.eclipse.jgit")
+                val blacklistedGroups = listOf("commons-io", "org.eclipse.jgit")
                 val rejected = listOf("alpha", "beta", "rc", "cr", "m", "preview")
                     .map { qualifier -> Regex("(?i).*[.-]$qualifier[.\\d-]*") }
                     .any { it.matches(candidate.version) && blacklistedGroups.contains(candidate.group) }


### PR DESCRIPTION
As we've now moved up the minimum API level 21, we can make use of the storage access framework. This is going to need some further testing on different devices.

Fixes #391 as you no longer need storage permissions to export passwords or import ssh key.