### PR TITLE
Enable parallel installation of release and debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'eclipse'
 
 android {
     compileSdkVersion 28
+
     defaultConfig {
         applicationId "com.zeapo.pwdstore"
         minSdkVersion 21
@@ -14,19 +15,29 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     lintOptions {
         abortOnError true // make sure build fails with lint errors!
         disable 'MissingTranslation', 'PluralsCandidate'
     }
+
     packagingOptions {
         exclude '.readme'
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
+
     //
     // To sign release builds, create the file `gradle.properties` in
     // $HOME/.gradle or in your project directory with this content:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,3 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0-alpha4'
 }
-repositories {
-    mavenCentral()
-}


### PR DESCRIPTION
Hi! Thank you for this great app! 

I wanted to play around with the code and ultimately investigating if I could contribute to the Autofill implementation from #411. But the first thing I noticed is that it's currently not easily possible to have both a release and a debug build installed at the same time. 

This PR addresses this by specifying an `applicationIdSuffix` for the `debug` build type. With that, the debug build will have a different application id (`com.zeapo.pwdstore.debug`) and thus will not collide with the release app when installed on the same device.

This would allow for a "dev"/"testing" environment, where one could e.g. setup a different password store for development purposes. At the same time, the release build would still be available for day-to-day usage.

What one would probably want in this case is a different icon for the debug app to visually differentiate between the two apps in the application launcher. This is where I would need some help, since I neither have any skills in manipulating Vector images, nor do I have access to the source SVG file that was used to generate the launcher icons (it would be nice if this svg source could be added to the repository). Usually a simple "DEBUG" text badge would do the job. 
