### PR TITLE
Fix autofill preference referencing hard-coded application id

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -375,7 +375,9 @@ class UserPreference : AppCompatActivity() {
                 .getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
             val runningServices = am
                 .getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_GENERIC)
-            return runningServices.any { "com.zeapo.pwdstore/.autofill.AutofillService" == it.id }
+            return runningServices
+                    .map { it.id.substringBefore("/") }
+                    .any { it == BuildConfig.APPLICATION_ID }
         }
 
     override fun onActivityResult(


### PR DESCRIPTION
Apologies, but there is a second follow-up needed for #471.

The preference screen was determining whether Autofill is enabled or not by checking the enabled accessibility services against a hard-coded service id.

With having a different app id for debug builds, this has to be more dynamic.
The service id for release is `com.zeapo.pwdstore/.autofill.AutofillService`, while for debug it's `com.zeapo.pwdstore.debug/com.zeapo.pwdstore.autofill.AutofillService`. 

I changed the logic to just check for the application id. This should be good enough and is also less prone to breakage, since the service class name is not hard-coded anymore (this could silently stop working during refactorings/renamings).

Let me know what you think!