### PR TITLE
Add option for default directory on open

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.java
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.java
@@ -118,13 +118,15 @@ public class PasswordRepository {
         File dir = null;
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
 
+        String defaultDirectory = settings.getString("default_password_directory", "");
+
         if (settings.getBoolean("git_external", false)) {
             String external_repo = settings.getString("git_external_repo", null);
             if (external_repo != null) {
-                dir = new File(external_repo);
+                dir = new File(external_repo + defaultDirectory);
             }
         } else {
-            dir = new File(context.getFilesDir() + "/store");
+            dir = new File(context.getFilesDir() + "/store" + defaultDirectory);
         }
 
         return dir;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,8 @@
     <string name="prefs_clear_after_copy_summary">After an automatic copy or a manual copy of the password, the clipboard will be automatically cleared.</string>
     <string name="prefs_export_passwords_title">Export Passwords</string>
     <string name="prefs_export_passwords_summary">Exports the encrypted passwords to an external directory</string>
+    <string name="pref_default_password_directory_title">Default password directory</string>
+    <string name="pref_default_password_directory_summary">Directory that the app opens in the repository on launch</string>
     <string name="prefs_version">Version</string>
 
     <!-- PasswordGenerator fragment -->

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -127,6 +127,14 @@
             android:defaultValue="false"
             android:key="use_android_file_picker"
             android:title="@string/prefs_use_default_file_picker" />
+
+        <EditTextPreference
+            android:defaultValue="/"
+            android:dialogTitle="@string/pref_default_password_directory_title"
+            android:inputType="textNoSuggestions"
+            android:key="default_password_directory"
+            android:summary="@string/pref_default_password_directory_summary"
+            android:title="@string/pref_default_password_directory_title" />
     </PreferenceCategory>
 
     <Preference


### PR DESCRIPTION
This could work around the issue with people having their
.password-store as a directory in the repository. Because they can
specify that directory to be the default directory and pop in there
automatically.

Also this would make a nicer experience for people with other things
in the same repository since they will only see relevant files and
directories.

Known problems:
Changing the setting doesn't do anything until the app is restarted.

But bear with me here. I have never touched Java, Kotlin, Android or Android Studio before in my life.

I believe that this fixes #446