### PR TITLE
Fix clear clipboard 20 times history (#465)

### DIFF
--- a/app/src/androidTest/java/com/zeapo/pwdstore/DecryptTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/DecryptTest.kt
@@ -116,7 +116,9 @@ class DecryptTest {
         SystemClock.sleep(4000)
 
         // The clipboard should be cleared!!
-        assertEquals("", clipboard.primaryClip.getItemAt(0).text)
+        for(i in 0..clipboard.primaryClip.itemCount) {
+            assertEquals("", clipboard.primaryClip.getItemAt(i).text)
+        }
 
         // set back the timer
         activity.settings.edit().putString("general_show_time", showTime.toString()).commit()

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PgpActivity.kt
@@ -753,7 +753,7 @@ class PgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
             clipboard.primaryClip = clip
             if (settings.getBoolean("clear_clipboard_20x", false)) {
                 val handler = Handler()
-                for (i in 0..18) {
+                for (i in 0..19) {
                     val count = i.toString()
                     handler.postDelayed(
                         { clipboard.primaryClip = ClipData.newPlainText(count, count) },


### PR DESCRIPTION
I tested it on a Samsung Galaxy S9+ and the clipboard history is now clearing properly.