### PR TITLE
Allow configuring pull behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   OTP codes can be automatically filled from SMS (requires Android P+ and Google Play Services)
 -   Importing TOTP secrets using QR codes
 -   Navigate into newly created folders and scroll to newly created passwords
+-   Allow configuring pull behavior. Head to the Git utils screen to choose from Merge or Rebase strategies.
 
 ## [1.9.2] - 2020-06-30
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -187,9 +187,10 @@ abstract class BaseGitActivity : AppCompatActivity() {
             }
 
             val localDir = requireNotNull(PasswordRepository.getRepositoryDirectory(this))
+            val rebase = settings.getBoolean("rebase_on_pull", true)
             val op = when (operation) {
                 REQUEST_CLONE, GitOperation.GET_SSH_KEY_FROM_CLONE -> CloneOperation(localDir, this).setCommand(url!!)
-                REQUEST_PULL -> PullOperation(localDir, this).setCommand()
+                REQUEST_PULL -> PullOperation(localDir, this).setCommand(rebase)
                 REQUEST_PUSH -> PushOperation(localDir, this).setCommand()
                 REQUEST_SYNC -> SyncOperation(localDir, this).setCommands()
                 BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(localDir, this).setCommands()

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -249,10 +249,9 @@ abstract class BaseGitActivity : AppCompatActivity() {
         const val REQUEST_PULL = 101
         const val REQUEST_PUSH = 102
         const val REQUEST_CLONE = 103
-        const val REQUEST_INIT = 104
-        const val REQUEST_SYNC = 105
-        const val BREAK_OUT_OF_DETACHED = 106
-        const val REQUEST_RESET = 107
+        const val REQUEST_SYNC = 104
+        const val BREAK_OUT_OF_DETACHED = 105
+        const val REQUEST_RESET = 106
         const val TAG = "AbstractGitActivity"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
@@ -68,5 +68,19 @@ class GitConfigActivity : BaseGitActivity() {
                 Handler().postDelayed(500) { finish() }
             }
         }
+        binding.pullStrategyGroup.apply {
+            check(if (settings.getBoolean("rebase_on_pull", true)) {
+                R.id.pull_strategy_rebase
+            } else {
+                R.id.pull_strategy_merge
+            })
+            addOnButtonCheckedListener { _, checkedId, checked ->
+                if (checked) {
+                    settings.edit {
+                        putBoolean("rebase_on_pull", checkedId != R.id.pull_strategy_merge)
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
@@ -77,7 +77,7 @@ class GitConfigActivity : BaseGitActivity() {
             addOnButtonCheckedListener { _, checkedId, checked ->
                 if (checked) {
                     settings.edit {
-                        putBoolean("rebase_on_pull", checkedId != R.id.pull_strategy_merge)
+                        putBoolean("rebase_on_pull", checkedId == R.id.pull_strategy_rebase)
                     }
                 }
             }

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
@@ -21,14 +21,15 @@ import org.eclipse.jgit.api.PullCommand
 class PullOperation(fileDir: File, callingActivity: AppCompatActivity) : GitOperation(fileDir, callingActivity) {
 
     /**
-     * Sets the command
+     * Sets the commands required to do a git pull on the repository. The [rebase] parameter decides
+     * whether the pull will be of type `git pull origin --rebase` or `git pull origin --no-rebase`.
      *
-     * @return the current object
+     * @return An instance of [PullOperation]
      */
-    fun setCommand(): PullOperation {
+    fun setCommand(rebase: Boolean): PullOperation {
         this.command = Git(repository)
             .pull()
-            .setRebase(true)
+            .setRebase(rebase)
             .setRemote("origin")
         return this
     }

--- a/app/src/main/res/layout/activity_git_config.xml
+++ b/app/src/main/res/layout/activity_git_config.xml
@@ -58,16 +58,50 @@
         app:layout_constraintTop_toBottomOf="@id/email_input_layout" />
 
     <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/pull_strategy_heading"
+        style="@style/AppTheme.HeaderText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/pull_strategy_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/save_button" />
+
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/pull_strategy_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/pull_strategy_heading"
+        app:selectionRequired="true"
+        app:singleSelection="true">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/pull_strategy_rebase"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/pull_strategy_merge" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/pull_strategy_merge"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/pull_strategy_rebase" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/git_tools_title"
-        style="@style/TextAppearance.MaterialComponents.Headline5"
+        style="@style/AppTheme.HeaderText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:text="@string/hackish_tools"
-        android:textSize="24sp"
-        android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/save_button" />
+        app:layout_constraintTop_toBottomOf="@id/pull_strategy_group" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/commit_hash_label"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,11 @@
     <string name="openpgp_error_no_user_ids">No matching PGP keys found</string>
     <string name="openpgp_error_unknown">Error from OpenKeyChain : %s</string>
 
+    <!-- Pull strategy -->
+    <string name="pull_strategy_title">Pull Strategy</string>
+    <string name="pull_strategy_merge">MERGE</string>
+    <string name="pull_strategy_rebase">REBASE</string>
+
     <!-- Password creation failure -->
     <string name="password_creation_file_fail_title">Error</string>
     <string name="password_creation_file_write_fail_message">Failed to write password file to the store, please try again.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -60,6 +60,11 @@
         <item name="colorSecondary">@color/secondary_color</item>
     </style>
 
+    <style name="AppTheme.HeaderText" parent="TextAppearance.MaterialComponents.Headline5">
+        <item name="android:textSize">24sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="ActionMode" parent="@style/Widget.AppCompat.ActionMode">
         <item name="background">@color/primary_color</item>
     </style>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
This PR allows configuring the pull behavior for JGit through the Git utils screen. While we were here,
I also went ahead and resolved a couple UX related issues I noticed. Git server config activity will
no longer request focus each time you open it, matching the behavior of Git config activity which only
does so when things are unconfigured. We also now have a password toggle for the git credential input
dialog similar to all the other input fields that accept confidential data.

## :bulb: Motivation and Context
The ability to configure pull behavior was requested in #836.

## :green_heart: How did you test it?
UX improvements were verified by manual checks, pull behavior remains untested. @Schueni1 will have to
step in and help verify this works as he expects it to.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :camera_flash: Screenshots / GIFs

<details>
<summary>Password Toggle</summary>

![Password Toggle](https://i.imgur.com/YNRfk2I.png)

</details>
