### PR TITLE
Remove API 30 from pull request test matrix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [23, 29, 30]
+        api-level: [23, 29]
         variant: [Debug, Release]
     steps:
 
@@ -71,10 +71,10 @@ jobs:
 
     - name: Run instrumentation tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: reactivecircus/android-emulator-runner@v2.10.0
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
-        target: google_apis
+        target: default
         script: |
           adb shell settings put global animator_duration_scale 0
           adb shell settings put global transition_animation_scale 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Run instrumentation tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.11.0
       with:
         api-level: ${{ matrix.api-level }}
         target: default


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Removes API 30 from the PR test matrix and bumps the emulator-runner action to its latest release.

## :bulb: Motivation and Context
API 30 tests are regularly failing for reasons beyond our control and since GitHub doesn't allow matrix members to fail independently,
this holds up PRs for no reason.

## :green_heart: How did you test it?
Hopefully, this PR.
