### PR TITLE
Reset SSH passphrase after SSH key import

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -655,6 +655,7 @@ class UserPreference : AppCompatActivity() {
                         val prefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
 
                         prefs.edit { putBoolean("use_generated_key", false) }
+                        getEncryptedPrefs("git_operation").edit { remove("ssh_key_local_passphrase") }
 
                         // Delete the public key from generation
                         File("""$filesDir/.ssh_key.pub""").delete()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
We should reset the SSH passphrase when the user imports a new private key.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
