### PR TITLE
Offer TOTP Autofill for OTP fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   TOTP support is reintroduced by popular demand. HOTP continues to be unsupported and heavily discouraged.
+-   Initial support for detecting and filling OTP fields with Autofill
 
 ## [1.9.1] - 2020-06-28
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,9 @@ android {
 }
 
 dependencies {
-    implementation deps.androidx.annotation
     implementation deps.androidx.activity_ktx
+    implementation deps.androidx.annotation
+    implementation deps.androidx.autofill
     implementation deps.androidx.appcompat
     implementation deps.androidx.biometric
     implementation deps.androidx.constraint_layout

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
@@ -86,7 +86,7 @@ val AssistStructure.ViewNode.webOrigin: String?
         "$scheme://$domain"
     }
 
-data class Credentials(val username: String?, val password: String) {
+data class Credentials(val username: String?, val password: String, val otp: String?) {
     companion object {
         fun fromStoreEntry(
             context: Context,
@@ -98,7 +98,7 @@ data class Credentials(val username: String?, val password: String) {
             val username = entry.username
                 ?: directoryStructure.getUsernameFor(file)
                 ?: context.getDefaultUsername()
-            return Credentials(username, entry.password)
+            return Credentials(username, entry.password, entry.calculateTotpCode())
         }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillScenario.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillScenario.kt
@@ -29,6 +29,7 @@ sealed class AutofillScenario<out T : Any> {
     companion object {
         const val BUNDLE_KEY_USERNAME_ID = "usernameId"
         const val BUNDLE_KEY_FILL_USERNAME = "fillUsername"
+        const val BUNDLE_KEY_OTP_ID = "otpId"
         const val BUNDLE_KEY_CURRENT_PASSWORD_IDS = "currentPasswordIds"
         const val BUNDLE_KEY_NEW_PASSWORD_IDS = "newPasswordIds"
         const val BUNDLE_KEY_GENERIC_PASSWORD_IDS = "genericPasswordIds"
@@ -38,6 +39,7 @@ sealed class AutofillScenario<out T : Any> {
                 Builder<AutofillId>().apply {
                     username = clientState.getParcelable(BUNDLE_KEY_USERNAME_ID)
                     fillUsername = clientState.getBoolean(BUNDLE_KEY_FILL_USERNAME)
+                    otp = clientState.getParcelable(BUNDLE_KEY_OTP_ID)
                     currentPassword.addAll(
                         clientState.getParcelableArrayList(
                             BUNDLE_KEY_CURRENT_PASSWORD_IDS
@@ -64,6 +66,7 @@ sealed class AutofillScenario<out T : Any> {
     class Builder<T : Any> {
         var username: T? = null
         var fillUsername = false
+        var otp: T? = null
         val currentPassword = mutableListOf<T>()
         val newPassword = mutableListOf<T>()
         val genericPassword = mutableListOf<T>()
@@ -74,6 +77,7 @@ sealed class AutofillScenario<out T : Any> {
                 ClassifiedAutofillScenario(
                     username = username,
                     fillUsername = fillUsername,
+                    otp = otp,
                     currentPassword = currentPassword,
                     newPassword = newPassword
                 )
@@ -81,6 +85,7 @@ sealed class AutofillScenario<out T : Any> {
                 GenericAutofillScenario(
                     username = username,
                     fillUsername = fillUsername,
+                    otp = otp,
                     genericPassword = genericPassword
                 )
             }
@@ -89,6 +94,7 @@ sealed class AutofillScenario<out T : Any> {
 
     abstract val username: T?
     abstract val fillUsername: Boolean
+    abstract val otp: T?
     abstract val allPasswordFields: List<T>
     abstract val passwordFieldsToFillOnMatch: List<T>
     abstract val passwordFieldsToFillOnSearch: List<T>
@@ -99,19 +105,19 @@ sealed class AutofillScenario<out T : Any> {
         get() = listOfNotNull(username) + passwordFieldsToSave
 
     val allFields
-        get() = listOfNotNull(username) + allPasswordFields
+        get() = listOfNotNull(username, otp) + allPasswordFields
 
     fun fieldsToFillOn(action: AutofillAction): List<T> {
-        val passwordFieldsToFill = when (action) {
-            AutofillAction.Match -> passwordFieldsToFillOnMatch
-            AutofillAction.Search -> passwordFieldsToFillOnSearch
+        val credentialFieldsToFill = when (action) {
+            AutofillAction.Match -> passwordFieldsToFillOnMatch + listOfNotNull(otp)
+            AutofillAction.Search -> passwordFieldsToFillOnSearch + listOfNotNull(otp)
             AutofillAction.Generate -> passwordFieldsToFillOnGenerate
         }
         return when {
-            passwordFieldsToFill.isNotEmpty() -> {
+            credentialFieldsToFill.isNotEmpty() -> {
                 // If the current action would fill into any password field, we also fill into the
                 // username field if possible.
-                listOfNotNull(username.takeIf { fillUsername }) + passwordFieldsToFill
+                listOfNotNull(username.takeIf { fillUsername }) + credentialFieldsToFill
             }
             allPasswordFields.isEmpty() && action != AutofillAction.Generate -> {
                 // If there no password fields at all, we still offer to fill the username, e.g. in
@@ -127,6 +133,7 @@ sealed class AutofillScenario<out T : Any> {
 data class ClassifiedAutofillScenario<T : Any>(
     override val username: T?,
     override val fillUsername: Boolean,
+    override val otp: T?,
     val currentPassword: List<T>,
     val newPassword: List<T>
 ) : AutofillScenario<T>() {
@@ -147,6 +154,7 @@ data class ClassifiedAutofillScenario<T : Any>(
 data class GenericAutofillScenario<T : Any>(
     override val username: T?,
     override val fillUsername: Boolean,
+    override val otp: T?,
     val genericPassword: List<T>
 ) : AutofillScenario<T>() {
 
@@ -183,14 +191,15 @@ fun Dataset.Builder.fillWith(
 ) {
     val credentialsToFill = credentials ?: Credentials(
         "USERNAME",
-        "PASSWORD"
+        "PASSWORD",
+        "OTP"
     )
     for (field in scenario.fieldsToFillOn(action)) {
-        val value = if (field == scenario.username) {
-            credentialsToFill.username
-        } else {
-            credentialsToFill.password
-        } ?: continue
+        val value = when (field) {
+            scenario.username -> credentialsToFill.username
+            scenario.otp -> credentialsToFill.otp
+            else -> credentialsToFill.password
+        }
         setValue(field, AutofillValue.forText(value))
     }
 }
@@ -209,6 +218,7 @@ inline fun <T : Any, S : Any> AutofillScenario<T>.map(transform: (T) -> S): Auto
     val builder = AutofillScenario.Builder<S>()
     builder.username = username?.let(transform)
     builder.fillUsername = fillUsername
+    builder.otp = otp?.let(transform)
     when (this) {
         is ClassifiedAutofillScenario -> {
             builder.currentPassword.addAll(currentPassword.map(transform))
@@ -225,9 +235,10 @@ inline fun <T : Any, S : Any> AutofillScenario<T>.map(transform: (T) -> S): Auto
 @JvmName("toBundleAutofillId")
 private fun AutofillScenario<AutofillId>.toBundle(): Bundle = when (this) {
     is ClassifiedAutofillScenario<AutofillId> -> {
-        Bundle(4).apply {
+        Bundle(5).apply {
             putParcelable(AutofillScenario.BUNDLE_KEY_USERNAME_ID, username)
             putBoolean(AutofillScenario.BUNDLE_KEY_FILL_USERNAME, fillUsername)
+            putParcelable(AutofillScenario.BUNDLE_KEY_OTP_ID, otp)
             putParcelableArrayList(
                 AutofillScenario.BUNDLE_KEY_CURRENT_PASSWORD_IDS, ArrayList(currentPassword)
             )
@@ -237,9 +248,10 @@ private fun AutofillScenario<AutofillId>.toBundle(): Bundle = when (this) {
         }
     }
     is GenericAutofillScenario<AutofillId> -> {
-        Bundle(3).apply {
+        Bundle(4).apply {
             putParcelable(AutofillScenario.BUNDLE_KEY_USERNAME_ID, username)
             putBoolean(AutofillScenario.BUNDLE_KEY_FILL_USERNAME, fillUsername)
+            putParcelable(AutofillScenario.BUNDLE_KEY_OTP_ID, otp)
             putParcelableArrayList(
                 AutofillScenario.BUNDLE_KEY_GENERIC_PASSWORD_IDS, ArrayList(genericPassword)
             )

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategy.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategy.kt
@@ -166,6 +166,13 @@ val autofillStrategy = strategy {
         }
     }
 
+    // Match a single focused OTP field.
+    rule(applyInSingleOriginMode = true) {
+        otp {
+            takeSingle { otpCertainty >= Likely && isFocused }
+        }
+    }
+
     // Match a single focused username field without a password field.
     rule(applyInSingleOriginMode = true) {
         username {

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategyDsl.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategyDsl.kt
@@ -164,7 +164,7 @@ class AutofillRule private constructor(
     )
 
     enum class FillableFieldType {
-        Username, CurrentPassword, NewPassword, GenericPassword,
+        Username, Otp, CurrentPassword, NewPassword, GenericPassword,
     }
 
     @AutofillDsl
@@ -188,6 +188,18 @@ class AutofillRule private constructor(
                     matcher = SingleFieldMatcher.Builder().apply(block).build(),
                     optional = optional,
                     matchHidden = matchHidden
+                )
+            )
+        }
+
+        fun otp(optional: Boolean = false, block: SingleFieldMatcher.Builder.() -> Unit) {
+            require(matchers.none { it.type == FillableFieldType.Otp }) { "Every rule block can only have at most one otp block" }
+            matchers.add(
+                AutofillRuleMatcher(
+                    type = FillableFieldType.Otp,
+                    matcher = SingleFieldMatcher.Builder().apply(block).build(),
+                    optional = optional,
+                    matchHidden = false
                 )
             )
         }
@@ -247,6 +259,7 @@ class AutofillRule private constructor(
     fun match(
         allPassword: List<FormField>,
         allUsername: List<FormField>,
+        allOtp: List<FormField>,
         singleOriginMode: Boolean,
         isManualRequest: Boolean
     ): AutofillScenario<FormField>? {
@@ -264,6 +277,7 @@ class AutofillRule private constructor(
         for ((type, matcher, optional, matchHidden) in matchers) {
             val fieldsToMatchOn = when (type) {
                 FillableFieldType.Username -> allUsername
+                FillableFieldType.Otp -> allOtp
                 else -> allPassword
             }.filter { matchHidden || it.isVisible }
             val matchResult = matcher.match(fieldsToMatchOn, alreadyMatched) ?: if (optional) {
@@ -280,6 +294,10 @@ class AutofillRule private constructor(
                     scenarioBuilder.username = matchResult.single()
                     // Hidden username fields should be saved but not filled.
                     scenarioBuilder.fillUsername = scenarioBuilder.username!!.isVisible == true
+                }
+                FillableFieldType.Otp -> {
+                    check(matchResult.size == 1 && scenarioBuilder.otp == null)
+                    scenarioBuilder.otp = matchResult.single()
                 }
                 FillableFieldType.CurrentPassword -> scenarioBuilder.currentPassword.addAll(
                     matchResult
@@ -338,12 +356,16 @@ class AutofillStrategy private constructor(private val rules: List<AutofillRule>
         val possibleUsernameFields =
             fields.filter { it.usernameCertainty >= CertaintyLevel.Possible }
         d { "Possible username fields: ${possibleUsernameFields.size}" }
+        val possibleOtpFields =
+            fields.filter { it.otpCertainty >= CertaintyLevel.Possible }
+        d { "Possible otp fields: ${possibleOtpFields.size}" }
         // Return the result of the first rule that matches
         d { "Rules: ${rules.size}" }
         for (rule in rules) {
             return rule.match(
                 possiblePasswordFields,
                 possibleUsernameFields,
+                possibleOtpFields,
                 singleOriginMode = singleOriginMode,
                 isManualRequest = isManualRequest
             )

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
@@ -106,7 +106,7 @@ class OreoAutofillService : AutofillService() {
         callback.onSuccess(
             AutofillSaveActivity.makeSaveIntentSender(
                 this,
-                credentials = Credentials(username, password),
+                credentials = Credentials(username, password, null),
                 formOrigin = formOrigin
             )
         )

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
@@ -100,7 +100,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
         directoryStructure = AutofillPreferences.directoryStructure(this)
         d { action.toString() }
         launch {
-            val credentials = decryptUsernameAndPassword(File(filePath))
+            val credentials = decryptCredential(File(filePath))
             if (credentials == null) {
                 setResult(RESULT_CANCELED)
             } else {
@@ -153,7 +153,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
         }
     }
 
-    private suspend fun decryptUsernameAndPassword(
+    private suspend fun decryptCredential(
         file: File,
         resumeIntent: Intent? = null
     ): Credentials? {
@@ -178,6 +178,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
             OpenPgpApi.RESULT_CODE_SUCCESS -> {
                 try {
                     val entry = withContext(Dispatchers.IO) {
+                        @Suppress("BlockingMethodInNonBlockingContext")
                         PasswordEntry(decryptedOutput)
                     }
                     Credentials.fromStoreEntry(this, file, entry, directoryStructure)
@@ -203,7 +204,7 @@ class AutofillDecryptActivity : Activity(), CoroutineScope {
                             )
                         }
                     }
-                    decryptUsernameAndPassword(file, intentToResume)
+                    decryptCredential(file, intentToResume)
                 } catch (e: Exception) {
                     e(e) { "OpenPgpApi ACTION_DECRYPT_VERIFY failed with user interaction" }
                     null

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
@@ -130,7 +130,7 @@ class AutofillSaveActivity : Activity() {
                         finish()
                         return
                     }
-                val credentials = Credentials(username, password)
+                val credentials = Credentials(username, password, null)
                 val fillInDataset = FillableForm.makeFillInDataset(
                     this,
                     credentials,

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
@@ -200,12 +200,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
                                         }
                                         launch(Dispatchers.IO) {
                                             repeat(Int.MAX_VALUE) {
-                                                val code = Otp.calculateCode(
-                                                    entry.totpSecret!!,
-                                                    Date().time / (1000 * entry.totpPeriod),
-                                                    entry.totpAlgorithm,
-                                                    entry.digits
-                                                ) ?: "Error"
+                                                val code = entry.calculateTotpCode() ?: "Error"
                                                 withContext(Dispatchers.Main) {
                                                     otpText.setText(code)
                                                 }

--- a/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
@@ -4,10 +4,12 @@
  */
 package com.zeapo.pwdstore.model
 
+import com.zeapo.pwdstore.utils.Otp
 import com.zeapo.pwdstore.utils.TotpFinder
 import com.zeapo.pwdstore.utils.UriTotpFinder
 import java.io.ByteArrayOutputStream
 import java.io.UnsupportedEncodingException
+import java.util.Date
 
 /**
  * A single entry in password store. [totpFinder] is an implementation of [TotpFinder] that let's us
@@ -48,6 +50,12 @@ class PasswordEntry(content: String, private val totpFinder: TotpFinder = UriTot
 
     fun hasUsername(): Boolean {
         return username != null
+    }
+
+    fun calculateTotpCode(): String? {
+        if (totpSecret == null)
+            return null
+        return Otp.calculateCode(totpSecret, Date().time / (1000 * totpPeriod), totpAlgorithm, digits)
     }
 
     val extraContentWithoutAuthData by lazy {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,8 +24,9 @@ ext.deps = [
     ],
 
     androidx: [
-        annotation: 'androidx.annotation:annotation:1.2.0-alpha01',
         activity_ktx: 'androidx.activity:activity-ktx:1.2.0-alpha06',
+        annotation: 'androidx.annotation:annotation:1.2.0-alpha01',
+        autofill: 'androidx.autofill:autofill:1.0.0',
         appcompat: 'androidx.appcompat:appcompat:1.3.0-alpha01',
         biometric: 'androidx.biometric:biometric:1.1.0-alpha01',
         constraint_layout: 'androidx.constraintlayout:constraintlayout:2.0.0-beta7',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Make (modern) Autofill detect OTP fields and offer to fill them with TOTPs calculated from a secret stored in the encrypted extras.

OTP fields are currently detected based on the W3C hint `one-time-code`, a `maxLength` between 6 and 8 and/or the strings "otp" and "code" in attributes. For now, we don't allow filling both OTPs and passwords/usernames at the same time since I have never seen a site do this.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TOTPs are here to stay and we should do our best to protect them from phishing. It also turns out that our Autofill implementation is flexible enough that adding support for this requires only ~100 changed lines.
Fixes #663.

## :green_heart: How did you test it?
I verified that this works with Amazon in Chrome and that existing workflows are not obviously broken. Since I rarely use OTPs, I would like to let the snapshot users test this more thoroughly and focus on fixing the issues they find.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
I will look into providing autofilled OTPs from SMS.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
