### PR TITLE
Backport crash workaround for 1.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+-   App crashes upon launching the app for the first time
+
 ## [1.9.1] - 2020-06-28
 
 ### Fixed

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -291,6 +291,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
         recyclerViewState: Parcelable? = null,
         pushPreviousLocation: Boolean = true
     ) {
+        if (!newDirectory.exists()) return
         require(newDirectory.isDirectory) { "Can only navigate to a directory" }
         if (pushPreviousLocation) {
             navigationStack.push(NavigationStackEntry(_currentDir.value!!, recyclerViewState))


### PR DESCRIPTION
## :scroll: Description
Backports first run crash workaround for patch release


## :bulb: Motivation and Context
This has been reported in the wild and is readily reproducible

## :green_heart: How did you test it?
Wipe data and start app, observe crash.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
