### PR TITLE
Allow importing TOTP configuration through QR codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 -   TOTP support is reintroduced by popular demand. HOTP continues to be unsupported and heavily discouraged.
 -   Initial support for detecting and filling OTP fields with Autofill
+-   Importing TOTP secrets using URI codes
 
 ## [1.9.1] - 2020-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 -   TOTP support is reintroduced by popular demand. HOTP continues to be unsupported and heavily discouraged.
 -   Initial support for detecting and filling OTP fields with Autofill
--   Importing TOTP secrets using URI codes
+-   Importing TOTP secrets using QR codes
 
 ## [1.9.1] - 2020-06-28
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     implementation deps.kotlin.coroutines.android
     implementation deps.kotlin.coroutines.core
 
+    implementation deps.first_party.openpgp_ktx
+    implementation deps.first_party.zxing_android_embedded
+
     implementation deps.third_party.commons_codec
     implementation deps.third_party.fastscroll
     implementation(deps.third_party.jgit) {
@@ -102,7 +105,6 @@ dependencies {
     implementation deps.third_party.sshj
     implementation deps.third_party.bouncycastle
     implementation deps.third_party.plumber
-    implementation deps.third_party.openpgp_ktx
     implementation deps.third_party.ssh_auth
     implementation deps.third_party.timber
     implementation deps.third_party.timberkt

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,14 @@
         </activity>
 
         <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:clearTaskOnLaunch="true"
+            android:stateNotNeeded="true"
+            android:theme="@style/zxing_CaptureTheme"
+            android:windowSoftInputMode="stateAlwaysHidden"
+            tools:node="replace" />
+
+        <activity
             android:name=".git.GitOperationActivity"
             android:theme="@style/NoBackgroundTheme" />
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -17,6 +17,8 @@ import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.lifecycleScope
 import com.github.ajalt.timberkt.e
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.zxing.integration.android.IntentIntegrator
+import com.google.zxing.integration.android.IntentIntegrator.QR_CODE
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.autofill.oreo.AutofillPreferences
 import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
@@ -62,6 +64,23 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
         with(binding) {
             setContentView(root)
             generatePassword.setOnClickListener { generatePassword() }
+            otpImportButton.setOnClickListener {
+                registerForActivityResult(StartActivityForResult()) { result ->
+                    if (result.resultCode == RESULT_OK) {
+                        val intentResult = IntentIntegrator.parseActivityResult(RESULT_OK, result.data)
+                        extraContent.append("\n${intentResult.contents}")
+                        snackbar(message = getString(R.string.otp_import_success))
+                    } else {
+                        snackbar(message = getString(R.string.otp_import_failure))
+                    }
+                }.launch(
+                    IntentIntegrator(this@PasswordCreationActivity)
+                        .setOrientationLocked(false)
+                        .setBeepEnabled(false)
+                        .setDesiredBarcodeFormats(QR_CODE)
+                        .createScanIntent()
+                )
+            }
 
             category.apply {
                 if (suggestedName != null || suggestedPass != null || shouldGeneratePassword) {

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -64,6 +64,8 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
         with(binding) {
             setContentView(root)
             generatePassword.setOnClickListener { generatePassword() }
+            otpImportButton.isVisible = !(suggestedExtra != null &&
+                (suggestedExtra.contains("otpauth://") || suggestedExtra.contains("totp:")))
             otpImportButton.setOnClickListener {
                 registerForActivityResult(StartActivityForResult()) { result ->
                     if (result.resultCode == RESULT_OK) {

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -74,7 +74,8 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                         } else {
                             "totp: ${intentResult.contents}\n"
                         }
-                        if (extraContent.text.toString().last() != '\n')
+                        val currentExtras = extraContent.text.toString()
+                        if (currentExtras.isNotEmpty() && currentExtras.last() != '\n')
                             extraContent.append("\n$contents")
                         else
                             extraContent.append(contents)

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -69,10 +69,15 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                     if (result.resultCode == RESULT_OK) {
                         otpImportButton.isVisible = false
                         val intentResult = IntentIntegrator.parseActivityResult(RESULT_OK, result.data)
+                        val contents = if (intentResult.contents.startsWith("otpauth://")) {
+                            "${intentResult.contents}\n"
+                        } else {
+                            "totp: ${intentResult.contents}\n"
+                        }
                         if (extraContent.text.toString().last() != '\n')
-                            extraContent.append("\n${intentResult.contents}\n")
+                            extraContent.append("\n$contents")
                         else
-                            extraContent.append("${intentResult.contents}\n")
+                            extraContent.append(contents)
                         snackbar(message = getString(R.string.otp_import_success))
                     } else {
                         snackbar(message = getString(R.string.otp_import_failure))

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -70,7 +70,10 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                 registerForActivityResult(StartActivityForResult()) { result ->
                     if (result.resultCode == RESULT_OK) {
                         val intentResult = IntentIntegrator.parseActivityResult(RESULT_OK, result.data)
-                        extraContent.append("\n${intentResult.contents}")
+                        if (extraContent.text.toString().last() != '\n')
+                            extraContent.append("\n${intentResult.contents}\n")
+                        else
+                            extraContent.append("${intentResult.contents}\n")
                         snackbar(message = getString(R.string.otp_import_success))
                     } else {
                         snackbar(message = getString(R.string.otp_import_failure))

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -63,14 +63,14 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
             getString(R.string.new_password_title)
         with(binding) {
             setContentView(root)
+            val pwEntry = PasswordEntry("${suggestedPass}\n${suggestedExtra}")
             generatePassword.setOnClickListener { generatePassword() }
-            otpImportButton.isVisible = !(suggestedExtra != null &&
-                (suggestedExtra.contains("otpauth://") || suggestedExtra.contains("totp:")))
+            otpImportButton.isVisible = !pwEntry.hasTotp()
             otpImportButton.setOnClickListener {
                 registerForActivityResult(StartActivityForResult()) { result ->
                     if (result.resultCode == RESULT_OK) {
                         val intentResult = IntentIntegrator.parseActivityResult(RESULT_OK, result.data)
-                        if (extraContent.text.toString().last() != '\n')
+                        if (pwEntry.extraContent.last() != '\n')
                             extraContent.append("\n${intentResult.contents}\n")
                         else
                             extraContent.append("${intentResult.contents}\n")

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -119,7 +119,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                             val username = filename.text.toString()
                             val extras = "username:$username\n${extraContent.text}"
 
-                            filename.setText("")
+                            filename.text?.clear()
                             extraContent.setText(extras)
                         } else {
                             // User wants to disable username encryption, so we extract the

--- a/app/src/main/res/drawable/ic_qr_code_scanner.xml
+++ b/app/src/main/res/drawable/ic_qr_code_scanner.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9.5,6.5v3h-3v-3H9.5M11,5H5v6h6V5L11,5zM9.5,14.5v3h-3v-3H9.5M11,13H5v6h6V13L11,13zM17.5,6.5v3h-3v-3H17.5M19,5h-6v6h6V5L19,5zM13,13h1.5v1.5H13V13zM14.5,14.5H16V16h-1.5V14.5zM16,13h1.5v1.5H16V13zM13,16h1.5v1.5H13V16zM14.5,17.5H16V19h-1.5V17.5zM16,16h1.5v1.5H16V16zM17.5,14.5H19V16h-1.5V14.5zM17.5,17.5H19V19h-1.5V17.5zM22,7h-2V4h-3V2h5V7zM22,22v-5h-2v3h-3v2H22zM2,22h5v-2H4v-3H2V22zM2,2v5h2V4h3V2H2z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/layout/password_creation_activity.xml
+++ b/app/src/main/res/layout/password_creation_activity.xml
@@ -84,6 +84,15 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/otp_import_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/setup_otp_from_qr_code"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/extra_input_layout" />
+
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/encrypt_username"
         android:layout_width="match_parent"
@@ -92,6 +101,6 @@
         android:text="@string/crypto_encrypt_username_label"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/extra_input_layout"
+        app:layout_constraintTop_toBottomOf="@id/otp_import_button"
         tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/password_creation_activity.xml
+++ b/app/src/main/res/layout/password_creation_activity.xml
@@ -89,7 +89,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        android:text="@string/setup_otp_from_qr_code"
+        android:text="@string/add_otp"
+        app:icon="@drawable/ic_qr_code_scanner"
+        app:iconTint="?attr/colorOnSecondary"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/extra_input_layout" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -383,4 +383,7 @@
     <string name="password_creation_file_write_fail_message">Failed to write password file to the store, please try again.</string>
     <string name="password_creation_file_delete_fail_message">Failed to delete password file %1$s from the store, please delete it manually.</string>
     <string name="password_creation_duplicate_error">File already exists, please use a different name</string>
+    <string name="setup_otp_from_qr_code">Setup OTP from QR code</string>
+    <string name="otp_import_success">Successfully imported TOTP configuration</string>
+    <string name="otp_import_failure">Failed to import TOTP configuration</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -383,7 +383,7 @@
     <string name="password_creation_file_write_fail_message">Failed to write password file to the store, please try again.</string>
     <string name="password_creation_file_delete_fail_message">Failed to delete password file %1$s from the store, please delete it manually.</string>
     <string name="password_creation_duplicate_error">File already exists, please use a different name</string>
-    <string name="setup_otp_from_qr_code">Setup OTP from QR code</string>
+    <string name="add_otp">Add OTP</string>
     <string name="otp_import_success">Successfully imported TOTP configuration</string>
     <string name="otp_import_failure">Failed to import TOTP configuration</string>
 </resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,6 +44,11 @@ ext.deps = [
         swiperefreshlayout: 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     ],
 
+    first_party: [
+        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:2.0.0',
+        zxing_android_embedded: 'com.github.android-password-store:zxing-android-embedded:v4.1.0-aps'
+    ],
+
     third_party: [
         bouncycastle: 'org.bouncycastle:bcprov-jdk15on:1.65.01',
         commons_codec: 'commons-codec:commons-codec:1.13',
@@ -52,7 +57,6 @@ ext.deps = [
         jgit: 'org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r',
         leakcanary: 'com.squareup.leakcanary:leakcanary-android:2.4',
         plumber: 'com.squareup.leakcanary:plumber-android:2.4',
-        openpgp_ktx: 'com.github.android-password-store:openpgp-ktx:2.0.0',
         sshj: 'com.hierynomus:sshj:0.29.0',
         ssh_auth: 'org.sufficientlysecure:sshauthentication-api:1.0',
         timber: 'com.jakewharton.timber:timber:4.7.1',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Adds a button to password creation/edit screen that starts a camera view to import QR codes. The implementation
is very rudimentary and does no error checking, which we should change. The view also starts in landscape which
I will probably need to rectify in the source library.

## :bulb: Motivation and Context
Let's just say that I am better at Kotlin than at Bash and leave it at that.

## :green_heart: How did you test it?
Manually imported by 20+ TOTP sites into files with and without extra content and validated the generated OTPs.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

## :camera_flash: Screenshots / GIFs

¯\\_(ツ)_/¯