### PR TITLE
Revert "Support directly importing secrets"

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -69,11 +69,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                     if (result.resultCode == RESULT_OK) {
                         otpImportButton.isVisible = false
                         val intentResult = IntentIntegrator.parseActivityResult(RESULT_OK, result.data)
-                        val contents = if (intentResult.contents.startsWith("otpauth://")) {
-                            "${intentResult.contents}\n"
-                        } else {
-                            "totp: ${intentResult.contents}\n"
-                        }
+                        val contents = "${intentResult.contents}\n"
                         val currentExtras = extraContent.text.toString()
                         if (currentExtras.isNotEmpty() && currentExtras.last() != '\n')
                             extraContent.append("\n$contents")


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Remove support for importing bare secrets through QR import

## :bulb: Motivation and Context
This has no precedent in the wild. The only possible use-case is scripting, where it would probably be best to just include the entire thing within the script.

## :green_heart: How did you test it?
Haven't :eek:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Probably error-handling of some sort?

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
