### PR TITLE
Fix up URIish instances with @ in user name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   Folder names that were very long did not look right
 -   Error message for wrong SSH/HTTPS password now looks cleaner
+-   Fix authentication failure with usernames that contain the `@` character
 
 ### Added
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Manually fix up `URIish` instances with `@` characters in the hostname. The parsing is broken and should allow `@` in usernames.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #912.

## :green_heart: How did you test it?
I can connect to a Google Source repo with this change, but @ProjectMoon should verify this themself.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Consider whether this warrants a backport/changelog entry.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
