### PR TITLE
styles: re-add alertDialogTheme override

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,6 +22,7 @@
         <item name="android:navigationBarColor">@color/navigation_bar_color</item>
         <item name="android:windowLightStatusBar">@bool/light_status_bar</item>
         <item name="actionModeStyle">@style/ActionMode</item>
+        <item name="alertDialogTheme">@style/AppTheme.Dialog</item>
         <item name="materialAlertDialogTheme">@style/AppTheme.Dialog</item>
         <item name="materialButtonStyle">@style/AppTheme.MaterialButton</item>
         <item name="materialButtonOutlinedStyle">@style/AppTheme.OutlinedButton</item>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Change the default alert dialog theme to our custom one.

## :bulb: Motivation and Context
AndroidX Preference uses AppCompat's AlertDialog which needs this attribute to be customized.

## :green_heart: How did you test it?
Select the 'App theme' option and observe the 'Cancel' button is now visible in light and dark theme.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
