### PR TITLE
global: set an import order rule and reformat with it

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -17,6 +17,23 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="android" alias="false" withSubpackages="true" />
+          <package name="androidx" alias="false" withSubpackages="true" />
+          <package name="com" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="kotlinx" alias="false" withSubpackages="true" />
+          <package name="me" alias="false" withSubpackages="true" />
+          <package name="mozilla" alias="false" withSubpackages="true" />
+          <package name="net" alias="false" withSubpackages="true" />
+          <package name="org" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />

--- a/app/src/main/java/com/zeapo/pwdstore/ClipboardService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ClipboardService.kt
@@ -153,6 +153,7 @@ class ClipboardService : Service() {
     }
 
     companion object {
+
         private const val ACTION_CLEAR = "ACTION_CLEAR_CLIPBOARD"
         const val ACTION_START = "ACTION_START_CLIPBOARD_TIMER"
         private const val CHANNEL_ID = "NotificationService"

--- a/app/src/main/java/com/zeapo/pwdstore/LaunchActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/LaunchActivity.kt
@@ -55,6 +55,7 @@ class LaunchActivity : AppCompatActivity() {
     }
 
     companion object {
+
         const val ACTION_DECRYPT_PASS = "DECRYPT_PASS"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -35,10 +35,11 @@ import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.viewBinding
-import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import java.io.File
+import me.zhanghai.android.fastscroll.FastScrollerBuilder
 
 class PasswordFragment : Fragment(R.layout.password_recycler_view) {
+
     private lateinit var recyclerAdapter: PasswordItemRecyclerAdapter
     private lateinit var listener: OnFragmentInteractionListener
     private lateinit var settings: SharedPreferences
@@ -280,6 +281,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     }
 
     companion object {
+
         const val ITEM_CREATION_REQUEST_KEY = "creation_key"
         const val ACTION_KEY = "action"
         const val ACTION_FOLDER = "folder"
@@ -301,6 +303,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     }
 
     interface OnFragmentInteractionListener {
+
         fun onFragmentInteraction(item: PasswordItem)
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -70,14 +70,14 @@ import com.zeapo.pwdstore.utils.contains
 import com.zeapo.pwdstore.utils.isInsideRepository
 import com.zeapo.pwdstore.utils.listFilesRecursively
 import com.zeapo.pwdstore.utils.requestInputFocusOnView
+import java.io.File
+import java.lang.Character.UnicodeBlock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.GitAPIException
 import org.eclipse.jgit.revwalk.RevCommit
-import java.io.File
-import java.lang.Character.UnicodeBlock
 
 class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
 
@@ -904,6 +904,7 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
         get() = getSortOrder(settings)
 
     companion object {
+
         const val REQUEST_ARG_PATH = "PATH"
         const val CLONE_REPO_BUTTON = 401
         const val NEW_REPO_BUTTON = 402

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -31,6 +31,10 @@ import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
+import java.io.File
+import java.text.Collator
+import java.util.Locale
+import java.util.Stack
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -45,10 +49,6 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.yield
 import me.zhanghai.android.fastscroll.PopupTextProvider
-import java.io.File
-import java.text.Collator
-import java.util.Locale
-import java.util.Stack
 
 private fun File.toPasswordItem(root: File) = if (isFile)
     PasswordItem.newPassword(name, this, root)
@@ -380,6 +380,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
 }
 
 private object PasswordItemDiffCallback : DiffUtil.ItemCallback<PasswordItem>() {
+
     override fun areItemsTheSame(oldItem: PasswordItem, newItem: PasswordItem) =
         oldItem.file.absolutePath == newItem.file.absolutePath
 

--- a/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
@@ -14,6 +14,7 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 
 
 class SelectFolderActivity : AppCompatActivity(R.layout.select_folder_layout) {
+
     private lateinit var passwordList: SelectFolderFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/zeapo/pwdstore/SelectFolderFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SelectFolderFragment.kt
@@ -16,10 +16,11 @@ import com.zeapo.pwdstore.databinding.PasswordRecyclerViewBinding
 import com.zeapo.pwdstore.ui.adapters.PasswordItemRecyclerAdapter
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.viewBinding
-import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import java.io.File
+import me.zhanghai.android.fastscroll.FastScrollerBuilder
 
 class SelectFolderFragment : Fragment(R.layout.password_recycler_view) {
+
     private val binding by viewBinding(PasswordRecyclerViewBinding::bind)
     private lateinit var recyclerAdapter: PasswordItemRecyclerAdapter
     private lateinit var listener: OnFragmentInteractionListener
@@ -70,6 +71,7 @@ class SelectFolderFragment : Fragment(R.layout.password_recycler_view) {
         get() = model.currentDir.value!!
 
     interface OnFragmentInteractionListener {
+
         fun onFragmentInteraction(item: PasswordItem)
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -57,7 +57,6 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.autofillManager
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
-import me.msfjarvis.openpgpktx.util.OpenPgpUtils
 import java.io.File
 import java.io.IOException
 import java.time.LocalDateTime
@@ -65,6 +64,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.HashSet
 import java.util.TimeZone
+import me.msfjarvis.openpgpktx.util.OpenPgpUtils
 
 typealias ClickListener = Preference.OnPreferenceClickListener
 typealias ChangeListener = Preference.OnPreferenceChangeListener
@@ -74,6 +74,7 @@ class UserPreference : AppCompatActivity() {
     private lateinit var prefsFragment: PrefsFragment
 
     class PrefsFragment : PreferenceFragmentCompat() {
+
         private var autoFillEnablePreference: SwitchPreferenceCompat? = null
         private var oreoAutofillChromeCompatFix: SwitchPreferenceCompat? = null
         private var clearSavedPassPreference: Preference? = null
@@ -843,6 +844,7 @@ class UserPreference : AppCompatActivity() {
     }
 
     companion object {
+
         private const val TAG = "UserPreference"
 
         /**

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillActivity.kt
@@ -90,6 +90,7 @@ class AutofillActivity : AppCompatActivity() {
     }
 
     companion object {
+
         const val REQUEST_CODE_DECRYPT_AND_VERIFY = 9913
         const val REQUEST_CODE_PICK = 777
         const val REQUEST_CODE_PICK_MATCH_WITH = 778

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillFragment.kt
@@ -34,6 +34,7 @@ import com.zeapo.pwdstore.utils.resolveAttribute
 import com.zeapo.pwdstore.utils.splitLines
 
 class AutofillFragment : DialogFragment() {
+
     private var adapter: ArrayAdapter<String>? = null
     private var isWeb: Boolean = false
 
@@ -225,6 +226,7 @@ class AutofillFragment : DialogFragment() {
     }
 
     companion object {
+
         private const val MATCH_WITH = 777
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillPreferenceActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillPreferenceActivity.kt
@@ -22,9 +22,9 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.databinding.AutofillRecyclerViewBinding
 import com.zeapo.pwdstore.utils.viewBinding
-import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import java.lang.ref.WeakReference
 import java.util.ArrayList
+import me.zhanghai.android.fastscroll.FastScrollerBuilder
 
 class AutofillPreferenceActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillRecyclerAdapter.kt
@@ -20,9 +20,9 @@ import androidx.recyclerview.widget.SortedList
 import androidx.recyclerview.widget.SortedListAdapterCallback
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.utils.splitLines
-import me.zhanghai.android.fastscroll.PopupTextProvider
 import java.util.ArrayList
 import java.util.Locale
+import me.zhanghai.android.fastscroll.PopupTextProvider
 
 internal class AutofillRecyclerAdapter(
     allApps: List<AppInfo>,
@@ -161,6 +161,7 @@ internal class AutofillRecyclerAdapter(
     }
 
     internal inner class ViewHolder(var view: View) : RecyclerView.ViewHolder(view), View.OnClickListener {
+
         var name: AppCompatTextView = view.findViewById(R.id.app_name)
         var icon: AppCompatImageView = view.findViewById(R.id.app_icon)
         var secondary: AppCompatTextView = view.findViewById(R.id.secondary_text)

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/AutofillService.kt
@@ -35,15 +35,6 @@ import com.zeapo.pwdstore.model.PasswordEntry
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.splitLines
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import me.msfjarvis.openpgpktx.util.OpenPgpApi
-import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
-import org.openintents.openpgp.IOpenPgpService2
-import org.openintents.openpgp.OpenPgpError
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
@@ -53,8 +44,18 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.ArrayList
 import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.msfjarvis.openpgpktx.util.OpenPgpApi
+import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
+import org.openintents.openpgp.IOpenPgpService2
+import org.openintents.openpgp.OpenPgpError
 
 class AutofillService : AccessibilityService(), CoroutineScope by CoroutineScope(Dispatchers.Default) {
+
     private var serviceConnection: OpenPgpServiceConnection? = null
     private var settings: SharedPreferences? = null
     private var info: AccessibilityNodeInfo? = null // the original source of the event (the edittext field)
@@ -560,10 +561,12 @@ class AutofillService : AccessibilityService(), CoroutineScope by CoroutineScope
     }
 
     internal object Constants {
+
         const val TAG = "Keychain"
     }
 
     private inner class OnBoundListener : OpenPgpServiceConnection.OnBound {
+
         override fun onBound(service: IOpenPgpService2) {
             decryptAndVerify()
         }
@@ -574,6 +577,7 @@ class AutofillService : AccessibilityService(), CoroutineScope by CoroutineScope
     }
 
     companion object {
+
         var instance: AutofillService? = null
             private set
     }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillHelper.kt
@@ -89,6 +89,7 @@ val AssistStructure.ViewNode.webOrigin: String?
 
 data class Credentials(val username: String?, val password: String?, val otp: String?) {
     companion object {
+
         fun fromStoreEntry(
             context: Context,
             file: File,

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillMatcher.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillMatcher.kt
@@ -43,6 +43,7 @@ class AutofillPublisherChangedException(val formOrigin: FormOrigin) :
 class AutofillMatcher {
 
     companion object {
+
         private const val MAX_NUM_MATCHES = 10
 
         private const val PREFERENCE_PREFIX_TOKEN = "token;"

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillPreferences.kt
@@ -110,6 +110,7 @@ enum class DirectoryStructure(val value: String) {
     }
 
     companion object {
+
         const val PREFERENCE = "oreo_autofill_directory_structure"
         private val DEFAULT = FileBased
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillScenario.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillScenario.kt
@@ -27,6 +27,7 @@ enum class AutofillAction {
 sealed class AutofillScenario<out T : Any> {
 
     companion object {
+
         const val BUNDLE_KEY_USERNAME_ID = "usernameId"
         const val BUNDLE_KEY_FILL_USERNAME = "fillUsername"
         const val BUNDLE_KEY_OTP_ID = "otpId"
@@ -64,6 +65,7 @@ sealed class AutofillScenario<out T : Any> {
     }
 
     class Builder<T : Any> {
+
         var username: T? = null
         var fillUsername = false
         var otp: T? = null

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategyDsl.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillStrategyDsl.kt
@@ -174,6 +174,7 @@ class AutofillRule private constructor(
     ) {
 
         companion object {
+
             private var ruleId = 1
         }
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/Form.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/Form.kt
@@ -37,6 +37,7 @@ sealed class FormOrigin(open val identifier: String) {
     data class App(override val identifier: String) : FormOrigin(identifier)
 
     companion object {
+
         private const val BUNDLE_KEY_WEB_IDENTIFIER = "webIdentifier"
         private const val BUNDLE_KEY_APP_IDENTIFIER = "appIdentifier"
 
@@ -74,6 +75,7 @@ sealed class FormOrigin(open val identifier: String) {
 private class Form(context: Context, structure: AssistStructure, isManualRequest: Boolean) {
 
     companion object {
+
         private val SUPPORTED_SCHEMES = listOf("http", "https")
     }
 
@@ -202,6 +204,7 @@ class FillableForm private constructor(
 ) {
 
     companion object {
+
         fun makeFillInDataset(
             context: Context,
             credentials: Credentials,

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/OreoAutofillService.kt
@@ -24,6 +24,7 @@ import com.zeapo.pwdstore.utils.hasFlag
 class OreoAutofillService : AutofillService() {
 
     companion object {
+
         // TODO: Provide a user-configurable denylist
         private val DENYLISTED_PACKAGES = listOf(
             BuildConfig.APPLICATION_ID,

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/PublicSuffixListCache.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/PublicSuffixListCache.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 
 private object PublicSuffixListCache {
+
     private lateinit var publicSuffixList: PublicSuffixList
 
     fun getOrCachePublicSuffixList(context: Context): PublicSuffixList {

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
@@ -24,16 +24,6 @@ import com.zeapo.pwdstore.autofill.oreo.Credentials
 import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
 import com.zeapo.pwdstore.autofill.oreo.FillableForm
 import com.zeapo.pwdstore.model.PasswordEntry
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import me.msfjarvis.openpgpktx.util.OpenPgpApi
-import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
-import org.openintents.openpgp.IOpenPgpService2
-import org.openintents.openpgp.OpenPgpError
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileNotFoundException
@@ -44,11 +34,22 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.msfjarvis.openpgpktx.util.OpenPgpApi
+import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
+import org.openintents.openpgp.IOpenPgpService2
+import org.openintents.openpgp.OpenPgpError
 
 @RequiresApi(Build.VERSION_CODES.O)
 class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
 
     companion object {
+
         private const val EXTRA_FILE_PATH = "com.zeapo.pwdstore.autofill.oreo.EXTRA_FILE_PATH"
         private const val EXTRA_SEARCH_ACTION =
             "com.zeapo.pwdstore.autofill.oreo.EXTRA_SEARCH_ACTION"

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
@@ -43,6 +43,7 @@ import com.zeapo.pwdstore.utils.viewBinding
 class AutofillFilterView : AppCompatActivity() {
 
     companion object {
+
         private const val HEIGHT_PERCENTAGE = 0.9
         private const val WIDTH_PERCENTAGE = 0.75
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
@@ -28,6 +28,7 @@ import com.zeapo.pwdstore.utils.viewBinding
 class AutofillPublisherChangedActivity : AppCompatActivity() {
 
     companion object {
+
         private const val EXTRA_APP_PACKAGE =
             "com.zeapo.pwdstore.autofill.oreo.ui.EXTRA_APP_PACKAGE"
         private var publisherChangedRequestCode = 1

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillSaveActivity.kt
@@ -32,6 +32,7 @@ import java.io.File
 class AutofillSaveActivity : AppCompatActivity() {
 
     companion object {
+
         private const val EXTRA_FOLDER_NAME =
             "com.zeapo.pwdstore.autofill.oreo.ui.EXTRA_FOLDER_NAME"
         private const val EXTRA_PASSWORD = "com.zeapo.pwdstore.autofill.oreo.ui.EXTRA_PASSWORD"

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/PasswordViewHolder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/PasswordViewHolder.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.zeapo.pwdstore.R
 
 class PasswordViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+
     val title: TextView = itemView.findViewById(R.id.title)
     val subtitle: TextView = itemView.findViewById(R.id.subtitle)
 }

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/BasePgpActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/BasePgpActivity.kt
@@ -30,11 +30,11 @@ import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.clipboard
 import com.zeapo.pwdstore.utils.snackbar
+import java.io.File
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import org.openintents.openpgp.IOpenPgpService2
 import org.openintents.openpgp.OpenPgpError
-import java.io.File
 
 @Suppress("Registered")
 open class BasePgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBound {
@@ -237,6 +237,7 @@ open class BasePgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBou
     }
 
     companion object {
+
         private const val TAG = "APS/BasePgpActivity"
         const val KEY_PWGEN_TYPE_CLASSIC = "classic"
         const val KEY_PWGEN_TYPE_XKPASSWD = "xkpasswd"

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
@@ -22,6 +22,10 @@ import com.zeapo.pwdstore.databinding.DecryptLayoutBinding
 import com.zeapo.pwdstore.model.PasswordEntry
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.viewBinding
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -29,12 +33,9 @@ import kotlinx.coroutines.withContext
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import org.openintents.openpgp.IOpenPgpService2
-import java.io.ByteArrayOutputStream
-import java.io.File
-import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
+
     private val binding by viewBinding(DecryptLayoutBinding::inflate)
 
     private val relativeParentPath by lazy { getParentPath(fullPath, repoPath) }

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -32,15 +32,15 @@ import com.zeapo.pwdstore.utils.commitChange
 import com.zeapo.pwdstore.utils.isInsideRepository
 import com.zeapo.pwdstore.utils.snackbar
 import com.zeapo.pwdstore.utils.viewBinding
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import org.eclipse.jgit.api.Git
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.IOException
 
 class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
 
@@ -349,6 +349,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
     }
 
     companion object {
+
         private const val KEY_PWGEN_TYPE_CLASSIC = "classic"
         private const val KEY_PWGEN_TYPE_XKPASSWD = "xkpasswd"
         const val RETURN_EXTRA_CREATED_FILE = "CREATED_FILE"

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -243,6 +243,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
     }
 
     companion object {
+
         const val REQUEST_ARG_OP = "OPERATION"
         const val REQUEST_PULL = 101
         const val REQUEST_PUSH = 102

--- a/app/src/main/java/com/zeapo/pwdstore/git/BreakOutOfDetached.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BreakOutOfDetached.kt
@@ -7,13 +7,14 @@ package com.zeapo.pwdstore.git
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.GitCommand
 import org.eclipse.jgit.api.PushCommand
 import org.eclipse.jgit.api.RebaseCommand
-import java.io.File
 
 class BreakOutOfDetached(fileDir: File, callingActivity: AppCompatActivity) : GitOperation(fileDir, callingActivity) {
+
     private lateinit var commands: List<GitCommand<out Any>>
 
     /**

--- a/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/CloneOperation.kt
@@ -8,9 +8,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.CloneCommand
 import org.eclipse.jgit.api.Git
-import java.io.File
 
 /**
  * Creates a new clone operation

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitAsyncTask.kt
@@ -12,6 +12,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.github.ajalt.timberkt.e
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.config.SshjSessionFactory
+import java.io.IOException
+import java.lang.ref.WeakReference
 import net.schmizz.sshj.common.DisconnectReason
 import net.schmizz.sshj.common.SSHException
 import net.schmizz.sshj.userauth.UserAuthException
@@ -23,8 +25,6 @@ import org.eclipse.jgit.api.RebaseResult
 import org.eclipse.jgit.api.StatusCommand
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.SshSessionFactory
-import java.io.IOException
-import java.lang.ref.WeakReference
 
 
 class GitAsyncTask(

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
@@ -26,6 +26,9 @@ import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import com.zeapo.pwdstore.utils.requestInputFocusOnView
+import java.io.File
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
 import net.schmizz.sshj.userauth.password.PasswordFinder
 import org.eclipse.jgit.api.GitCommand
 import org.eclipse.jgit.errors.UnsupportedCredentialItem
@@ -34,9 +37,6 @@ import org.eclipse.jgit.transport.CredentialItem
 import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.URIish
-import java.io.File
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.resume
 import com.google.android.material.R as materialR
 
 
@@ -245,6 +245,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: AppCompa
     open fun onSuccess() {}
 
     companion object {
+
         const val GET_SSH_KEY_FROM_CLONE = 201
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperationActivity.kt
@@ -14,6 +14,7 @@ import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.utils.PasswordRepository
 
 open class GitOperationActivity : BaseGitActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         when (intent.extras?.getInt(REQUEST_ARG_OP)) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PullOperation.kt
@@ -8,9 +8,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.PullCommand
-import java.io.File
 
 /**
  * Creates a new git operation

--- a/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/PushOperation.kt
@@ -8,9 +8,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.PushCommand
-import java.io.File
 
 /**
  * Creates a new git operation

--- a/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/ResetToRemoteOperation.kt
@@ -8,11 +8,11 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.AddCommand
 import org.eclipse.jgit.api.FetchCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ResetCommand
-import java.io.File
 
 /**
  * Creates a new git operation

--- a/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/SyncOperation.kt
@@ -8,13 +8,13 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import java.io.File
 import org.eclipse.jgit.api.AddCommand
 import org.eclipse.jgit.api.CommitCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.PullCommand
 import org.eclipse.jgit.api.PushCommand
 import org.eclipse.jgit.api.StatusCommand
-import java.io.File
 
 /**
  * Creates a new git operation

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/ConnectionMode.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/ConnectionMode.kt
@@ -12,6 +12,7 @@ enum class ConnectionMode(val pref: String) {
     ;
 
     companion object {
+
         private val map = values().associateBy(ConnectionMode::pref)
         fun fromString(type: String?): ConnectionMode {
             return map[type ?: return SshKey]

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/Protocol.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/Protocol.kt
@@ -10,6 +10,7 @@ enum class Protocol(val pref: String) {
     ;
 
     companion object {
+
         private val map = values().associateBy(Protocol::pref)
         fun fromString(type: String?): Protocol {
             return map[type ?: return Ssh]

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/SshjConfig.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/SshjConfig.kt
@@ -10,6 +10,7 @@ import com.hierynomus.sshj.signature.SignatureEdDSA
 import com.hierynomus.sshj.transport.cipher.BlockCiphers
 import com.hierynomus.sshj.transport.mac.Macs
 import com.hierynomus.sshj.userauth.keyprovider.OpenSSHKeyV1KeyFile
+import java.security.Security
 import net.schmizz.keepalive.KeepAliveProvider
 import net.schmizz.sshj.ConfigImpl
 import net.schmizz.sshj.common.LoggerFactory
@@ -30,7 +31,6 @@ import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.Logger
 import org.slf4j.Marker
-import java.security.Security
 
 
 fun setUpBouncyCastleForSshj() {

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/SshjSessionFactory.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/SshjSessionFactory.kt
@@ -8,6 +8,14 @@ import android.util.Base64
 import com.github.ajalt.timberkt.d
 import com.github.ajalt.timberkt.w
 import com.zeapo.pwdstore.utils.clear
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.GeneralSecurityException
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import net.schmizz.sshj.SSHClient
@@ -26,23 +34,17 @@ import org.eclipse.jgit.transport.RemoteSession
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.URIish
 import org.eclipse.jgit.util.FS
-import java.io.File
-import java.io.IOException
-import java.io.InputStream
-import java.io.OutputStream
-import java.security.GeneralSecurityException
-import java.util.concurrent.TimeUnit
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.suspendCoroutine
 
 sealed class SshAuthData {
     class Password(val passwordFinder: InteractivePasswordFinder) : SshAuthData() {
+
         override fun clearCredentials() {
             passwordFinder.clearPasswords()
         }
     }
 
     class PublicKeyFile(val keyFile: File, val passphraseFinder: InteractivePasswordFinder) : SshAuthData() {
+
         override fun clearCredentials() {
             passphraseFinder.clearPasswords()
         }

--- a/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
@@ -106,6 +106,7 @@ class PasswordEntry(content: String, private val totpFinder: TotpFinder = UriTot
     }
 
     companion object {
+
         val USERNAME_FIELDS = arrayOf(
             "login:",
             "username:",

--- a/app/src/main/java/com/zeapo/pwdstore/pwgen/PasswordGenerator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgen/PasswordGenerator.kt
@@ -21,6 +21,7 @@ enum class PasswordOption(val key: String) {
 }
 
 object PasswordGenerator {
+
     const val DEFAULT_LENGTH = 16
 
     const val DIGITS = 0x0001

--- a/app/src/main/java/com/zeapo/pwdstore/pwgen/RandomPhonemesGenerator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgen/RandomPhonemesGenerator.kt
@@ -8,6 +8,7 @@ import com.zeapo.pwdstore.utils.hasFlag
 import java.util.Locale
 
 object RandomPhonemesGenerator {
+
     private const val CONSONANT = 0x0001
     private const val VOWEL = 0x0002
     private const val DIPHTHONG = 0x0004
@@ -57,6 +58,7 @@ object RandomPhonemesGenerator {
     )
 
     private class Element(str: String, val flags: Int) {
+
         val upperCase = str.toUpperCase(Locale.ROOT)
         val lowerCase = str.toLowerCase(Locale.ROOT)
         val length = str.length

--- a/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/PasswordBuilder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/PasswordBuilder.kt
@@ -138,6 +138,7 @@ class PasswordBuilder(ctx: Context) {
     }
 
     companion object {
+
         private const val SYMBOLS = "!@\$%^&*-_+=:|~?/.;#"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/XkpwdDictionary.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/XkpwdDictionary.kt
@@ -11,6 +11,7 @@ import com.zeapo.pwdstore.utils.PreferenceKeys
 import java.io.File
 
 class XkpwdDictionary(context: Context) {
+
     val words: Map<Int, List<String>>
 
     init {
@@ -32,6 +33,7 @@ class XkpwdDictionary(context: Context) {
     }
 
     companion object {
+
         const val XKPWD_CUSTOM_DICT_FILE = "custom_dict.txt"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/sshkeygen/SshKeyGenActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/sshkeygen/SshKeyGenActivity.kt
@@ -20,11 +20,11 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.databinding.ActivitySshKeygenBinding
 import com.zeapo.pwdstore.utils.getEncryptedPrefs
 import com.zeapo.pwdstore.utils.viewBinding
+import java.io.File
+import java.io.FileOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
-import java.io.FileOutputStream
 
 class SshKeyGenActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
@@ -41,6 +41,7 @@ open class PasswordItemRecyclerAdapter :
     }
 
     class PasswordItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+
         private val name: AppCompatTextView = itemView.findViewById(R.id.label)
         private val typeImage: AppCompatImageView = itemView.findViewById(R.id.type_image)
         private val childCount: AppCompatTextView = itemView.findViewById(R.id.child_count)

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -43,6 +43,7 @@ class FolderCreationDialogFragment : DialogFragment() {
     }
 
     companion object {
+
         private const val CURRENT_DIR_EXTRA = "CURRENT_DIRECTORY"
         fun newInstance(startingDirectory: String): FolderCreationDialogFragment {
             val extras = bundleOf(CURRENT_DIR_EXTRA to startingDirectory)

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/ItemCreationBottomSheet.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/ItemCreationBottomSheet.kt
@@ -24,6 +24,7 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.utils.resolveAttribute
 
 class ItemCreationBottomSheet : BottomSheetDialogFragment() {
+
     private var behavior: BottomSheetBehavior<FrameLayout>? = null
     private val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
         override fun onSlide(bottomSheet: View, slideOffset: Float) {

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
@@ -109,6 +109,7 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
     }
 
     companion object {
+
         const val PREF_KEY_CAPITALS_STYLE = "pref_key_capitals_style"
         const val PREF_KEY_NUM_WORDS = "pref_key_num_words"
         const val PREF_KEY_SEPARATOR = "pref_key_separator"

--- a/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
@@ -17,6 +17,7 @@ import com.github.ajalt.timberkt.d
 import com.zeapo.pwdstore.R
 
 object BiometricAuthenticator {
+
     private const val TAG = "BiometricAuthenticator"
     private val handler = Handler()
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -26,8 +26,8 @@ import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.git.GitAsyncTask
 import com.zeapo.pwdstore.git.GitOperation
 import com.zeapo.pwdstore.utils.PasswordRepository.Companion.getRepositoryDirectory
-import org.eclipse.jgit.api.Git
 import java.io.File
+import org.eclipse.jgit.api.Git
 
 fun Int.clearFlag(flag: Int): Int {
     return this and flag.inv()

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Otp.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Otp.kt
@@ -6,7 +6,6 @@
 package com.zeapo.pwdstore.utils
 
 import com.github.ajalt.timberkt.e
-import org.apache.commons.codec.binary.Base32
 import java.nio.ByteBuffer
 import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
@@ -14,8 +13,10 @@ import java.util.Locale
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.experimental.and
+import org.apache.commons.codec.binary.Base32
 
 object Otp {
+
     private val BASE_32 = Base32()
     private val STEAM_ALPHABET = "23456789BCDFGHJKMNPQRTVWXY".toCharArray()
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordItem.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordItem.kt
@@ -41,6 +41,7 @@ data class PasswordItem(
     }
 
     companion object {
+
         const val TYPE_CATEGORY = 'c'
         const val TYPE_PASSWORD = 'p'
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -8,15 +8,15 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import java.io.File
+import java.io.FileFilter
+import java.util.Comparator
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.eclipse.jgit.transport.RefSpec
 import org.eclipse.jgit.transport.RemoteConfig
 import org.eclipse.jgit.transport.URIish
-import java.io.File
-import java.io.FileFilter
-import java.util.Comparator
 
 open class PasswordRepository protected constructor() {
 
@@ -37,6 +37,7 @@ open class PasswordRepository protected constructor() {
         });
 
         companion object {
+
             @JvmStatic
             fun getSortOrder(settings: SharedPreferences): PasswordSortOrder {
                 return valueOf(settings.getString(PreferenceKeys.SORT_ORDER, null)

--- a/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
+++ b/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
@@ -31,6 +31,7 @@ class PublicSuffixList(
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val scope: CoroutineScope = CoroutineScope(dispatcher)
 ) {
+
     private val data: PublicSuffixListData by lazy { PublicSuffixListLoader.load(context) }
 
     /**

--- a/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
+++ b/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
@@ -17,6 +17,7 @@ internal class PublicSuffixListData(
     private val rules: ByteArray,
     private val exceptions: ByteArray
 ) {
+
     private fun binarySearchRules(labels: List<ByteArray>, labelIndex: Int): String? {
         return rules.binarySearch(labels, labelIndex)
     }
@@ -147,6 +148,7 @@ internal class PublicSuffixListData(
     }
 
     companion object {
+
         val WILDCARD_LABEL = byteArrayOf('*'.toByte())
         val PREVAILING_RULE = listOf("*")
         val EMPTY_RULE = listOf<String>()

--- a/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoader.kt
+++ b/app/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoader.kt
@@ -14,6 +14,7 @@ import java.io.IOException
 private const val PUBLIC_SUFFIX_LIST_FILE = "publicsuffixes"
 
 internal object PublicSuffixListLoader {
+
     fun load(context: Context): PublicSuffixListData = context.assets.open(
         PUBLIC_SUFFIX_LIST_FILE
     ).buffered().use { stream ->


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Uses the new `PACKAGES_IMPORT_LAYOUT` setting to force imports to be ordered alphabetically. This seems to
be available only in Android Studio 4.2.0 Canary 3 as of now.

## :bulb: Motivation and Context
Import ordering so far has been dictated by arbitrary logic within the IDE, this let's us exercise some control over it.

## :green_heart: How did you test it?
N/A

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
