### PR TITLE
Exclude third_party scope from reformats

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,7 @@
     <option name="SOFT_MARGINS" value="100" />
     <option name="DO_NOT_FORMAT">
       <list>
-        <fileSet type="namedScope" name="publicsuffixlist" pattern="src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixList||src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixListData||src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixListLoader||src[app]:mozilla.components.lib.publicsuffixlist.ext.ByteArray" />
+        <fileSet type="namedScope" name="third_party" pattern="src[Android-Password-Store.app]:mozilla.components.lib.publicsuffixlist..*" />
       </list>
     </option>
     <JavaCodeStyleSettings>

--- a/.idea/scopes/third_party.xml
+++ b/.idea/scopes/third_party.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="third_party" pattern="src[Android-Password-Store.app]:mozilla.components.lib.publicsuffixlist..*" />
+</component>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Excludes a `third_party` scope, currently containing all Mozilla Public Suffix List sources, from IDE reformatting.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
