### PR TITLE
Properly guard against invalid renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 -   A brand new icon to go with our biggest update ever!
 -   Light theme is now a consistent white across the board with ample contrast
 -   XkPassword generator is now easier to use with less configuration options
+-   Edit screen now has better protection and guidance for invalid names
 
 ### Fixed
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -89,7 +89,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                 )
             }
 
-            category.apply {
+            directoryInputLayout.apply {
                 if (suggestedName != null || suggestedPass != null || shouldGeneratePassword) {
                     isEnabled = true
                 } else {
@@ -100,7 +100,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                 if (path.isEmpty() && !isEnabled)
                     visibility = View.GONE
                 else {
-                    setText(path)
+                    directory.setText(path)
                     oldCategory = path
                 }
             }
@@ -213,6 +213,9 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
         if (editName.isEmpty()) {
             snackbar(message = resources.getString(R.string.file_toast_text))
             return@with
+        } else if (editName.contains('/')) {
+            snackbar(message = resources.getString(R.string.invalid_filename_text))
+            return@with
         }
 
         if (editPass.isEmpty() && editExtra.isEmpty()) {
@@ -239,8 +242,8 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
         val path = when {
             // If we allowed the user to edit the relative path, we have to consider it here instead
             // of fullPath.
-            category.isEnabled -> {
-                val editRelativePath = category.text.toString().trim()
+            directoryInputLayout.isEnabled -> {
+                val editRelativePath = directory.text.toString().trim()
                 if (editRelativePath.isEmpty()) {
                     snackbar(message = resources.getString(R.string.path_toast_text))
                     return
@@ -272,6 +275,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                 snackbar(message = getString(R.string.message_error_destination_outside_repo))
                                 return@executeApiAsync
                             }
+
                             try {
                                 file.outputStream().use {
                                     it.write(outputStream.toByteArray())
@@ -318,7 +322,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                 }
                             }
 
-                            if (category.isVisible && category.isEnabled && oldFileName != null) {
+                            if (directoryInputLayout.isVisible && directoryInputLayout.isEnabled && oldFileName != null) {
                                 val oldFile = File("$repoPath/${oldCategory?.trim('/')}/$oldFileName.gpg")
                                 if (oldFile.path != file.path && !oldFile.delete()) {
                                     setResult(RESULT_CANCELED)

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -287,6 +287,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                         finish()
                                     }
                                     .show()
+                                return@executeApiAsync
                             }
 
                             val returnIntent = Intent()

--- a/app/src/main/res/layout/password_creation_activity.xml
+++ b/app/src/main/res/layout/password_creation_activity.xml
@@ -12,17 +12,26 @@
     android:padding="@dimen/activity_horizontal_margin"
     tools:context="com.zeapo.pwdstore.crypto.PasswordCreationActivity">
 
-    <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/category"
-        android:layout_width="wrap_content"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/directory_input_layout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_gravity="center_vertical"
+        android:layout_margin="8dp"
         android:enabled="false"
-        android:textColor="?android:attr/textColor"
-        android:textSize="18sp"
+        android:hint="@string/directory_hint"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="CATEGORY HERE" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/directory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionNext"
+            android:inputType="textNoSuggestions"
+            android:nextFocusForward="@id/password"
+            tools:text="CATEGORY HERE" />
+    </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/name_input_layout"
@@ -32,7 +41,7 @@
         android:layout_margin="8dp"
         android:hint="@string/crypto_name_hint"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/category">
+        app:layout_constraintTop_toBottomOf="@id/directory_input_layout">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/filename"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,4 +401,6 @@
     <string name="oreo_autofill_chrome_compat_fix_preference_title">Improve reliability in Chrome</string>
     <string name="oreo_autofill_chrome_compat_fix_preference_summary">Requires activating an accessibility service and may affect overall Chrome performance</string>
     <string name="exporting_passwords">Exporting passwords…</string>
+    <string name="invalid_filename_text">File name must not contain \'/\', use category to set directory</string>
+    <string name="directory_hint">Directory</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,6 +401,6 @@
     <string name="oreo_autofill_chrome_compat_fix_preference_title">Improve reliability in Chrome</string>
     <string name="oreo_autofill_chrome_compat_fix_preference_summary">Requires activating an accessibility service and may affect overall Chrome performance</string>
     <string name="exporting_passwords">Exporting passwords…</string>
-    <string name="invalid_filename_text">File name must not contain \'/\', use category to set directory</string>
+    <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
     <string name="directory_hint">Directory</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Switch up password edit layout and check against users incorrectly specifying directories in the filename.

## :bulb: Motivation and Context
Fixes #928

## :green_heart: How did you test it?
Try to rename `test1` from password root to `foo/test` by changing filename and observe it failing correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
