### PR TITLE
Fix navigation bar theming and reformat

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,3 +1,8 @@
+#
+# Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+
 org.gradle.daemon=true
 org.gradle.configureondemand=true
 android.enableBuildCache=true

--- a/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/StrictDomainRegexTest.kt
@@ -4,15 +4,16 @@
  */
 package com.zeapo.pwdstore
 
-import org.junit.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.Test
 
 private infix fun String.matchedForDomain(domain: String) =
     SearchableRepositoryViewModel.generateStrictDomainRegex(domain)?.containsMatchIn(this) == true
 
 class StrictDomainRegexTest {
+
     @Test fun acceptsLiteralDomain() {
         assertTrue("work/example.org/john.doe@example.org.gpg" matchedForDomain "example.org")
         assertTrue("example.org/john.doe@example.org.gpg" matchedForDomain "example.org")

--- a/app/src/androidTest/java/com/zeapo/pwdstore/git/GitServerConfigActivityTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/git/GitServerConfigActivityTest.kt
@@ -17,11 +17,11 @@ import androidx.test.rule.ActivityTestRule
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.BaseGitActivity.GitUpdateUrlResult
+import kotlin.test.assertEquals
 import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class GitServerConfigActivityTest {

--- a/app/src/androidTest/java/com/zeapo/pwdstore/utils/UriTotpFinderTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/utils/UriTotpFinderTest.kt
@@ -5,8 +5,8 @@
 
 package com.zeapo.pwdstore.utils
 
-import org.junit.Test
 import kotlin.test.assertEquals
+import org.junit.Test
 
 class UriTotpFinderTest {
 
@@ -34,6 +34,7 @@ class UriTotpFinderTest {
     }
 
     companion object {
+
         const val TOTP_URI = "otpauth://totp/ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA256&digits=12&period=25"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordExportService.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordExportService.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package com.zeapo.pwdstore
 
 import android.app.NotificationChannel

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ChromeCompatFix.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ChromeCompatFix.kt
@@ -24,6 +24,7 @@ import com.zeapo.pwdstore.utils.autofillManager
 class ChromeCompatFix : AccessibilityService() {
 
     companion object {
+
         fun setStatusInPreferences(context: Context, enabled: Boolean) {
             PreferenceManager.getDefaultSharedPreferences(context).edit {
                 putBoolean(PreferenceKeys.OREO_AUTOFILL_CHROME_COMPAT_FIX, enabled)

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package com.zeapo.pwdstore.utils
 
 object PreferenceKeys {

--- a/app/src/main/res/color/outlined_box_selector.xml
+++ b/app/src/main/res/color/outlined_box_selector.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@color/secondary_color" android:state_focused="true" />
     <item android:color="@color/secondary_color" android:state_hovered="true" />

--- a/app/src/main/res/drawable-v24/ic_launcher_background.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_background.xml
@@ -1,3 +1,8 @@
+<!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"

--- a/app/src/main/res/drawable/ic_autofill_sms.xml
+++ b/app/src/main/res/drawable/ic_autofill_sms.xml
@@ -1,3 +1,8 @@
+<!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_qr_code_scanner.xml
+++ b/app/src/main/res/drawable/ic_qr_code_scanner.xml
@@ -1,3 +1,8 @@
+<!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_round_import_export.xml
+++ b/app/src/main/res/drawable/ic_round_import_export.xml
@@ -1,10 +1,15 @@
+<!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:tint="?attr/colorControlNormal"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M8.65,3.35L5.86,6.14c-0.32,0.31 -0.1,0.85 0.35,0.85H8V13c0,0.55 0.45,1 1,1s1,-0.45 1,-1V6.99h1.79c0.45,0 0.67,-0.54 0.35,-0.85L9.35,3.35c-0.19,-0.19 -0.51,-0.19 -0.7,0zM16,17.01V11c0,-0.55 -0.45,-1 -1,-1s-1,0.45 -1,1v6.01h-1.79c-0.45,0 -0.67,0.54 -0.35,0.85l2.79,2.78c0.2,0.19 0.51,0.19 0.71,0l2.79,-2.78c0.32,-0.31 0.09,-0.85 -0.35,-0.85H16z"/>
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M8.65,3.35L5.86,6.14c-0.32,0.31 -0.1,0.85 0.35,0.85H8V13c0,0.55 0.45,1 1,1s1,-0.45 1,-1V6.99h1.79c0.45,0 0.67,-0.54 0.35,-0.85L9.35,3.35c-0.19,-0.19 -0.51,-0.19 -0.7,0zM16,17.01V11c0,-0.55 -0.45,-1 -1,-1s-1,0.45 -1,1v6.01h-1.79c-0.45,0 -0.67,0.54 -0.35,0.85l2.79,2.78c0.2,0.19 0.51,0.19 0.71,0l2.79,-2.78c0.32,-0.31 0.09,-0.85 -0.35,-0.85H16z" />
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />

--- a/app/src/main/res/values-night/bools.xml
+++ b/app/src/main/res/values-night/bools.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <bool name="light_status_bar">false</bool>
 </resources>

--- a/app/src/main/res/values-v23/colors.xml
+++ b/app/src/main/res/values-v23/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="navigation_bar_color">#000000</color>
+</resources>

--- a/app/src/main/res/values-v23/colors.xml
+++ b/app/src/main/res/values-v23/colors.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <color name="navigation_bar_color">#000000</color>
 </resources>

--- a/app/src/main/res/values-v26/bools.xml
+++ b/app/src/main/res/values-v26/bools.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <bool name="enable_accessibility_autofill">false</bool>
 </resources>

--- a/app/src/main/res/values-v27/colors.xml
+++ b/app/src/main/res/values-v27/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="navigation_bar_color">@color/primary_color</color>
+</resources>

--- a/app/src/main/res/values-v27/colors.xml
+++ b/app/src/main/res/values-v27/colors.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <color name="navigation_bar_color">@color/primary_color</color>
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
 
     <style name="AppTheme" parent="APSTheme">

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="APSTheme">
+        <item name="android:windowLightNavigationBar">@bool/light_status_bar</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v28/bools.xml
+++ b/app/src/main/res/values-v28/bools.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <bool name="enable_chrome_compat_fix">true</bool>
 </resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
 <resources>
     <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
     <bool name="enable_accessibility_autofill">true</bool>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+    <style name="APSTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/primary_color</item>
         <item name="colorOnPrimary">@color/color_control_normal</item>
         <item name="colorPrimaryDark">@color/primary_color</item>
@@ -29,6 +29,8 @@
         <item name="bottomSheetDialogTheme">@style/BottomSheetDialogTheme</item>
         <item name="textInputStyle">@style/AppTheme.TextInputLayout</item>
     </style>
+
+    <style name="AppTheme" parent="APSTheme" />
 
     <style name="AppTheme.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
         <item name="boxStrokeColor">@color/outlined_box_selector</item>

--- a/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
+++ b/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
@@ -6,15 +6,16 @@ package com.zeapo.pwdstore.model
 
 import com.zeapo.pwdstore.utils.Otp
 import com.zeapo.pwdstore.utils.TotpFinder
-import org.junit.Test
 import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.Test
 
 class PasswordEntryTest {
+
     private fun makeEntry(content: String) = PasswordEntry(content, testFinder)
 
     @Test fun testGetPassword() {
@@ -83,6 +84,7 @@ class PasswordEntryTest {
     }
 
     companion object {
+
         const val TOTP_URI = "otpauth://totp/ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30"
 
         // This implementation is hardcoded for the URI above.

--- a/app/src/test/java/com/zeapo/pwdstore/utils/OtpTest.kt
+++ b/app/src/test/java/com/zeapo/pwdstore/utils/OtpTest.kt
@@ -1,9 +1,14 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 package com.zeapo.pwdstore.utils
 
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.Test
 
 class OtpTest {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
+#
+# Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+
 # AndroidX
 android.enableJetifier=false
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,8 @@
+#
+# Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=143a28f54f1ae93ef4f72d862dbc3c438050d81bb45b4601eb7076e998362920


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Use a black navigation bar on API levels 23 through 26 and turn on `windowLightNavigationBar` above API 27.

## :bulb: Motivation and Context
When the app theme was redone in #920, the navigation bar was broken. It had a white icons on a white background
which affected legibility. We do not have the ability to darken navigation bar icons before API 27, so we opt
to make the navigation bar black instead.


## :green_heart: How did you test it?
Verify visually that navigation bar color matches expectations.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
![Navigation bar on API 23](https://i.imgur.com/UyfVn7O.png)
