### PR TITLE
github: remove freeDebug variant from pull request matrix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         api-level: [23, 29]
-        variant: [freeDebug, freeRelease, nonFreeRelease]
+        variant: [freeRelease, nonFreeRelease]
     steps:
 
     - name: Check if relevant files have changed


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Removes the `freeDebug` build type from pull request checks.

## :bulb: Motivation and Context
We don't really need it since `freeRelease` covers the source set, and being able to run only
5 checks in parallel means the speed benefits from losing it are enough to make it worthwhile.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
