### PR TITLE
Fix Autofill result contract bug

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillDecryptActivity.kt
@@ -199,7 +199,7 @@ class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
                             registerForActivityResult(StartIntentSenderForResult()) { result ->
                                 if (continueAfterUserInteraction != null) {
                                     val data = result.data
-                                    if (resultCode == RESULT_OK && data != null) {
+                                    if (result.resultCode == RESULT_OK && data != null) {
                                         continueAfterUserInteraction?.resume(data)
                                     } else {
                                         continueAfterUserInteraction?.resumeWithException(Exception("OpenPgpApi ACTION_DECRYPT_VERIFY failed to continue after user interaction"))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a bug introduced in #910 that breaks Autofill if the OpenKeychain flow requires user interaction.

No changelog entry since Autofill since #910 has not been included in a stable release yet.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Can use Autofill with my Yubikey again

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
