### PR TITLE
Use a more common SSH version string

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/config/SshjConfig.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/SshjConfig.kt
@@ -199,6 +199,7 @@ class SshjConfig : ConfigImpl() {
     init {
         loggerFactory = TimberLoggerFactory
         keepAliveProvider = KeepAliveProvider.HEARTBEAT
+        version = "OpenSSH_8.2p1 Ubuntu-4ubuntu0.1"
 
         initKeyExchangeFactories()
         initSignatureFactories()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
We are currently using an empty SSH version string, which might cause compatibility issues. SSHJ's default leaks the fact that we are using SSHJ version 0.29.0, which is unnecessary.

In order to maximize compatibility with servers that might be basing decisions on our version string, with this commit we are now using the one of Ubuntu 20.04.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
