### PR TITLE
Extract general improvements from custom font work

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,3 +92,10 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global window_animation_scale 0
           ./gradlew :app:connectedNonFreeDebugAndroidTest
+
+    - name: (Fail-only) upload test report
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+          name: Test report
+          path: app/build/reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Slightly reduce APK size
+- Always show the parent path in entries
+
 ### Fixed
 
 - Properly handle cases where files contain only TOTP secrets and no password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Properly handle cases where files contain only TOTP secrets and no password
+- Allow creating nested directories directly
 
 ## [1.10.1] - 2020-07-23
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,9 +39,9 @@ android {
     }
 
     packagingOptions {
-        exclude(".readme")
-        exclude("META-INF/LICENSE.txt")
-        exclude("META-INF/NOTICE.txt")
+        exclude("**/*.version")
+        exclude("**/*.txt")
+        exclude("**/*.kotlin_module")
     }
 
     buildTypes {

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
@@ -52,7 +52,15 @@ open class PasswordItemRecyclerAdapter :
             val settings =
                 PreferenceManager.getDefaultSharedPreferences(itemView.context.applicationContext)
             val showHidden = settings.getBoolean(PreferenceKeys.SHOW_HIDDEN_FOLDERS, false)
-            name.text = item.toString()
+            val parentPath = item.fullPathToParent.replace("(^/)|(/$)".toRegex(), "")
+            val source = if (parentPath.isNotEmpty()) {
+                "$parentPath\n$item"
+            } else {
+                "$item"
+            }
+            val spannable = SpannableString(source)
+            spannable.setSpan(RelativeSizeSpan(0.7f), 0, parentPath.length, 0)
+            name.text = spannable
             if (item.type == PasswordItem.TYPE_CATEGORY) {
                 folderIndicator.visibility = View.VISIBLE
                 val children = item.file.listFiles { pathname ->
@@ -62,15 +70,6 @@ open class PasswordItemRecyclerAdapter :
                 childCount.visibility = if (count > 0) View.VISIBLE else View.GONE
                 childCount.text = "$count"
             } else {
-                val parentPath = item.fullPathToParent.replace("(^/)|(/$)".toRegex(), "")
-                val source = if (parentPath.isNotEmpty()) {
-                    "$parentPath\n$item"
-                } else {
-                    "$item"
-                }
-                val spannable = SpannableString(source)
-                spannable.setSpan(RelativeSizeSpan(0.7f), 0, parentPath.length, 0)
-                name.text = spannable
                 childCount.visibility = View.GONE
                 folderIndicator.visibility = View.GONE
             }

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -37,7 +37,7 @@ class FolderCreationDialogFragment : DialogFragment() {
         val materialTextView = dialog.findViewById<TextInputEditText>(R.id.folder_name_text)
         val folderName = materialTextView.text.toString()
         val newFolder = File("$currentDir/$folderName")
-        newFolder.mkdir()
+        newFolder.mkdirs()
         (requireActivity() as PasswordStore).refreshPasswordList(newFolder)
         dismiss()
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

- Updates the PR workflow to upload test reports on failure
- Updates the list of items discarded during APK assembly to reduce the final binary's size
- Shows the parent path on all items regardless of type
- Fixes being unable to create directories recursively

## :bulb: Motivation and Context

Extracts unrelated changes from the font work that can be applied here independently. We don't
know yet why the tests fail there so this is the most logical recourse.

While testing the parent path change I accidentally encountered a bug where we incorrectly swallow
the error when attempting to create a nested directory by specifying a path like `base_path/subdir1`.
I've fixed this to allow that creation to succeed as opposed to marking it as an error.

## :green_heart: How did you test it?

Visually and in GitHub Actions.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Maybe figure out why the custom font breaks our tests?

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
