### PR TITLE
Correctly set error on incorrect credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Properly handle cases where files contain only TOTP secrets and no password
 - Allow creating nested directories directly
+- I keep saying this but for real: error message for wrong SSH/HTTPS password is properly fixed now
 
 ## [1.10.1] - 2020-07-23
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitOperation.kt
@@ -9,12 +9,12 @@ import android.content.Intent
 import android.view.LayoutInflater
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.git.config.ConnectionMode
@@ -37,7 +37,6 @@ import org.eclipse.jgit.transport.CredentialItem
 import org.eclipse.jgit.transport.CredentialsProvider
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.URIish
-import com.google.android.material.R as materialR
 
 
 private class GitOperationCredentialFinder(
@@ -78,13 +77,13 @@ private class GitOperationCredentialFinder(
 
             @SuppressLint("InflateParams")
             val dialogView = layoutInflater.inflate(R.layout.git_credential_layout, null)
+            val credentialLayout = dialogView.findViewById<TextInputLayout>(R.id.git_auth_passphrase_layout)
             val editCredential = dialogView.findViewById<TextInputEditText>(R.id.git_auth_credential)
             editCredential.setHint(hintRes)
             val rememberCredential = dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_credential)
             rememberCredential.setText(rememberRes)
             if (isRetry)
-                editCredential.setError(callingActivity.resources.getString(errorRes),
-                    ContextCompat.getDrawable(callingActivity, materialR.drawable.mtrl_ic_error))
+                credentialLayout.error = callingActivity.resources.getString(errorRes)
             MaterialAlertDialogBuilder(callingActivity).run {
                 setTitle(R.string.passphrase_dialog_title)
                 setMessage(messageRes)

--- a/app/src/main/res/layout/git_credential_layout.xml
+++ b/app/src/main/res/layout/git_credential_layout.xml
@@ -15,6 +15,7 @@
         android:layout_height="wrap_content"
         app:endIconMode="password_toggle"
         app:hintEnabled="true"
+        app:errorEnabled="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Properly sets the error message for credential errors in line with material specifications.

## :bulb: Motivation and Context
[This comment](https://github.com/material-components/material-components-android/issues/1444#issuecomment-663968723) reminded me that my previous workaround is not compliant with the material specs and also wrong in general.

## :green_heart: How did you test it?
Visually verified as can be seen in the attached screenshots

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :camera_flash: Screenshots / GIFs

<details>
<summary>Before</summary>

![screenshot-20200726-184736](https://user-images.githubusercontent.com/13348378/88480703-18a7e100-cf75-11ea-9fa7-eb79a1010f82.png)


</details>

<details>
<summary>After</summary>

![screenshot-20200726-184443](https://user-images.githubusercontent.com/13348378/88480709-1e9dc200-cf75-11ea-9a85-30f50a1ce0d6.png)


</details>
