### PR TITLE
Add specific warning for short key IDs in .gpg-id

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -316,7 +316,11 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                 .filter { it.isNotBlank() }
                 .map { line ->
                     parseGpgIdentifier(line) ?: run {
-                        snackbar(message = resources.getString(R.string.invalid_gpg_id))
+                        if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {
+                            snackbar(message = resources.getString(R.string.short_key_ids_unsupported))
+                        } else {
+                            snackbar(message = resources.getString(R.string.invalid_gpg_id))
+                        }
                         return@with
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -368,6 +368,7 @@
     <string name="exporting_passwords">Exporting passwords…</string>
     <string name="failed_to_find_key_id">Failed to locate .gpg-id, is your store set up correctly?</string>
     <string name="invalid_gpg_id">Found .gpg-id, but it contains an invalid key ID, fingerprint or user ID</string>
+    <string name="short_key_ids_unsupported">A key ID in .gpg-id is too short, please use either long key IDs (16 characters) or fingerprints (40 characters)</string>
     <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
     <string name="directory_hint">Directory</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Shows a specific warning if a short key ID (8 hex characters) is encountered in the `.gpg-id` file.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/android-password-store/Android-Password-Store/issues/955#issuecomment-664045569

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
