### PR TITLE
Fix delete store message formatting

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -157,7 +157,7 @@ class GitServerConfigActivity : BaseGitActivity() {
             !(localDirFiles.size == 1 && localDirFiles[0].name == ".git")) {
             MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.dialog_delete_title)
-                .setMessage(resources.getString(R.string.dialog_delete_msg) + " " + localDir.toString())
+                .setMessage(resources.getString(R.string.dialog_delete_msg, localDir.toString()))
                 .setCancelable(false)
                 .setPositiveButton(R.string.dialog_delete) { dialog, _ ->
                     try {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Fix the string formatting of the confirmation message shown when a local store is going to be deleted.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
