### PR TITLE
Disable Autofill compatibility for Firefox

### DIFF
--- a/app/src/main/res/xml/oreo_autofill_service.xml
+++ b/app/src/main/res/xml/oreo_autofill_service.xml
@@ -3,7 +3,9 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 
-<autofill-service xmlns:android="http://schemas.android.com/apk/res/android">
+<autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="UnusedAttribute">
     <compatibility-package android:name="com.android.chrome" />
     <compatibility-package android:name="com.brave.browser" />
     <compatibility-package android:name="com.chrome.beta" />
@@ -12,7 +14,13 @@
     <compatibility-package android:name="com.microsoft.emmx" />
     <compatibility-package android:name="com.opera.mini.native" />
     <compatibility-package android:name="com.opera.mini.native.beta" />
-    <compatibility-package android:name="org.mozilla.fennec_fdroid" />
-    <compatibility-package android:name="org.mozilla.firefox" />
-    <compatibility-package android:name="org.mozilla.firefox_beta" />
+    <compatibility-package
+        android:name="org.mozilla.fennec_fdroid"
+        android:maxLongVersionCode="679999" />
+    <compatibility-package
+        android:name="org.mozilla.firefox"
+        android:maxLongVersionCode="679999" />
+    <compatibility-package
+        android:name="org.mozilla.firefox_beta"
+        android:maxLongVersionCode="679999" />
 </autofill-service>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
As of at least version 68, Firefox supports Autofill natively and no longer requires the accessibility compatibility mode. We disable it for version 68 and upwards.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
I restarted my phone and verified that Firefox still triggers Autofill requests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
