### PR TITLE
PasswordFragment: bring back dividers

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -21,6 +21,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.observe
 import androidx.preference.PreferenceManager
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.databinding.PasswordRecyclerViewBinding
@@ -125,6 +126,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
             }
         val recyclerView = binding.passRecycler
         recyclerView.apply {
+            addItemDecoration(DividerItemDecoration(requireContext(), LinearLayoutManager.VERTICAL))
             layoutManager = LinearLayoutManager(requireContext())
             itemAnimator = OnOffItemAnimator()
             adapter = recyclerAdapter


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Re-adds item dividers to the password list

## :bulb: Motivation and Context
Split off from #942 since it is currently blocked

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
