### PR TITLE
Add "challenge" and "verification" to OTP heuristic terms

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
@@ -122,6 +122,8 @@ class FormField(
         private val OTP_HEURISTIC_TERMS = listOf(
             "einmal",
             "otp",
+            "challenge",
+            "verification",
         )
         private val OTP_WEAK_HEURISTIC_TERMS = listOf(
             "code",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Add "challenge" and "verification" to OTP heuristic terms, as they are e.g. used by Twitter. There seems to be little potential for misidentification here (which is also why I decided against adding "response").

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
The SMS OTP field in the native Twitter app now shows an Autofill prompt.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
