### PR TITLE
Fix two SMS Autofill crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Allow creating nested directories directly
 - I keep saying this but for real: error message for wrong SSH/HTTPS password is properly fixed now
 - Correctly hide TOTP import button when TOTP secret/OTPAUTH URL is already present in extra content
+- SMS OTP Autofill no longer crashes when invoked and correctly asks for the required permission on first use
 
 ## [1.10.1] - 2020-07-23
 


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
SMS OTP Autofill currently crashes for two reasons:

1.  Tasks.await has a precondition of not running on the UI thread.
2.  Exceptions thrown from Tasks are always wrapped into
    ExecutionExceptions and need to be unwrapped before they can be
    identified as ResolvableApiException.

This commit addresses both issues by making waitForSms a proper
coroutine using withContext and a custom wrapper around Task<T> that
relies on suspendCoroutine and automatically unwraps exceptions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turns out the switch over to `lifecycleScope` broke this, but at least now its in a much more dependable state.

## :green_heart: How did you test it?
It works in both the native Twitter app and the PWA and correctly asked for permission on first use.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
