### PR TITLE
Switch to non-deprecated stdlib methods

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FormField.kt
@@ -271,7 +271,7 @@ class FormField(
     }
 
     infix fun directlyPrecedes(that: Iterable<FormField>): Boolean {
-        val firstIndex = that.map { it.index }.min() ?: return false
+        val firstIndex = that.map { it.index }.minOrNull() ?: return false
         return index == firstIndex - 1
     }
 
@@ -280,7 +280,7 @@ class FormField(
     }
 
     infix fun directlyFollows(that: Iterable<FormField>): Boolean {
-        val lastIndex = that.map { it.index }.max() ?: return false
+        val lastIndex = that.map { it.index }.maxOrNull() ?: return false
         return index == lastIndex + 1
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Switches `min` and `max` to their new names.

## :bulb: Motivation and Context
`min` and `max` were deprecated in favor of minOrNull and maxOrNull respectively to match their names to the typical naming format used by stdlib methods with nullable return types.


## :green_heart: How did you test it?
Things build as before but without the warning.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
