### PR TITLE
Downgrade coroutines to 1.3.6 to fix VerifyErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+-   Worked around a dependency bug that would crash the Autofill service when triggered on an OTP field
+
 ## [1.10.2] - 2020-07-30
 
 ### Fixed

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,8 +17,9 @@ ext.deps = [
 
     kotlin: [
         coroutines: [
-            android: 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7',
-            core: 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7',
+            // #989: Keep these at 1.3.6 as long as we are not using Kotlin 1.4 to prevent crashes.
+            android: 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.6',
+            core: 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6',
         ],
         stdlib8: 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
     ],


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Downgrade coroutine dependencies to 1.3.6 as long as `release` is not using Kotlin 1.4 to prevent a `VerifyError` on `AutofillSmsActivity`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #989.

## :green_heart: How did you test it?
Verified that the Twitter.com OTP field no longer crashes the AutofillService. Please do the same.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
