### PR TITLE
Replicate key selection flow for directory creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Allow changing the branch used for Git operations
+- Allow setting a subdirectory key when creating folders
 
 ### Changed
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,8 @@ android {
         }
     }
 
+    adbOptions.installOptions("--user 0")
+
     buildFeatures.viewBinding = true
 
     defaultConfig {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -26,7 +26,6 @@ import org.eclipse.jgit.api.CommitCommand
 import org.eclipse.jgit.api.PullCommand
 import org.eclipse.jgit.api.PushCommand
 import org.eclipse.jgit.api.RebaseResult
-import org.eclipse.jgit.api.StatusCommand
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.SshSessionFactory
 
@@ -43,22 +42,14 @@ class GitCommandExecutor(
             message = activity.resources.getString(R.string.git_operation_running),
             length = Snackbar.LENGTH_INDEFINITE,
         )
-        var nbChanges = 0
         var operationResult: Result = Result.Ok
         for (command in operation.commands) {
             try {
                 when (command) {
-                    is StatusCommand -> {
-                        // in case we have changes, we want to keep track of it
-                        val status = withContext(Dispatchers.IO) {
-                            command.call()
-                        }
-                        nbChanges = status.changed.size + status.missing.size
-                    }
                     is CommitCommand -> {
                         // the previous status will eventually be used to avoid a commit
                         withContext(Dispatchers.IO) {
-                            if (nbChanges > 0) command.call()
+                            command.call()
                         }
                     }
                     is PullCommand -> {

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
@@ -18,7 +18,6 @@ class SyncOperation(fileDir: File, callingActivity: AppCompatActivity) : GitOper
 
     override val commands = arrayOf(
         git.add().addFilepattern("."),
-        git.status(),
         git.commit().setAll(true).setMessage("[Android Password Store] Sync"),
         git.pull().setRebase(true).setRemote("origin"),
         git.push().setPushAll().setRemote("origin"),

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -5,15 +5,29 @@
 package com.zeapo.pwdstore.ui.dialogs
 
 import android.app.Dialog
+import android.content.Intent
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.zeapo.pwdstore.PasswordStore
 import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.crypto.BasePgpActivity
+import com.zeapo.pwdstore.crypto.GetKeyIdsActivity
+import com.zeapo.pwdstore.utils.PasswordRepository
+import com.zeapo.pwdstore.utils.PasswordRepository.Companion.getRepositoryDirectory
+import com.zeapo.pwdstore.utils.commitChange
 import com.zeapo.pwdstore.utils.requestInputFocusOnView
 import java.io.File
+import kotlinx.coroutines.launch
+import me.msfjarvis.openpgpktx.util.OpenPgpApi
 
 class FolderCreationDialogFragment : DialogFragment() {
 
@@ -21,25 +35,65 @@ class FolderCreationDialogFragment : DialogFragment() {
         val alertDialogBuilder = MaterialAlertDialogBuilder(requireContext())
         alertDialogBuilder.setTitle(R.string.title_create_folder)
         alertDialogBuilder.setView(R.layout.folder_dialog_fragment)
-        alertDialogBuilder.setPositiveButton(getString(R.string.button_create)) { _, _ ->
-            createDirectory(requireArguments().getString(CURRENT_DIR_EXTRA)!!)
-        }
+        alertDialogBuilder.setPositiveButton(getString(R.string.button_create), null)
         alertDialogBuilder.setNegativeButton(getString(android.R.string.cancel)) { _, _ ->
             dismiss()
         }
         val dialog = alertDialogBuilder.create()
         dialog.requestInputFocusOnView<TextInputEditText>(R.id.folder_name_text)
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                createDirectory(requireArguments().getString(CURRENT_DIR_EXTRA)!!)
+            }
+        }
         return dialog
     }
 
     private fun createDirectory(currentDir: String) {
         val dialog = requireDialog()
-        val materialTextView = dialog.findViewById<TextInputEditText>(R.id.folder_name_text)
-        val folderName = materialTextView.text.toString()
-        val newFolder = File("$currentDir/$folderName")
+        val folderNameView = dialog.findViewById<TextInputEditText>(R.id.folder_name_text)
+        val folderNameViewContainer = dialog.findViewById<TextInputLayout>(R.id.folder_name_container)
+        val newFolder = File("$currentDir/${folderNameView.text}")
+        if (newFolder.exists()) {
+            folderNameViewContainer.error = when {
+                newFolder.isFile -> getString(R.string.folder_creation_err_file_exists)
+                newFolder.isDirectory -> getString(R.string.folder_creation_err_folder_exists)
+                // Should be impossible but eh.
+                else -> return
+            }
+            return
+        } else {
+            folderNameViewContainer.error = null
+        }
         newFolder.mkdirs()
         (requireActivity() as PasswordStore).refreshPasswordList(newFolder)
-        dismiss()
+        if (dialog.findViewById<MaterialCheckBox>(R.id.set_gpg_key).isChecked) {
+            val gpgIdentifierFile = File(newFolder, ".gpg-id")
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == AppCompatActivity.RESULT_OK) {
+                    result.data?.getStringArrayExtra(OpenPgpApi.EXTRA_KEY_IDS)?.let { keyIds ->
+                        gpgIdentifierFile.writeText(keyIds.joinToString("\n"))
+                        val repo = PasswordRepository.getRepository(null)
+                        if (repo != null) {
+                            lifecycleScope.launch {
+                                val repoPath = getRepositoryDirectory().absolutePath
+                                requireActivity().commitChange(
+                                    getString(
+                                        R.string.git_commit_gpg_id,
+                                        BasePgpActivity.getLongName(gpgIdentifierFile.parentFile!!.absolutePath, repoPath, gpgIdentifierFile.name)
+                                    ),
+                                    finishActivityOnEnd = false,
+                                )
+                                dismiss()
+                            }
+                        }
+                    }
+                }
+            }.launch(Intent(requireContext(), GetKeyIdsActivity::class.java))
+            return
+        } else {
+            dismiss()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -54,17 +54,12 @@ class FolderCreationDialogFragment : DialogFragment() {
         val folderNameView = dialog.findViewById<TextInputEditText>(R.id.folder_name_text)
         val folderNameViewContainer = dialog.findViewById<TextInputLayout>(R.id.folder_name_container)
         val newFolder = File("$currentDir/${folderNameView.text}")
-        if (newFolder.exists()) {
-            folderNameViewContainer.error = when {
-                newFolder.isFile -> getString(R.string.folder_creation_err_file_exists)
-                newFolder.isDirectory -> getString(R.string.folder_creation_err_folder_exists)
-                // Should be impossible but eh.
-                else -> return
-            }
-            return
-        } else {
-            folderNameViewContainer.error = null
+        folderNameViewContainer.error = when {
+            newFolder.isFile -> getString(R.string.folder_creation_err_file_exists)
+            newFolder.isDirectory -> getString(R.string.folder_creation_err_folder_exists)
+            else -> null
         }
+        if (folderNameViewContainer.error != null) return
         newFolder.mkdirs()
         (requireActivity() as PasswordStore).refreshPasswordList(newFolder)
         if (dialog.findViewById<MaterialCheckBox>(R.id.set_gpg_key).isChecked) {

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -116,7 +116,6 @@ suspend fun FragmentActivity.commitChange(
     object : GitOperation(getRepositoryDirectory(), this@commitChange) {
         override val commands = arrayOf(
             git.add().addFilepattern("."),
-            git.status(),
             git.commit().setAll(true).setMessage(message),
         )
 

--- a/app/src/main/res/layout/folder_dialog_fragment.xml
+++ b/app/src/main/res/layout/folder_dialog_fragment.xml
@@ -3,17 +3,21 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
 
     <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/folder_name_container"
         style="@style/AppTheme.TextInputLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/crypto_name_hint">
+        android:hint="@string/crypto_name_hint"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/folder_name_text"
@@ -22,4 +26,12 @@
             android:inputType="textNoSuggestions|textVisiblePassword" />
 
     </com.google.android.material.textfield.TextInputLayout>
-</LinearLayout>
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/set_gpg_key"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="@string/new_folder_set_gpg_key"
+        app:layout_constraintTop_toBottomOf="@id/folder_name_container" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,6 +367,7 @@
     <string name="short_key_ids_unsupported">A key ID in .gpg-id is too short, please use either long key IDs (16 characters) or fingerprints (40 characters)</string>
     <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
     <string name="directory_hint">Directory</string>
+    <string name="new_folder_set_gpg_key">Set GPG key for directory</string>
 
     <!-- GitException messages -->
     <string name="git_unknown_error">Unknown error</string>
@@ -375,4 +376,6 @@
     <string name="git_push_generic_error">Push was rejected by remote, reason: %1$s</string>
     <string name="git_push_other_error">Remote rejected non-fast-forward push. Check receive.denyNonFastForwards variable in config file of destination repository.</string>
     <string name="git_operation_running">Running git operation…</string>
+    <string name="folder_creation_err_file_exists">A file by that name already exists</string>
+    <string name="folder_creation_err_folder_exists">A folder by that name already exists</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Replicates the key selection flow in the folder creation dialog and peppers in some error handling.

## :bulb: Motivation and Context
Fixes #994

## :green_heart: How did you test it?
Manually replicated error and success cases.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
