### PR TITLE
Prompt user to install OpenKeychain when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Allow creating nested directories directly
 - I keep saying this but for real: error message for wrong SSH/HTTPS password is properly fixed now
+- Fix crash when OpenKeychain is not installed
 
 ## [1.10.3] - 2020-07-30
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,4 +375,12 @@
     <string name="git_push_generic_error">Push was rejected by remote, reason: %1$s</string>
     <string name="git_push_other_error">Remote rejected non-fast-forward push. Check receive.denyNonFastForwards variable in config file of destination repository.</string>
     <string name="git_operation_running">Running git operation…</string>
+
+    <!-- OpenKeychain not installed -->
+    <string name="openkeychain_not_installed_title">OpenKeychain not installed</string>
+    <string name="openkeychain_not_installed_message">OpenKeychain is required for Password Store to function, please install it from the stores below</string>
+    <string name="openkeychain_not_installed_google_play">Google Play</string>
+    <string name="play_deeplink_template">https://play.google.com/store/apps/details?id=%1$s</string>
+    <string name="openkeychain_not_installed_fdroid">F-Droid</string>
+    <string name="fdroid_deeplink_template">https://f-droid.org/en/packages/%1$s/</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
When attempting to bind to OpenKeychain, alert the user if its unavailable and take them to Google Play or F-Droid.

## :bulb: Motivation and Context
Fixes #996 which has been reported to me over a 1 star Google Play review and multiple messages on Telegram.

## :green_heart: How did you test it?
Uninstalled OpenKeychain, used the Google Play button to install it, set it up again, and was prompted to authenticate
when I resumed `DecryptActivity`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
