### PR TITLE
Disable automatic copy on decrypt by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Slightly reduce APK size
 - Always show the parent path in entries
+- Passwords will no longer be copied to the clipboard by default
 
 ### Fixed
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
@@ -206,7 +206,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
                                 }
                             }
 
-                            if (settings.getBoolean(PreferenceKeys.COPY_ON_DECRYPT, true)) {
+                            if (settings.getBoolean(PreferenceKeys.COPY_ON_DECRYPT, false)) {
                                 copyPasswordToClipboard(entry.password)
                             }
                         } catch (e: Exception) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
The default behaviour of automatically copying to clipboard is both a bit insecure on most devices (w.r.t. unfettered clipboard access before Q) as well as counterproductive for some use-cases like in #922.

## :bulb: Motivation and Context
This has been brought up before in #476, and while the clipboard is relatively safer on Android Q and above, a large section of our users are still on older versions of Android.

## :green_heart: How did you test it?
Verified password is not automatically copied on a clean installation of APS.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
