### PR TITLE
Improve clone operation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Allow creating nested directories directly
 - I keep saying this but for real: error message for wrong SSH/HTTPS password is properly fixed now
 - Fix crash when OpenKeychain is not installed
+- Clone operation won't leave user on an empty password list upon failure
 
 ## [1.10.3] - 2020-07-30
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/CloneOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/CloneOperation.kt
@@ -24,6 +24,15 @@ class CloneOperation(fileDir: File, uri: String, callingActivity: AppCompatActiv
     )
 
     override suspend fun execute() {
-        GitCommandExecutor(callingActivity, this).execute()
+        GitCommandExecutor(callingActivity, this, finishActivityOnEnd = false).execute()
+    }
+
+    override fun onSuccess() {
+        callingActivity.finish()
+    }
+
+    override fun onError(err: Exception) {
+        finishFromErrorDialog = false
+        super.onError(err)
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -46,6 +46,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
     private var provider: CredentialsProvider? = null
     private val sshKeyFile = callingActivity.filesDir.resolve(".ssh_key")
     private val hostKeyFile = callingActivity.filesDir.resolve(".host_key")
+    protected var finishFromErrorDialog = true
     protected val repository = PasswordRepository.getRepository(gitDir)
     protected val git = Git(repository)
     protected val remoteBranch = GitSettings.branch
@@ -166,7 +167,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
             .setTitle(callingActivity.resources.getString(R.string.jgit_error_dialog_title))
             .setMessage(ErrorMessages[err])
             .setPositiveButton(callingActivity.resources.getString(R.string.dialog_ok)) { _, _ ->
-                callingActivity.finish()
+                if (finishFromErrorDialog) callingActivity.finish()
             }.show()
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Prevent `GitServerConfigActivity` from going away when the clone operation fails.

## :bulb: Motivation and Context
As noted in #1003, the user is left on `PasswordFragment` when clone fails, and while we do prompt to clone the repo when attempting to run a sync operation, its just simpler to force them to stick in the clone UI until they get it right.

## :green_heart: How did you test it?
Enter wrong data into URL field and observe that the resulting error dialog does not finish the activity.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
