### PR TITLE
Create only one SSH session per GitOperation

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -44,8 +44,8 @@ class GitCommandExecutor(
             length = Snackbar.LENGTH_INDEFINITE,
         )
         var operationResult: Result = Result.Ok
-        for (command in operation.commands) {
-            try {
+        try {
+            for (command in operation.commands) {
                 when (command) {
                     is CommitCommand -> {
                         // the previous status will eventually be used to avoid a commit
@@ -108,9 +108,9 @@ class GitCommandExecutor(
                         }
                     }
                 }
-            } catch (e: Exception) {
-                operationResult = Result.Err(e)
             }
+        } catch (e: Exception) {
+            operationResult = Result.Err(e)
         }
         when (operationResult) {
             is Result.Err -> {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -131,6 +131,9 @@ class GitCommandExecutor(
             }
         }
         snackbar.dismiss()
+        withContext(Dispatchers.IO) {
+            (SshSessionFactory.getInstance() as? SshjSessionFactory)?.close()
+        }
         SshSessionFactory.setInstance(null)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -131,7 +131,6 @@ class GitCommandExecutor(
             }
         }
         snackbar.dismiss()
-        (SshSessionFactory.getInstance() as? SshjSessionFactory)?.clearCredentials()
         SshSessionFactory.setInstance(null)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/SshjSessionFactory.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/SshjSessionFactory.kt
@@ -7,7 +7,6 @@ package com.zeapo.pwdstore.git.config
 import android.util.Base64
 import com.github.ajalt.timberkt.d
 import com.github.ajalt.timberkt.w
-import com.zeapo.pwdstore.utils.clear
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -36,56 +35,24 @@ import org.eclipse.jgit.transport.URIish
 import org.eclipse.jgit.util.FS
 
 sealed class SshAuthData {
-    class Password(val passwordFinder: InteractivePasswordFinder) : SshAuthData() {
-
-        override fun clearCredentials() {
-            passwordFinder.clearPassword()
-        }
-    }
-
-    class PublicKeyFile(val keyFile: File, val passphraseFinder: InteractivePasswordFinder) : SshAuthData() {
-
-        override fun clearCredentials() {
-            passphraseFinder.clearPassword()
-        }
-    }
-
-    abstract fun clearCredentials()
+    class Password(val passwordFinder: InteractivePasswordFinder) : SshAuthData()
+    class PublicKeyFile(val keyFile: File, val passphraseFinder: InteractivePasswordFinder) : SshAuthData()
 }
 
 abstract class InteractivePasswordFinder : PasswordFinder {
 
+    private var isRetry = false
+
     abstract fun askForPassword(cont: Continuation<String?>, isRetry: Boolean)
 
-    private var isRetry = false
-    private var lastPassword: CharArray? = null
-
-    fun resetForReuse() {
-        isRetry = false
-    }
-
-    fun clearPassword() {
-        lastPassword?.clear()
-        lastPassword = null
-    }
-
     final override fun reqPassword(resource: Resource<*>?): CharArray {
-        if (lastPassword != null && !isRetry) {
-            // This instance successfully authenticated in a previous authentication step and is
-            // now being reused for a new one. We try the previous password so that the user
-            // does not have to type it again.
-            isRetry = true
-            return lastPassword!!
-        }
-        clearPassword()
         val password = runBlocking(Dispatchers.Main) {
             suspendCoroutine<String?> { cont ->
                 askForPassword(cont, isRetry)
             }
         }
         isRetry = true
-        return password?.toCharArray()?.also { lastPassword = it }
-            ?: throw SSHException(DisconnectReason.AUTH_CANCELLED_BY_USER)
+        return password?.toCharArray() ?: throw SSHException(DisconnectReason.AUTH_CANCELLED_BY_USER)
     }
 
     final override fun shouldRetry(resource: Resource<*>?) = true
@@ -95,10 +62,6 @@ class SshjSessionFactory(private val authData: SshAuthData, private val hostKeyF
 
     override fun getSession(uri: URIish, credentialsProvider: CredentialsProvider?, fs: FS?, tms: Int): RemoteSession {
         return SshjSession(uri, uri.user, authData, hostKeyFile).connect()
-    }
-
-    fun clearCredentials() {
-        authData.clearCredentials()
     }
 }
 
@@ -151,11 +114,9 @@ private class SshjSession(uri: URIish, private val username: String, private val
         when (authData) {
             is SshAuthData.Password -> {
                 ssh.authPassword(username, authData.passwordFinder)
-                authData.passwordFinder.resetForReuse()
             }
             is SshAuthData.PublicKeyFile -> {
                 ssh.authPublickey(username, ssh.loadKeys(authData.keyFile.absolutePath, authData.passphraseFinder))
-                authData.passphraseFinder.resetForReuse()
             }
         }
         return this

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -42,12 +42,6 @@ fun String.splitLines(): Array<String> {
     return split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 }
 
-fun CharArray.clear() {
-    forEachIndexed { i, _ ->
-        this[i] = 0.toChar()
-    }
-}
-
 val Context.clipboard get() = getSystemService<ClipboardManager>()
 
 fun FragmentActivity.snackbar(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
We should only create a single SSH session per GitOperation to reduce overhead and prevent repeated password prompts without bandaid solution and I finally figured out how to do it.

Along the way, a subtle bug is fixed that can lead to Git operations continuing after an error has been encountered. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Would greatly improve the usability of #995 with security tokens and simplifies the code considerably.

## :green_heart: How did you test it?
I synced and cancelled password prompts and everything worked as expected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
