### PR TITLE
Add symlink support to JGit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ android {
         exclude("**/*.version")
         exclude("**/*.txt")
         exclude("**/*.kotlin_module")
+        exclude("**/plugin.properties")
     }
 
     buildTypes {
@@ -117,6 +118,8 @@ dependencies {
     implementation(Dependencies.ThirdParty.jgit) {
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
+    // Loaded dynamically by JGit to provider symlink support
+    implementation(Dependencies.ThirdParty.jgit_java7)
     implementation(Dependencies.ThirdParty.jsch)
     implementation(Dependencies.ThirdParty.sshj)
     implementation(Dependencies.ThirdParty.bouncycastle)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,7 +118,7 @@ dependencies {
     implementation(Dependencies.ThirdParty.jgit) {
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    // Loaded dynamically by JGit to provider symlink support
+    // Loaded dynamically by JGit to provide symlink support
     implementation(Dependencies.ThirdParty.jgit_java7)
     implementation(Dependencies.ThirdParty.jsch)
     implementation(Dependencies.ThirdParty.sshj)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -53,6 +53,7 @@ object Dependencies {
         const val fastscroll = "me.zhanghai.android.fastscroll:library:1.1.4"
         const val jsch = "com.jcraft:jsch:0.1.55"
         const val jgit = "org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r"
+        const val jgit_java7 = "org.eclipse.jgit:org.eclipse.jgit.java7:3.7.1.201504261725-r"
         const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.4"
         const val plumber = "com.squareup.leakcanary:plumber-android:2.4"
         const val sshj = "com.hierynomus:sshj:0.29.0"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Enable symlink support in JGit.

Symlink support is provided by the `FS_POSIX_Java7` file system, which is loaded dynamically from the `org.eclipse.jgit.java7` module. Previously, we didn't include that module, which meant that symlinks were treated as ordinary files as the relevant check [here](https://github.com/eclipse/jgit/blob/2383cccf1226ad4c3140846517458de1e5283c27/org.eclipse.jgit/src/org/eclipse/jgit/dircache/DirCacheCheckout.java#L1228) would fail for the `FS_POSIX_Java6` filesystem provider.

This probably requires users to delete and re-checkout their repositories to get their symlinks to work. @msfjarvis I'm unsure about how to communicate this best, would a changelog entry be enough?

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #636.

## :green_heart: How did you test it?
Cloned the https://github.com/android-password-store/pass-test repository and observed that the symlinked file is decrypted correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
