### PR TITLE
Restore workaround for preventing empty commits

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,8 +118,6 @@ dependencies {
     implementation(Dependencies.ThirdParty.jgit) {
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    // Loaded dynamically by JGit to provide symlink support
-    implementation(Dependencies.ThirdParty.jgit_java7)
     implementation(Dependencies.ThirdParty.jsch)
     implementation(Dependencies.ThirdParty.sshj)
     implementation(Dependencies.ThirdParty.bouncycastle)

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.launch
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
 import me.msfjarvis.openpgpktx.util.OpenPgpServiceConnection
 import me.msfjarvis.openpgpktx.util.OpenPgpUtils
-import org.eclipse.jgit.api.Git
 
 class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
 
@@ -328,16 +327,13 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                     if (result.resultCode == RESULT_OK) {
                         result.data?.getStringArrayExtra(OpenPgpApi.EXTRA_KEY_IDS)?.let { keyIds ->
                             gpgIdentifierFile.writeText(keyIds.joinToString("\n"))
-                            val repo = PasswordRepository.getRepository(null)
-                            if (repo != null) {
-                                lifecycleScope.launch {
-                                    commitChange(
-                                        getString(
-                                            R.string.git_commit_gpg_id,
-                                            getLongName(gpgIdentifierFile.parentFile!!.absolutePath, repoPath, gpgIdentifierFile.name)
-                                        )
+                            lifecycleScope.launch {
+                                commitChange(
+                                    getString(
+                                        R.string.git_commit_gpg_id,
+                                        getLongName(gpgIdentifierFile.parentFile!!.absolutePath, repoPath, gpgIdentifierFile.name)
                                     )
-                                }
+                                )
                             }
                             encrypt(data)
                         }
@@ -430,19 +426,13 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                     returnIntent.putExtra(RETURN_EXTRA_USERNAME, username)
                                 }
 
-                                val repo = PasswordRepository.getRepository(null)
-                                if (repo != null) {
-                                    val status = Git(repo).status().call()
-                                    if (status.modified.isNotEmpty()) {
-                                        lifecycleScope.launch {
-                                            commitChange(
-                                                getString(
-                                                    R.string.git_commit_edit_text,
-                                                    getLongName(fullPath, repoPath, editName)
-                                                )
-                                            )
-                                        }
-                                    }
+                                lifecycleScope.launch {
+                                    commitChange(
+                                        getString(
+                                            R.string.git_commit_edit_text,
+                                            getLongName(fullPath, repoPath, editName)
+                                        )
+                                    )
                                 }
 
                                 if (directoryInputLayout.isVisible && directoryInputLayout.isEnabled && oldFileName != null) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -27,6 +27,7 @@ import org.eclipse.jgit.api.CommitCommand
 import org.eclipse.jgit.api.PullCommand
 import org.eclipse.jgit.api.PushCommand
 import org.eclipse.jgit.api.RebaseResult
+import org.eclipse.jgit.api.StatusCommand
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.SshSessionFactory
 
@@ -43,14 +44,24 @@ class GitCommandExecutor(
             message = activity.resources.getString(R.string.git_operation_running),
             length = Snackbar.LENGTH_INDEFINITE,
         )
+        // Count the number of staged files
+        var nbChanges = 0
         var operationResult: Result = Result.Ok
         try {
             for (command in operation.commands) {
                 when (command) {
+                    is StatusCommand -> {
+                        val res = withContext(Dispatchers.IO) {
+                            command.call()
+                        }
+                        nbChanges = res.uncommittedChanges.size
+                    }
                     is CommitCommand -> {
                         // the previous status will eventually be used to avoid a commit
-                        withContext(Dispatchers.IO) {
-                            command.call()
+                        if (nbChanges > 0) {
+                            withContext(Dispatchers.IO) {
+                                command.call()
+                            }
                         }
                     }
                     is PullCommand -> {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -44,7 +44,7 @@ class GitCommandExecutor(
             message = activity.resources.getString(R.string.git_operation_running),
             length = Snackbar.LENGTH_INDEFINITE,
         )
-        // Count the number of staged files
+        // Count the number of uncommitted files
         var nbChanges = 0
         var operationResult: Result = Result.Ok
         try {

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/ResetToRemoteOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/ResetToRemoteOperation.kt
@@ -18,9 +18,14 @@ import org.eclipse.jgit.api.ResetCommand
 class ResetToRemoteOperation(fileDir: File, callingActivity: AppCompatActivity) : GitOperation(fileDir, callingActivity) {
 
     override val commands = arrayOf(
+        // Stage all files
         git.add().addFilepattern("."),
+        // Fetch everything from the origin remote
         git.fetch().setRemote("origin"),
+        // Do a hard reset to the remote branch. Equivalent to git reset --hard origin/$remoteBranch
         git.reset().setRef("origin/$remoteBranch").setMode(ResetCommand.ResetType.HARD),
+        // Force-create $remoteBranch if it doesn't exist. This covers the case where you switched
+        // branches from 'master' to anything else.
         git.branchCreate().setName(remoteBranch).setForce(true),
     )
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
@@ -17,9 +17,15 @@ import java.io.File
 class SyncOperation(fileDir: File, callingActivity: AppCompatActivity) : GitOperation(fileDir, callingActivity) {
 
     override val commands = arrayOf(
+        // Stage all files
         git.add().addFilepattern("."),
+        // Populate the changed files count
+        git.status(),
+        // Commit everything! If needed, obviously.
         git.commit().setAll(true).setMessage("[Android Password Store] Sync"),
+        // Pull and rebase on top of the remote branch
         git.pull().setRebase(true).setRemote("origin"),
+        // Push it all back
         git.push().setPushAll().setRemote("origin"),
     )
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -111,7 +111,11 @@ suspend fun FragmentActivity.commitChange(
     }
     object : GitOperation(getRepositoryDirectory(), this@commitChange) {
         override val commands = arrayOf(
+            // Stage all files
             git.add().addFilepattern("."),
+            // Populate the changed files count
+            git.status(),
+            // Commit everything! If anything changed, that is.
             git.commit().setAll(true).setMessage(message),
         )
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -53,7 +53,6 @@ object Dependencies {
         const val fastscroll = "me.zhanghai.android.fastscroll:library:1.1.4"
         const val jsch = "com.jcraft:jsch:0.1.55"
         const val jgit = "org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r"
-        const val jgit_java7 = "org.eclipse.jgit:org.eclipse.jgit.java7:3.7.1.201504261725-r"
         const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.4"
         const val plumber = "com.squareup.leakcanary:plumber-android:2.4"
         const val sshj = "com.hierynomus:sshj:0.29.0"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Reverts Java 7 FS support due to regressions and re-adds proper fix for preventing empty commits

## :bulb: Motivation and Context

Fixes #1014

## :green_heart: How did you test it?

Clone a fresh repository and observe that Sync action does not create a commit.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Figure out why the Java 7 FS dependency causes this breakage.

<details><summary>Stacktrace</summary>

```
     GitCommandExecutor  E  org.eclipse.jgit.api.errors.JGitInternalException: Short read of block.
                         E      at org.eclipse.jgit.api.StatusCommand.call(StatusCommand.java:154)
                         E      at com.zeapo.pwdstore.git.GitCommandExecutor$execute$res$1.invokeSuspend(GitCommandExecutor.kt:54)
                         E      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                         E      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
                         E      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
                         E  Caused by: java.io.EOFException: Short read of block.
                         E      at org.eclipse.jgit.util.IO.readFully(IO.java:248)
                         E      at org.eclipse.jgit.treewalk.WorkingTreeIterator.readContentAsNormalizedString(WorkingTreeIterator.java:1082)
                         E      at org.eclipse.jgit.treewalk.WorkingTreeIterator.contentCheck(WorkingTreeIterator.java:1020)
                         E      at org.eclipse.jgit.treewalk.WorkingTreeIterator.isModified(WorkingTreeIterator.java:951)
                         E      at org.eclipse.jgit.treewalk.filter.IndexDiffFilter.include(IndexDiffFilter.java:227)
                         E      at org.eclipse.jgit.treewalk.filter.AndTreeFilter$Binary.include(AndTreeFilter.java:131)
                         E      at org.eclipse.jgit.treewalk.TreeWalk.next(TreeWalk.java:560)
                         E      at org.eclipse.jgit.lib.IndexDiff.diff(IndexDiff.java:432)
                         E      at org.eclipse.jgit.lib.IndexDiff.diff(IndexDiff.java:374)
                         E      at org.eclipse.jgit.api.StatusCommand.call(StatusCommand.java:148)
                         E      ... 7 more
```
</details>

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
