### PR TITLE
Allow adding digits and symbols in XkPasswd generator using mask-like values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Allow changing the branch used for Git operations
 - Allow setting a subdirectory key when creating folders
+- XKpasswd generator fragment: add field add digits/symbols to the password by mask (e.g. `dds`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Allow changing the branch used for Git operations
 - Allow setting a subdirectory key when creating folders
-- XKpasswd generator fragment: add field add digits/symbols to the password by mask (e.g. `dds`)
+- XKpasswd: add field for appending digits/symbols to the password by mask (e.g. `dds`)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Allow changing the branch used for Git operations
 - Allow setting a subdirectory key when creating folders
-- XKpasswd: add field for appending digits/symbols to the password by mask (e.g. `dds`)
+- Allow adding digits/symbols in XkPasswd generated passwords using a mask-like value (`dds` gives you two digits and a symbol, and so on)
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/CapsType.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/CapsType.kt
@@ -5,5 +5,5 @@
 package com.zeapo.pwdstore.pwgenxkpwd
 
 enum class CapsType {
-    lowercase, UPPERCASE, TitleCase, Sentencecase, As_iS
+    lowercase, UPPERCASE, TitleCase, Sentence, As_iS
 }

--- a/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/PasswordBuilder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/pwgenxkpwd/PasswordBuilder.kt
@@ -22,7 +22,7 @@ class PasswordBuilder(ctx: Context) {
     private var maxWordLength = 9
     private var minWordLength = 5
     private var separator = "."
-    private var capsType = CapsType.Sentencecase
+    private var capsType = CapsType.Sentence
     private var prependDigits = 0
     private var numDigits = 0
     private var isPrependWithSeparator = false
@@ -109,7 +109,7 @@ class PasswordBuilder(ctx: Context) {
                 val candidate = wordBank.secureRandomElement()
                 val s = when (capsType) {
                     CapsType.UPPERCASE -> candidate.toUpperCase(Locale.getDefault())
-                    CapsType.Sentencecase -> if (i == 0) candidate.capitalize(Locale.getDefault()) else candidate
+                    CapsType.Sentence -> if (i == 0) candidate.capitalize(Locale.getDefault()) else candidate
                     CapsType.TitleCase -> candidate.capitalize(Locale.getDefault())
                     CapsType.lowercase -> candidate.toLowerCase(Locale.getDefault())
                     CapsType.As_iS -> candidate

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
@@ -118,8 +118,8 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
         const val PREF_KEY_NUM_WORDS = "pref_key_num_words"
         const val PREF_KEY_SEPARATOR = "pref_key_separator"
         const val PREF_KEY_EXTRA_SYMBOLS_MASK = "pref_key_xkpwgen_extra_symbols_mask"
-        val DEFAULT_CAPS_STYLE = CapsType.Sentencecase.name
-        val DEFAULT_CAPS_INDEX = CapsType.Sentencecase.ordinal
+        val DEFAULT_CAPS_STYLE = CapsType.Sentence.name
+        val DEFAULT_CAPS_INDEX = CapsType.Sentence.ordinal
         const val DEFAULT_NUMBER_OF_WORDS = "3"
         const val DEFAULT_WORD_SEPARATOR = "."
         const val DEFAULT_EXTRA_SYMBOLS_MASK = "ds"

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
@@ -58,6 +58,7 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
         binding.xkNumWords.setText(prefs.getString(PREF_KEY_NUM_WORDS, DEFAULT_NUMBER_OF_WORDS))
 
         binding.xkSeparator.setText(prefs.getString(PREF_KEY_SEPARATOR, DEFAULT_WORD_SEPARATOR))
+        binding.xkNumberSymbolMask.setText(prefs.getString(PREF_KEY_EXTRA_SYMBOLS_MASK, DEFAULT_EXTRA_SYMBOLS_MASK))
 
         binding.xkPasswordText.typeface = monoTypeface
 
@@ -92,6 +93,8 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
                 .setMinimumWordLength(DEFAULT_MIN_WORD_LENGTH)
                 .setMaximumWordLength(DEFAULT_MAX_WORD_LENGTH)
                 .setSeparator(binding.xkSeparator.text.toString())
+                .appendNumbers(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_SYMBOL_PLACEHOLDER_DIGIT })
+                .appendSymbols(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_SYMBOL_PLACEHOLDER_SYMBOL })
                 .setCapitalization(CapsType.valueOf(binding.xkCapType.selectedItem.toString())).create()
         } catch (e: PasswordGenerator.PasswordGeneratorException) {
             Toast.makeText(requireActivity(), e.message, Toast.LENGTH_SHORT).show()
@@ -105,6 +108,7 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
             putString(PREF_KEY_CAPITALS_STYLE, binding.xkCapType.selectedItem.toString())
             putString(PREF_KEY_NUM_WORDS, binding.xkNumWords.text.toString())
             putString(PREF_KEY_SEPARATOR, binding.xkSeparator.text.toString())
+            putString(PREF_KEY_EXTRA_SYMBOLS_MASK, binding.xkNumberSymbolMask.text.toString())
         }
     }
 
@@ -113,12 +117,16 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
         const val PREF_KEY_CAPITALS_STYLE = "pref_key_capitals_style"
         const val PREF_KEY_NUM_WORDS = "pref_key_num_words"
         const val PREF_KEY_SEPARATOR = "pref_key_separator"
+        const val PREF_KEY_EXTRA_SYMBOLS_MASK = "pref_key_xkpwgen_extra_symbols_mask"
         val DEFAULT_CAPS_STYLE = CapsType.Sentencecase.name
         val DEFAULT_CAPS_INDEX = CapsType.Sentencecase.ordinal
         const val DEFAULT_NUMBER_OF_WORDS = "3"
         const val DEFAULT_WORD_SEPARATOR = "."
+        const val DEFAULT_EXTRA_SYMBOLS_MASK = "ds"
         const val DEFAULT_MIN_WORD_LENGTH = 3
         const val DEFAULT_MAX_WORD_LENGTH = 9
         const val FALLBACK_ERROR_PASS = "42"
+        const val EXTRA_SYMBOL_PLACEHOLDER_DIGIT = 'd'
+        const val EXTRA_SYMBOL_PLACEHOLDER_SYMBOL = 's'
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/XkPasswordGeneratorDialogFragment.kt
@@ -93,8 +93,8 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
                 .setMinimumWordLength(DEFAULT_MIN_WORD_LENGTH)
                 .setMaximumWordLength(DEFAULT_MAX_WORD_LENGTH)
                 .setSeparator(binding.xkSeparator.text.toString())
-                .appendNumbers(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_SYMBOL_PLACEHOLDER_DIGIT })
-                .appendSymbols(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_SYMBOL_PLACEHOLDER_SYMBOL })
+                .appendNumbers(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_CHAR_PLACEHOLDER_DIGIT })
+                .appendSymbols(binding.xkNumberSymbolMask.text!!.count { c -> c == EXTRA_CHAR_PLACEHOLDER_SYMBOL })
                 .setCapitalization(CapsType.valueOf(binding.xkCapType.selectedItem.toString())).create()
         } catch (e: PasswordGenerator.PasswordGeneratorException) {
             Toast.makeText(requireActivity(), e.message, Toast.LENGTH_SHORT).show()
@@ -126,7 +126,7 @@ class XkPasswordGeneratorDialogFragment : DialogFragment() {
         const val DEFAULT_MIN_WORD_LENGTH = 3
         const val DEFAULT_MAX_WORD_LENGTH = 9
         const val FALLBACK_ERROR_PASS = "42"
-        const val EXTRA_SYMBOL_PLACEHOLDER_DIGIT = 'd'
-        const val EXTRA_SYMBOL_PLACEHOLDER_SYMBOL = 's'
+        const val EXTRA_CHAR_PLACEHOLDER_DIGIT = 'd'
+        const val EXTRA_CHAR_PLACEHOLDER_SYMBOL = 's'
     }
 }

--- a/app/src/main/res/layout/fragment_xkpwgen.xml
+++ b/app/src/main/res/layout/fragment_xkpwgen.xml
@@ -75,29 +75,27 @@
             android:entries="@array/capitalization_type_values"
             android:entryValues="@array/capitalization_type_values"
             android:spinnerMode="dropdown"
-            app:layout_constraintHorizontal_weight="0.5"
+            app:layout_constraintEnd_toEndOf="@id/total_words"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/total_words" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/xk_numbers_symbols_label"
-            android:layout_marginTop="16dp"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            app:layout_constraintHorizontal_weight="0.3"
             android:hint="@string/xkpwgen_extrachars_label"
-            app:layout_constraintStart_toEndOf="@id/xkCapType"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/separator">
+            app:layout_constraintStart_toStartOf="@id/separator"
+            app:layout_constraintTop_toBottomOf="@id/separator"
+            app:layout_constraintTop_toTopOf="@id/xkCapType">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/xk_number_symbol_mask"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:autofillHints=""
-                android:text="@string/xk_numbers_symbols_append_default"
-                android:inputType="text" />
+                android:inputType="text"
+                android:text="@string/xk_numbers_symbols_append_default" />
         </com.google.android.material.textfield.TextInputLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_xkpwgen.xml
+++ b/app/src/main/res/layout/fragment_xkpwgen.xml
@@ -81,6 +81,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/xk_numbers_symbols_label"
+            android:layout_marginTop="16dp"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"

--- a/app/src/main/res/layout/fragment_xkpwgen.xml
+++ b/app/src/main/res/layout/fragment_xkpwgen.xml
@@ -75,7 +75,29 @@
             android:entries="@array/capitalization_type_values"
             android:entryValues="@array/capitalization_type_values"
             android:spinnerMode="dropdown"
+            app:layout_constraintHorizontal_weight="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/separator" />
+            app:layout_constraintTop_toBottomOf="@id/total_words" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/xk_numbers_symbols_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            app:layout_constraintHorizontal_weight="0.3"
+            android:hint="@string/xkpwgen_extrachars_label"
+            app:layout_constraintStart_toEndOf="@id/xkCapType"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/separator">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/xk_number_symbol_mask"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:autofillHints=""
+                android:text="@string/xk_numbers_symbols_append_default"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -18,7 +18,7 @@
         <item>lowercase</item>
         <item>UPPERCASE</item>
         <item>TitleCase</item>
-        <item>Sentencecase</item>
+        <item>Sentence</item>
     </string-array>
     <string-array name="pwgen_provider_labels">
         <item>Classic</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,4 +390,6 @@
     <!-- GPG key selection in folder creation -->
     <string name="folder_creation_err_file_exists">A file by that name already exists</string>
     <string name="folder_creation_err_folder_exists">A folder by that name already exists</string>
+    <string name="xkpwgen_extrachars_label" >Digits/Symbols (d/s)</string>
+    <string name="xk_numbers_symbols_append_default">ds</string>
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
- update xkpass fields to allow appending numbers+symbols via a mask such as `ddds` which would generate `random.password123!`
currently position of `d` and `s` is not currently considered; only the count is relevant

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some sites have requirements for passwords to contain numbers and special symbols. Introducing a field where you can specify `ds` would append one digit and one symbol correspondingly. `dddsss` would append 3 numbers and 2 special characters.

<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
![Screen Shot 2020-08-16 at 14 22 40](https://user-images.githubusercontent.com/48893368/90334353-612f4900-dfcd-11ea-9625-ec6dbc5ff4bf.png)


## After code review changes (fixed alignment for caps type and digits/symbols)
![image](https://user-images.githubusercontent.com/48893368/90338059-39e57580-dfe7-11ea-8bb4-dd0de620fd3b.png)
