### PR TITLE
Also invert copy_on_decrypt preference value

### DIFF
--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -154,7 +154,7 @@
             app:summary="@string/show_extra_content_pref_summary"
             app:title="@string/show_extra_content_pref_title" />
         <CheckBoxPreference
-            app:defaultValue="true"
+            app:defaultValue="false"
             app:dialogTitle="@string/pref_copy_dialog_title"
             app:key="copy_on_decrypt"
             app:summary="@string/pref_copy_dialog_title"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Fixes the preference value for copy_on_decrypt

## :bulb: Motivation and Context

In #1006 we changed the default value for copy_on_decrypt to false in the Kotlin code but did not do the same for the actual preference which results in it still being enabled by default. This fixes that.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
