### PR TITLE
Update sshj to 0.30.0 and improve algorithm order

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -59,7 +59,7 @@ object Dependencies {
         const val jgit_java7 = "org.eclipse.jgit:org.eclipse.jgit.java7:3.7.1.201504261725-r"
         const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.4"
         const val plumber = "com.squareup.leakcanary:plumber-android:2.4"
-        const val sshj = "com.hierynomus:sshj:0.29.0"
+        const val sshj = "com.hierynomus:sshj:0.30.0"
         const val ssh_auth = "org.sufficientlysecure:sshauthentication-api:1.0"
         const val timber = "com.jakewharton.timber:timber:4.7.1"
         const val timberkt = "com.github.ajalt:timberkt:1.5.1"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Updates sshj to 0.30.0, which brings support for rsa-sha2-* key types
and bugfixes related to RSA certificates and Android Keystore backed
keys.

Along the way, this improves the algorithm preferences to be consistent
with the Mozilla Intermediate SSH configuration (as far as possible,
given that most certificate types and some encryption algorithms are
not yet supported).

We also add "ext-info-c" to the kex algorithm proposal to work around
certain kinds of "user agent sniffing" that limits the support of
rsa-sha2-* key types.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Not yet, but will later. Please also check for regressions.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
