### PR TITLE
Show recently used passwords

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,7 +16,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -105,7 +105,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
         }
         binding.passMruRecycler.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
         recyclerMRUAdapter = MRUPasswordItemRecyclerAdapter()
-        recyclerMRUAdapter.onItemClick =  { item -> Toast.makeText(context, item, Toast.LENGTH_SHORT).show() }
+        recyclerMRUAdapter.onItemClick = { item -> Toast.makeText(context, item, Toast.LENGTH_SHORT).show() }
         binding.passMruRecycler.adapter = recyclerMRUAdapter
 
         recyclerAdapter = PasswordItemRecyclerAdapter()

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -14,6 +14,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.view.ActionMode
 import androidx.fragment.app.Fragment
@@ -104,6 +105,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
         }
         binding.passMruRecycler.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
         recyclerMRUAdapter = MRUPasswordItemRecyclerAdapter()
+        recyclerMRUAdapter.onItemClick =  { item -> Toast.makeText(context, item, Toast.LENGTH_SHORT).show() }
         binding.passMruRecycler.adapter = recyclerMRUAdapter
 
         recyclerAdapter = PasswordItemRecyclerAdapter()

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -31,7 +31,6 @@ import com.zeapo.pwdstore.ui.OnOffItemAnimator
 import com.zeapo.pwdstore.ui.adapters.MRUPasswordItemRecyclerAdapter
 import com.zeapo.pwdstore.ui.adapters.PasswordItemRecyclerAdapter
 import com.zeapo.pwdstore.ui.dialogs.ItemCreationBottomSheet
-import com.zeapo.pwdstore.utils.MRU
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.sharedPrefs
@@ -104,7 +103,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
             }
         }
         binding.passMruRecycler.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
-        recyclerMRUAdapter = MRUPasswordItemRecyclerAdapter(MRU.getInstance()!!.toList())
+        recyclerMRUAdapter = MRUPasswordItemRecyclerAdapter()
         binding.passMruRecycler.adapter = recyclerMRUAdapter
 
         recyclerAdapter = PasswordItemRecyclerAdapter()

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -28,8 +28,10 @@ import com.zeapo.pwdstore.git.GitServerConfigActivity
 import com.zeapo.pwdstore.git.config.ConnectionMode
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.ui.OnOffItemAnimator
+import com.zeapo.pwdstore.ui.adapters.MRUPasswordItemRecyclerAdapter
 import com.zeapo.pwdstore.ui.adapters.PasswordItemRecyclerAdapter
 import com.zeapo.pwdstore.ui.dialogs.ItemCreationBottomSheet
+import com.zeapo.pwdstore.utils.MRU
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.sharedPrefs
@@ -40,6 +42,7 @@ import me.zhanghai.android.fastscroll.FastScrollerBuilder
 class PasswordFragment : Fragment(R.layout.password_recycler_view) {
 
     private lateinit var recyclerAdapter: PasswordItemRecyclerAdapter
+    private lateinit var recyclerMRUAdapter: MRUPasswordItemRecyclerAdapter
     private lateinit var listener: OnFragmentInteractionListener
     private lateinit var settings: SharedPreferences
 
@@ -100,6 +103,9 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
                 swipeResult.launch(intent)
             }
         }
+        binding.passMruRecycler.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+        recyclerMRUAdapter = MRUPasswordItemRecyclerAdapter(MRU.getInstance()!!.toList())
+        binding.passMruRecycler.adapter = recyclerMRUAdapter
 
         recyclerAdapter = PasswordItemRecyclerAdapter()
             .onItemClicked { _, item ->

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -52,6 +52,7 @@ import com.zeapo.pwdstore.git.GitServerConfigActivity
 import com.zeapo.pwdstore.git.config.ConnectionMode
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.ui.dialogs.FolderCreationDialogFragment
+import com.zeapo.pwdstore.utils.MRU
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PasswordRepository.Companion.closeRepository
@@ -89,6 +90,8 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
 
     private val settings by lazy { sharedPrefs }
 
+    // Most Recently Used password
+    private var mruPassword: MRU? = null
     private val model: SearchableRepositoryViewModel by viewModels {
         ViewModelProvider.AndroidViewModelFactory(application)
     }
@@ -175,6 +178,9 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
             savedInstance = null
         }
         super.onCreate(savedInstance)
+
+        MRU.MRUInit(sharedPrefs)
+        mruPassword = MRU.getInstance()
 
         // If user is eligible for Oreo autofill, prompt them to switch.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
@@ -551,6 +557,10 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
                 shortcutManager!!.addDynamicShortcuts(listOf(shortcut))
             }
         }
+        //add item as recently used
+        mruPassword?.add(item.file.absolutePath)
+        mruPassword?.print()
+
         startActivity(decryptIntent)
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -73,6 +73,7 @@ import com.zeapo.pwdstore.utils.requestInputFocusOnView
 import com.zeapo.pwdstore.utils.sharedPrefs
 import java.io.File
 import java.lang.Character.UnicodeBlock
+import java.util.LinkedList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -91,7 +92,6 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
     private val settings by lazy { sharedPrefs }
 
     // Most Recently Used password
-    private var mruPassword: MRU? = null
     private val model: SearchableRepositoryViewModel by viewModels {
         ViewModelProvider.AndroidViewModelFactory(application)
     }
@@ -179,8 +179,7 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
         }
         super.onCreate(savedInstance)
 
-        MRU.MRUInit(sharedPrefs)
-        mruPassword = MRU.getInstance()
+        MRU.mRUInit(sharedPrefs)
 
         // If user is eligible for Oreo autofill, prompt them to switch.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
@@ -558,8 +557,7 @@ class PasswordStore : AppCompatActivity(R.layout.activity_pwdstore) {
             }
         }
         //add item as recently used
-        mruPassword?.add(item.file.absolutePath)
-        mruPassword?.print()
+        MRU.add(item.file.absolutePath)
 
         startActivity(decryptIntent)
     }

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
@@ -9,6 +9,9 @@ import com.zeapo.pwdstore.utils.MRU
 
 class MRUPasswordItemRecyclerAdapter : RecyclerView.Adapter<MRUPasswordItemRecyclerAdapter.ViewHolder>() {
     private val mruPasswords = MRU.mRU
+    var onItemClick: ((String) -> Unit)? = null
+
+
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val v = LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false)
@@ -23,13 +26,16 @@ class MRUPasswordItemRecyclerAdapter : RecyclerView.Adapter<MRUPasswordItemRecyc
         return mruPasswords.size
     }
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        init {
+            itemView.setOnClickListener{
+                onItemClick?.invoke(mruPasswords[absoluteAdapterPosition])
+            }
+        }
         fun bindItems(path : String) {
             val textPath = itemView.findViewById<TextView>(android.R.id.text1)
             val relativePath = path.split("store/")
-            //textPath.text = relativePath[1]
-
-            textPath.text = path
+            textPath.text = relativePath[1]
         }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
@@ -5,8 +5,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.zeapo.pwdstore.utils.MRU
 
-class MRUPasswordItemRecyclerAdapter(var mruPasswords: List<String>) : RecyclerView.Adapter<MRUPasswordItemRecyclerAdapter.ViewHolder>() {
+class MRUPasswordItemRecyclerAdapter : RecyclerView.Adapter<MRUPasswordItemRecyclerAdapter.ViewHolder>() {
+    private val mruPasswords = MRU.mRU
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val v = LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false)

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
@@ -8,9 +8,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.zeapo.pwdstore.utils.MRU
 
 class MRUPasswordItemRecyclerAdapter : RecyclerView.Adapter<MRUPasswordItemRecyclerAdapter.ViewHolder>() {
+
     private val mruPasswords = MRU.mRU
     var onItemClick: ((String) -> Unit)? = null
-
 
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -28,11 +28,12 @@ class MRUPasswordItemRecyclerAdapter : RecyclerView.Adapter<MRUPasswordItemRecyc
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         init {
-            itemView.setOnClickListener{
+            itemView.setOnClickListener {
                 onItemClick?.invoke(mruPasswords[absoluteAdapterPosition])
             }
         }
-        fun bindItems(path : String) {
+
+        fun bindItems(path: String) {
             val textPath = itemView.findViewById<TextView>(android.R.id.text1)
             val relativePath = path.split("store/")
             textPath.text = relativePath[1]

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/MRUPasswordItemRecyclerAdapter.kt
@@ -1,0 +1,33 @@
+package com.zeapo.pwdstore.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class MRUPasswordItemRecyclerAdapter(var mruPasswords: List<String>) : RecyclerView.Adapter<MRUPasswordItemRecyclerAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val v = LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false)
+        return ViewHolder(v)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bindItems(mruPasswords[position])
+    }
+
+    override fun getItemCount(): Int {
+        return mruPasswords.size
+    }
+
+    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        fun bindItems(path : String) {
+            val textPath = itemView.findViewById<TextView>(android.R.id.text1)
+            val relativePath = path.split("store/")
+            //textPath.text = relativePath[1]
+
+            textPath.text = path
+        }
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
@@ -1,0 +1,84 @@
+package com.zeapo.pwdstore.utils
+
+import android.content.SharedPreferences
+import java.util.LinkedList
+
+class MRU private constructor() : LinkedList<String>() {
+    companion object {
+
+        @JvmStatic
+        private val maxSize: Int = 5
+
+        @JvmStatic
+        private var mRU: MRU? = null
+
+        @JvmStatic
+        var settings: SharedPreferences? = null
+
+        @JvmStatic
+        fun MRUInit(settings: SharedPreferences) {
+            this.settings = settings
+        }
+
+        @JvmStatic
+        fun getInstance(): MRU? {
+            if (mRU == null) {
+                mRU = MRU()
+                for (i in 4 downTo 0) {
+                    settings!!.getString("R$i", null)?.let { mRU!!.add(it) }
+                }
+            }
+            return mRU
+        }
+
+    }
+
+    /**
+     * Function to add a new file's absolute path inside the Most Recently Used Passwords.
+     * The head of the list is the most recently used (MRU), going down to the last recently used (LRU).
+     * If list contains already the path, this will be send to the top of the list (i.e becomes the MRU)
+     * When the list contains [maxSize] elements, if new path is inserted (and it's not already in the list),
+     * the LRU will be erased.
+     */
+    override fun add(element: String): Boolean {
+        when {
+            mRU!!.contains(element) -> {
+                //remove this element from current position
+                mRU!!.remove(element)
+                //put in head
+                mRU!!.push(element)
+            }
+            mRU!!.size < maxSize -> {
+                mRU!!.push(element)
+            }
+            else -> {
+                mRU!!.removeLast()
+                mRU!!.push(element)
+            }
+        }
+        save()
+        return true
+    }
+
+    //only for testing
+    fun print() {
+        for (i in 0 until mRU!!.size) {
+            println("R$i ${mRU!![i]}")
+        }
+    }
+
+    /**
+     * Save all the recently used passwords inside sharedPreferences with key R#
+     * Where 0 is the most recently used, to [size]-1 is last recently used
+     */
+    private fun save() {
+        val editor = settings?.edit()
+
+        for (i in 0 until mRU!!.size) {
+            editor?.putString("R$i", mRU!![i])
+        }
+
+        editor?.apply()
+    }
+
+}

--- a/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
@@ -10,7 +10,7 @@ object MRU {
     var settings: SharedPreferences? = null
 
     fun mRUInit(settings: SharedPreferences) {
-        if (this.settings == null){
+        if (this.settings == null) {
             this.settings = settings
             for (i in 4 downTo 0) {
                 MRU.settings!!.getString("R$i", null)?.let { mRU.add(it) }

--- a/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/MRU.kt
@@ -3,34 +3,19 @@ package com.zeapo.pwdstore.utils
 import android.content.SharedPreferences
 import java.util.LinkedList
 
-class MRU private constructor() : LinkedList<String>() {
-    companion object {
+object MRU {
 
-        @JvmStatic
-        private val maxSize: Int = 5
+    private const val maxSize: Int = 5
+    var mRU: LinkedList<String> = LinkedList<String>()
+    var settings: SharedPreferences? = null
 
-        @JvmStatic
-        private var mRU: MRU? = null
-
-        @JvmStatic
-        var settings: SharedPreferences? = null
-
-        @JvmStatic
-        fun MRUInit(settings: SharedPreferences) {
+    fun mRUInit(settings: SharedPreferences) {
+        if (this.settings == null){
             this.settings = settings
-        }
-
-        @JvmStatic
-        fun getInstance(): MRU? {
-            if (mRU == null) {
-                mRU = MRU()
-                for (i in 4 downTo 0) {
-                    settings!!.getString("R$i", null)?.let { mRU!!.add(it) }
-                }
+            for (i in 4 downTo 0) {
+                MRU.settings!!.getString("R$i", null)?.let { mRU.add(it) }
             }
-            return mRU
         }
-
     }
 
     /**
@@ -40,20 +25,21 @@ class MRU private constructor() : LinkedList<String>() {
      * When the list contains [maxSize] elements, if new path is inserted (and it's not already in the list),
      * the LRU will be erased.
      */
-    override fun add(element: String): Boolean {
+    fun add(element: String): Boolean {
+        val test = mRU
         when {
-            mRU!!.contains(element) -> {
+            mRU.contains(element) -> {
                 //remove this element from current position
-                mRU!!.remove(element)
+                mRU.remove(element)
                 //put in head
-                mRU!!.push(element)
+                mRU.push(element)
             }
-            mRU!!.size < maxSize -> {
-                mRU!!.push(element)
+            mRU.size < maxSize -> {
+                mRU.push(element)
             }
             else -> {
-                mRU!!.removeLast()
-                mRU!!.push(element)
+                mRU.removeLast()
+                mRU.push(element)
             }
         }
         save()
@@ -62,20 +48,20 @@ class MRU private constructor() : LinkedList<String>() {
 
     //only for testing
     fun print() {
-        for (i in 0 until mRU!!.size) {
-            println("R$i ${mRU!![i]}")
+        for (i in 0 until mRU.size) {
+            println("R$i ${mRU[i]}")
         }
     }
 
     /**
      * Save all the recently used passwords inside sharedPreferences with key R#
-     * Where 0 is the most recently used, to [size]-1 is last recently used
+     * Where 0 is the most recently used, until [mRU.size] is last recently used
      */
-    private fun save() {
+    fun save() {
         val editor = settings?.edit()
 
-        for (i in 0 until mRU!!.size) {
-            editor?.putString("R$i", mRU!![i])
+        for (i in 0 until mRU.size) {
+            editor?.putString("R$i", mRU[i])
         }
 
         editor?.apply()

--- a/app/src/main/res/layout/password_recycler_view.xml
+++ b/app/src/main/res/layout/password_recycler_view.xml
@@ -18,13 +18,45 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <me.zhanghai.android.fastscroll.FixOnItemTouchListenerRecyclerView
-            android:id="@+id/pass_recycler"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbars="none"
-            tools:itemCount="20"
-            tools:listitem="@layout/password_row_layout" />
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:textAlignment="center"
+                android:text="Recently used passwords"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+
+            <me.zhanghai.android.fastscroll.FixOnItemTouchListenerRecyclerView
+                android:id="@+id/pass_mru_recycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:scrollbars="none"
+                tools:itemCount="20"
+                tools:listitem="@layout/password_row_layout" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:textAlignment="center"
+                android:text="Passwords"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+            <me.zhanghai.android.fastscroll.FixOnItemTouchListenerRecyclerView
+                android:id="@+id/pass_recycler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:scrollbars="none"
+                tools:itemCount="20"
+                tools:listitem="@layout/password_row_layout" />
+
+        </LinearLayout>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Some progress on this feature

At the moment it only has the basic function of showing the last 5 passwords that the user has selected, and it orders them according to the Most Recently Used.

It's just a sample of how it can work, I'm still not sure if to leave the "recent passwords" in the same place as the "passwords", and I don't know for the moment how to send the user to decrypt the password from this list. And there are also bugs like always showing the recent passwords even if the path is not the root. 

I also keep looking how to use `PasswordItemRecyclerAdapter` to reuse the adapter, but I think there are some features that are not needed in this case, like being able to search for them or select more than 1.

I want to know what you think about this way of organizing the passwords, and also if it's a good idea to use `PasswordItemRecyclerAdapter` or create another adapter for this case.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#535 

## :green_heart: How did you test it?
I opened some passwords and the list should of recent passwords is updated and reorganized.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
