### PR TITLE
Wrap password creation layout in ScrollView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 -   Allow sorting by recently used
 
+### Fixed
+
+-   Password creation UI will scroll if it does not fit on the screen
+
 ## [1.11.0] - 2020-08-18
 
 ### Added

--- a/app/src/main/res/layout/password_creation_activity.xml
+++ b/app/src/main/res/layout/password_creation_activity.xml
@@ -3,118 +3,125 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="@dimen/activity_horizontal_margin"
+    android:fillViewport="false"
     tools:context="com.zeapo.pwdstore.crypto.PasswordCreationActivity">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/directory_input_layout"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_margin="8dp"
-        android:enabled="false"
-        android:hint="@string/directory_hint"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:orientation="vertical"
+        android:padding="@dimen/activity_horizontal_margin">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/directory"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/directory_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionNext"
-            android:inputType="textNoSuggestions"
-            android:nextFocusForward="@id/password"
-            tools:text="CATEGORY HERE" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_gravity="center_vertical"
+            android:layout_margin="8dp"
+            android:enabled="false"
+            android:hint="@string/directory_hint"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/name_input_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:layout_margin="8dp"
-        android:hint="@string/crypto_name_hint"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/directory_input_layout">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/directory"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="textNoSuggestions"
+                android:nextFocusForward="@id/password"
+                tools:text="CATEGORY HERE" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/filename"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/name_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionNext"
-            android:inputType="textNoSuggestions"
-            android:nextFocusForward="@id/password" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_gravity="center_vertical"
+            android:layout_margin="8dp"
+            android:hint="@string/crypto_name_hint"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/directory_input_layout">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/password_input_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:hint="@string/crypto_pass_label"
-        app:endIconMode="password_toggle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/name_input_layout">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/filename"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="textNoSuggestions"
+                android:nextFocusForward="@id/password" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/password"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/password_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionDone"
-            android:inputType="textVisiblePassword" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_margin="8dp"
+            android:hint="@string/crypto_pass_label"
+            app:endIconMode="password_toggle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/name_input_layout">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/generate_password"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:text="@string/pwd_generate_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/password_input_layout" />
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:inputType="textVisiblePassword" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/extra_input_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:hint="@string/crypto_extra_label"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/generate_password">
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/generate_password"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/pwd_generate_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/password_input_layout" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/extra_content"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/extra_input_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textMultiLine|textVisiblePassword" />
+            android:layout_margin="8dp"
+            android:hint="@string/crypto_extra_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/generate_password">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/extra_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textVisiblePassword" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/otp_import_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:text="@string/add_otp"
-        app:icon="@drawable/ic_qr_code_scanner"
-        app:iconTint="?attr/colorOnSecondary"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/extra_input_layout" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/encrypt_username"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:text="@string/crypto_encrypt_username_label"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/otp_import_button"
-        tools:visibility="visible" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/otp_import_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/add_otp"
+            app:icon="@drawable/ic_qr_code_scanner"
+            app:iconTint="?attr/colorOnSecondary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/extra_input_layout" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/encrypt_username"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/crypto_encrypt_username_label"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/otp_import_button"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Previously, some of the inputs in the PasswordCreationActivity would be off-screen and inaccessible, when the screen height was reduced by rotating the device from portrait to landscape orientation or opening the on-screen keyboard, for example. The visible portion of the inputs could not be changed.

To fix this, make the PasswordCreationActivity's layout scrollable. This way, inputs that are off-screen can be brought into view by scrolling.

Especially the 'Extra content' input is way more accessible now, as it would also be off-screen previously, even when it was being focused for editing. Now, it will be automatically brought into view again after the on-screen keyboard opens.

(I am not quite sure if I should have filed a bug issue first. I am sorry if i should have... Please enlighten me, though. :))

## :bulb: Motivation and Context
This change fixes parts of the functionality of the PasswordCreationActivity. Most notably, it fixes having to edit the 'Extra content' input while it is off-screen.


## :green_heart: How did you test it?
I added a new password and edited an existing password using
- an emulated phone with 1080x1920 resolution at 420 ppi running Android 10 and
- a physical phone with 1080x2280 resolution at 432 ppi running Android 9.

I then confirmed the functionality of the UI and the newly introduced scrolling.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
n/a

## :camera_flash: Screenshots / GIFs
![Before: Editing "Extra content" (focused) in portrait mode](https://user-images.githubusercontent.com/62889203/90820932-6e806680-e332-11ea-9150-ab01f74a22f7.png)
Before: Editing "Extra content" (focused) in portrait mode
<br/><br/>
![After: Editing "Extra content" (focused) in portrait mode](https://user-images.githubusercontent.com/62889203/90820934-6f18fd00-e332-11ea-817e-6b2229f99456.png)
After: Editing "Extra content" (focused) in portrait mode
<br/><br/>
![Before: "Edit password" UI in landscape mode](https://user-images.githubusercontent.com/62889203/90820935-6fb19380-e332-11ea-97e5-5fd30c35640a.png)
Before: "Edit password" UI in landscape mode
<br/><br/>
![After: "Edit password" UI in landscape mode](https://user-images.githubusercontent.com/62889203/90820936-6fb19380-e332-11ea-8dd2-ff43919b9dce.png)
After: "Edit password" UI in landscape mode

