### PR TITLE
Autofill: add support for Bromite and Ungoogled Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   Allow sorting by recently used
--   Support for [Bromite](https://www.bromite.org/) and [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android)
+-   Add [Bromite](https://www.bromite.org/) and [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android) to supported browsers list for Autofill
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   Allow sorting by recently used
+-   Support for [Bromite](https://www.bromite.org/) and [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android)
 
 ### Fixed
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
@@ -65,6 +65,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH = mapOf(
     "com.opera.mini.native" to "V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I=",
     "com.opera.mini.native.beta" to "V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I=",
     "com.opera.touch" to "qtjiBNJNF3k0yc0MY8xqo4779CxKaVcJfiIQ9X+qZ6o=",
+    "org.bromite.bromite" to "4e5c0HbXsNyEyytF+3i4bfLrOaO2xWuj3CkqXgw7lQQ=",
     "org.gnu.icecat" to "wi2iuVvK/WYZUzd2g0Qzn9ef3kAisQURZ8U1WSMTkcM=",
     "org.mozilla.fenix" to "UAR3kIjn+YjVvFzF+HmP6/T4zQhKGypG79TI7krq8hE=",
     "org.mozilla.fenix.nightly" to "d+rEzu02r++6dheZMd1MwZWrDNVLrzVdIV57vdKOQCo=",
@@ -75,6 +76,8 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH = mapOf(
     "org.mozilla.focus" to "YgOkc7421k7jf4f6UA7bx56rkwYQq5ufpMp9XB8bT/w=",
     "org.mozilla.klar" to "YgOkc7421k7jf4f6UA7bx56rkwYQq5ufpMp9XB8bT/w=",
     "org.torproject.torbrowser" to "IAYfBF5zfGc3XBd5TP7bQ2oDzsa6y3y5+WZCIFyizsg=",
+    "org.ungoogled.chromium.stable" to "29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk=",
+    "org.ungoogled.chromium.extensions.stable" to "29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk=",
 )
 
 private fun isTrustedBrowser(context: Context, appPackage: String): Boolean {
@@ -163,6 +166,8 @@ private val FLAKY_BROWSERS = listOf(
     "com.chrome.beta",
     "com.chrome.canary",
     "com.chrome.dev",
+    "org.bromite.bromite",
+    "org.ungoogled.chromium.stable",
 )
 
 enum class BrowserAutofillSupportLevel {

--- a/app/src/main/res/xml/oreo_autofill_service.xml
+++ b/app/src/main/res/xml/oreo_autofill_service.xml
@@ -14,6 +14,7 @@
     <compatibility-package android:name="com.microsoft.emmx" />
     <compatibility-package android:name="com.opera.mini.native" />
     <compatibility-package android:name="com.opera.mini.native.beta" />
+    <compatibility-package android:name="org.bromite.bromite" />
     <compatibility-package
         android:name="org.mozilla.fennec_fdroid"
         android:maxLongVersionCode="679999" />
@@ -23,4 +24,5 @@
     <compatibility-package
         android:name="org.mozilla.firefox_beta"
         android:maxLongVersionCode="679999" />
+    <compatibility-package android:name="org.ungoogled.chromium.stable" />
 </autofill-service>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Added [Bromite](https://www.bromite.org/) (org.bromite.bromite) and [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android) (org.ungoogled.chromium.stable) to the list of autofill-able browsers.  Since these are pretty direct Chromium mods, I assume they fall into the same categories as com.android.chrome.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows more browsers to benefit from the autofill feature.

## :green_heart: How did you test it?
I don't currently have space to install the Android SDK, so I'm marking this as a draft until I have the opportunity (may be a while).  If someone could at least build an APK for testing, that would be awesome.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (:set ts=4 sw=4 et)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable