### PR TITLE
Don't use git config for setting author and email

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -14,6 +14,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.GitException.PullException
 import com.zeapo.pwdstore.git.GitException.PushException
+import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.git.sshj.SshjSessionFactory
 import com.zeapo.pwdstore.git.operation.GitOperation
 import com.zeapo.pwdstore.utils.Result
@@ -28,6 +29,7 @@ import org.eclipse.jgit.api.PullCommand
 import org.eclipse.jgit.api.PushCommand
 import org.eclipse.jgit.api.RebaseResult
 import org.eclipse.jgit.api.StatusCommand
+import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.SshSessionFactory
 
@@ -60,7 +62,9 @@ class GitCommandExecutor(
                         // the previous status will eventually be used to avoid a commit
                         if (nbChanges > 0) {
                             withContext(Dispatchers.IO) {
-                                command.call()
+                                command
+                                    .setAuthor(PersonIdent(GitSettings.authorName, GitSettings.authorEmail))
+                                    .call()
                             }
                         }
                     }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
@@ -61,8 +61,6 @@ class GitConfigActivity : BaseGitActivity() {
             } else {
                 GitSettings.authorEmail = email
                 GitSettings.authorName = name
-                PasswordRepository.setGitAuthorEmail(email)
-                PasswordRepository.setGitAuthorName(name)
                 Snackbar.make(binding.root, getString(R.string.git_server_config_save_success), Snackbar.LENGTH_SHORT).show()
                 Handler().postDelayed(500) { finish() }
             }

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -244,47 +244,5 @@ open class PasswordRepository protected constructor() {
             passwordList.sortWith(sortOrder.comparator)
             return passwordList
         }
-
-        /**
-         * Sets the git user name
-         *
-         * @param username username
-         */
-        @JvmStatic
-        fun setGitAuthorName(username: String) {
-            setStringConfig("user", null, "name", username)
-        }
-
-        /**
-         * Sets the git user email
-         *
-         * @param email email
-         */
-        @JvmStatic
-        fun setGitAuthorEmail(email: String) {
-            setStringConfig("user", null, "email", email)
-        }
-
-        /**
-         * Sets a git config value
-         *
-         * @param section config section name
-         * @param subsection config subsection name
-         * @param name config name
-         * @param value the value to be set
-         */
-        @JvmStatic
-        @Suppress("SameParameterValue")
-        private fun setStringConfig(section: String, subsection: String?, name: String, value: String) {
-            if (isInitialized) {
-                val config = repository!!.config
-                config.setString(section, subsection, name, value)
-                try {
-                    config.save()
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Stop using JGit's StoredConfig implementation and directly set author and email ourselves

## :bulb: Motivation and Context
As reported in #1038 JGit is putting this file in `$worktree/config` instead of `$worktree/.git/config` and since we persist this data anyway its simpler to always specify it from our copy of the data. This simplifies the PasswordRepository code and makes committing behavior a bit more deterministic.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
