### PR TITLE
BiometricAuthenticator: fix multiple regressions from AndroidX update

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
@@ -9,6 +9,7 @@ import android.os.Handler
 import androidx.annotation.StringRes
 import androidx.biometric.BiometricConstants
 import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
@@ -60,13 +61,15 @@ object BiometricAuthenticator {
                 callback(Result.Success(result.cryptoObject))
             }
         }
-        val biometricPrompt = BiometricPrompt(activity, { handler.post(it) }, authCallback)
-        val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(activity.getString(dialogTitleRes))
-            .build()
-        if (BiometricManager.from(activity).canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
-            == BiometricManager.BIOMETRIC_SUCCESS || activity.getSystemService<KeyguardManager>()?.isDeviceSecure == true) {
-            biometricPrompt.authenticate(promptInfo)
+        val validAuthenticators = Authenticators.DEVICE_CREDENTIAL or Authenticators.BIOMETRIC_STRONG
+        val canAuth = BiometricManager.from(activity).canAuthenticate(validAuthenticators) == BiometricManager.BIOMETRIC_SUCCESS
+        val deviceHasKeyguard = activity.getSystemService<KeyguardManager>()?.isDeviceSecure == true
+        if (canAuth || deviceHasKeyguard) {
+            val promptInfo = BiometricPrompt.PromptInfo.Builder()
+                .setTitle(activity.getString(dialogTitleRes))
+                .setAllowedAuthenticators(validAuthenticators)
+                .build()
+            BiometricPrompt(activity, { handler.post(it) }, authCallback).authenticate(promptInfo)
         } else {
             callback(Result.HardwareUnavailableOrDisabled)
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Reconfigure BiometricAuthenticator to bring back the correct set of authentication parameters and fix #1044.

## :bulb: Motivation and Context
During the AndroidX updates from #1039 I misinterpreted the `BiometricManager.Authenticators` javadoc and caused
the dialog to only use device credential authentication, which in itself is a problem, and also caused the dialog
to consistently crash. While at it I took some liberty to move things around for readability.

## :green_heart: How did you test it?
Verify biometric authentication can be enabled and used with both strong biometrics and device credentials without
crashing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
