### PR TITLE
BiometricAuthenticator: also allow Class 2 biometric implementations

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
@@ -61,7 +61,7 @@ object BiometricAuthenticator {
                 callback(Result.Success(result.cryptoObject))
             }
         }
-        val validAuthenticators = Authenticators.DEVICE_CREDENTIAL or Authenticators.BIOMETRIC_STRONG
+        val validAuthenticators = Authenticators.DEVICE_CREDENTIAL or Authenticators.BIOMETRIC_WEAK
         val canAuth = BiometricManager.from(activity).canAuthenticate(validAuthenticators) == BiometricManager.BIOMETRIC_SUCCESS
         val deviceHasKeyguard = activity.getSystemService<KeyguardManager>()?.isDeviceSecure == true
         if (canAuth || deviceHasKeyguard) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Allow Class 2 biometric clients as noted in the Android CDD to also use the biometric authentication service. Fixes #1044.

## :bulb: Motivation and Context

A ton of devices ship with weak biometrics and some like Samsung manage to break their strong auth to the point its no better than weak ones. Since `BIOMETRIC_WEAK` is a superset of `BIOMETRIC_STRONG` we can instead use `BIOMETRIC_WEAK` and also be able to use `BIOMETRIC_STRONG` on devices where its available.

## :green_heart: How did you test it?

API 29 devices no longer crash.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
