### PR TITLE
Prevent racing double commits on password creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Password creation UI will scroll if it does not fit on the screen
+-   Saving a password after creating it fails to finish commit operation
 
 ## [1.11.1] - 2020-08-21
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -440,13 +440,15 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                     returnIntent.putExtra(RETURN_EXTRA_USERNAME, username)
                                 }
 
-                                lifecycleScope.launch {
-                                    commitChange(
-                                        getString(
-                                            R.string.git_commit_edit_text,
-                                            getLongName(fullPath, repoPath, editName)
+                                if (editing) {
+                                    lifecycleScope.launch {
+                                        commitChange(
+                                            getString(
+                                                R.string.git_commit_edit_text,
+                                                getLongName(fullPath, repoPath, editName)
+                                            )
                                         )
-                                    )
+                                    }
                                 }
 
                                 if (directoryInputLayout.isVisible && directoryInputLayout.isEnabled && oldFileName != null) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Since 57f1c65fdfbac9acd5e4fce30a6d5ef131fa9728 we were commiting new password twice asynchronously, which resulted in one of the two operations failing to obtain a lock.

@msfjarvis Could you add a changelog entry?

After we have tested and included this change in a point release, we should ensure that it is always the Activity that makes a change to the filesystem that also calls `commitChange`. In this way, we can also get rid of the confusing `finish...` parameters.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1042.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
