### PR TITLE
Return HTTPS URI username from CredentialsProvider

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -57,6 +57,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
         override fun get(uri: URIish?, vararg items: CredentialItem): Boolean {
             for (item in items) {
                 when (item) {
+                    is CredentialItem.Username -> item.value = uri?.user
                     is CredentialItem.Password -> item.value = passwordFinder.reqPassword(null)
                     else -> UnsupportedCredentialItem(uri, item.javaClass.name)
                 }
@@ -65,7 +66,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
         }
 
         override fun supports(vararg items: CredentialItem) = items.all {
-            it is CredentialItem.Password
+            it is CredentialItem.Username || it is CredentialItem.Password
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Let the PasswordFinderCredentialsProvider support Username as a
CredentialItem type and return the user part of the repository URI when
it is requested.

Note that we are currently not asking the user to provide a username interactively, but rather attempt to extract it from the URL as we do for git URLs. This means that HTTPS URLs will have to be specified in the form `https://FabianHenneke@github.com/FabianHenneke/pass-test`.

If this should be deemed too confusing for users, I would propose to add another commit that asks for the username when the user attempts to save a Git config without one in the (otherwise valid) URL. @msfjarvis What do you think?
 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix #1048.

## :green_heart: How did you test it?
Checked that there now is a password prompt when connecting to a private repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Add an appropriate changelog entry.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
