### PR TITLE
Get rid of explicit Git server protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 -   A descriptive error message is shown if no username is specified in the Git server settings
+-   Remove explicit protocol choice from Git server settings, it is now inferred from your URL
 
 ### Fixed
 

--- a/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
@@ -62,7 +62,7 @@ class MigrationsTest {
         checkOldKeysAreRemoved(context)
         assertEquals(
             context.sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_URL),
-            "msfjarvis@192.168.0.102:/mnt/disk3/pass-repo"
+            "ssh://msfjarvis@192.168.0.102:22/mnt/disk3/pass-repo"
         )
     }
 

--- a/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
@@ -24,6 +24,7 @@ class MigrationsTest {
         assertNull(getString(PreferenceKeys.GIT_REMOTE_USERNAME))
         assertNull(getString(PreferenceKeys.GIT_REMOTE_SERVER))
         assertNull(getString(PreferenceKeys.GIT_REMOTE_LOCATION))
+        assertNull(getString(PreferenceKeys.GIT_REMOTE_PROTOCOL))
     }
 
     @Test

--- a/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/zeapo/pwdstore/MigrationsTest.kt
@@ -62,7 +62,7 @@ class MigrationsTest {
         checkOldKeysAreRemoved(context)
         assertEquals(
             context.sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_URL),
-            "ssh://msfjarvis@192.168.0.102:22/mnt/disk3/pass-repo"
+            "msfjarvis@192.168.0.102:/mnt/disk3/pass-repo"
         )
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
@@ -75,13 +75,12 @@ private fun migrateToGitUrlBasedConfig(context: Context) {
         remove(PreferenceKeys.GIT_REMOTE_PORT)
         remove(PreferenceKeys.GIT_REMOTE_SERVER)
         remove(PreferenceKeys.GIT_REMOTE_USERNAME)
+        remove(PreferenceKeys.GIT_REMOTE_PROTOCOL)
     }
     if (url == null || GitSettings.updateConnectionSettingsIfValid(
-            newProtocol = protocol,
             newAuthMode = GitSettings.authMode,
             newUrl = url,
             newBranch = GitSettings.branch) != GitSettings.UpdateConnectionSettingsResult.Valid) {
         e { "Failed to migrate to URL-based Git config, generated URL is invalid" }
     }
 }
-

--- a/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
@@ -30,13 +30,24 @@ private fun migrateToGitUrlBasedConfig(context: Context) {
     val serverPath = context.sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_LOCATION) ?: ""
     val protocol = Protocol.fromString(context.sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_PROTOCOL))
 
+    // Whether we need the leading ssh:// depends on the use of a custom port.
     val hostnamePart = serverHostname.removePrefix("ssh://")
     val url = when (protocol) {
         Protocol.Ssh -> {
-            val portPart = if (serverPort.isEmpty()) "22" else serverPort
             val userPart = if (serverUser.isEmpty()) "" else "${serverUser.trimEnd('@')}@"
-            val serverPart = if (serverPath.startsWith('/')) serverPath else "/$serverPath"
-            "ssh://$userPart$hostnamePart:$portPart$serverPart"
+            val portPart =
+                if (serverPort == "22" || serverPort.isEmpty()) "" else ":$serverPort"
+            if (portPart.isEmpty()) {
+                "$userPart$hostnamePart:$serverPath"
+            } else {
+                // Only absolute paths are supported with custom ports.
+                if (!serverPath.startsWith('/'))
+                    null
+                else
+                    // We have to specify the ssh scheme as this is the only way to pass a custom
+                    // port.
+                    "ssh://$userPart$hostnamePart$portPart$serverPath"
+            }
         }
         Protocol.Https -> {
             val portPart =

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -96,7 +96,7 @@ class GitServerConfigActivity : BaseGitActivity() {
                     val message = getString(
                         R.string.git_server_config_save_auth_mode_mismatch,
                         updateResult.newProtocol,
-                        updateResult.validModes.joinToString(", ") { it.pref },
+                        updateResult.validModes.joinToString(", "),
                     )
                     Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
                 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -98,7 +98,10 @@ class GitServerConfigActivity : BaseGitActivity() {
                         Protocol.Ssh -> Snackbar.make(binding.root, getString(R.string.git_server_config_save_missing_username_ssh), Snackbar.LENGTH_LONG).show()
                     }
                 }
-                else -> {
+                GitSettings.UpdateConnectionSettingsResult.ProtocolMismatch -> {
+                    Snackbar.make(binding.root, getString(R.string.git_server_config_save_protocol_mismatch), Snackbar.LENGTH_LONG).show()
+                }
+                GitSettings.UpdateConnectionSettingsResult.Valid -> {
                     if (isClone && PasswordRepository.getRepository(null) == null)
                         PasswordRepository.initialize()
                     if (!isClone) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -79,9 +79,6 @@ class GitServerConfigActivity : BaseGitActivity() {
                         Protocol.Ssh -> Snackbar.make(binding.root, getString(R.string.git_server_config_save_missing_username_ssh), Snackbar.LENGTH_LONG).show()
                     }
                 }
-                GitSettings.UpdateConnectionSettingsResult.ProtocolMismatch -> {
-                    Snackbar.make(binding.root, getString(R.string.git_server_config_save_protocol_mismatch), Snackbar.LENGTH_LONG).show()
-                }
                 GitSettings.UpdateConnectionSettingsResult.Valid -> {
                     if (isClone && PasswordRepository.getRepository(null) == null)
                         PasswordRepository.initialize()

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
@@ -53,13 +53,6 @@ object GitSettings {
     private val settings by lazy { Application.instance.sharedPrefs }
     private val encryptedSettings by lazy { Application.instance.getEncryptedPrefs("git_operation") }
 
-    var protocol
-        get() = Protocol.fromString(settings.getString(PreferenceKeys.GIT_REMOTE_PROTOCOL))
-        private set(value) {
-            settings.edit {
-                putString(PreferenceKeys.GIT_REMOTE_PROTOCOL, value.pref)
-            }
-        }
     var authMode
         get() = AuthMode.fromString(settings.getString(PreferenceKeys.GIT_REMOTE_AUTH))
         private set(value) {
@@ -104,28 +97,40 @@ object GitSettings {
             }
         }
 
-    enum class UpdateConnectionSettingsResult {
-        Valid,
-        FailedToParseUrl,
-        MissingUsername,
-        ProtocolMismatch,
+    sealed class UpdateConnectionSettingsResult {
+        class MissingUsername(val newProtocol: Protocol) : UpdateConnectionSettingsResult()
+        class AuthModeMismatch(val newProtocol: Protocol, val validModes: List<AuthMode>) : UpdateConnectionSettingsResult()
+        object Valid : UpdateConnectionSettingsResult()
+        object FailedToParseUrl : UpdateConnectionSettingsResult()
+        object ProtocolMismatch : UpdateConnectionSettingsResult()
     }
 
-    fun updateConnectionSettingsIfValid(newProtocol: Protocol, newAuthMode: AuthMode, newUrl: String, newBranch: String): UpdateConnectionSettingsResult {
+    fun updateConnectionSettingsIfValid(newAuthMode: AuthMode, newUrl: String, newBranch: String): UpdateConnectionSettingsResult {
         val parsedUrl = try {
             URIish(newUrl)
         } catch (_: Exception) {
             return UpdateConnectionSettingsResult.FailedToParseUrl
         }
+        val newProtocol = when (parsedUrl.scheme) {
+            in listOf("http", "https") -> Protocol.Https
+            in listOf("ssh") -> Protocol.Ssh
+            else -> return UpdateConnectionSettingsResult.FailedToParseUrl
+        }
         if (newAuthMode != AuthMode.None && parsedUrl.user.isNullOrBlank())
-            return UpdateConnectionSettingsResult.MissingUsername
-        when (newProtocol) {
-            Protocol.Https -> if (parsedUrl.scheme !in listOf("http", "https")) return UpdateConnectionSettingsResult.ProtocolMismatch
-            Protocol.Ssh -> if (parsedUrl.scheme !in listOf(null, "git")) return UpdateConnectionSettingsResult.ProtocolMismatch
+            return UpdateConnectionSettingsResult.MissingUsername(newProtocol)
+
+        val validHttpsAuth = listOf(AuthMode.None, AuthMode.Password)
+        val validSshAuth = listOf(AuthMode.OpenKeychain, AuthMode.Password, AuthMode.SshKey)
+        when {
+            newProtocol == Protocol.Https && newAuthMode !in validHttpsAuth -> {
+                return UpdateConnectionSettingsResult.AuthModeMismatch(newProtocol, validHttpsAuth)
+            }
+            newProtocol == Protocol.Ssh && newAuthMode !in validSshAuth -> {
+                return UpdateConnectionSettingsResult.AuthModeMismatch(newProtocol, validSshAuth)
+            }
         }
 
         url = newUrl
-        protocol = newProtocol
         authMode = newAuthMode
         branch = newBranch
         return UpdateConnectionSettingsResult.Valid

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
@@ -112,7 +112,7 @@ object GitSettings {
         }
         val newProtocol = when (parsedUrl.scheme) {
             in listOf("http", "https") -> Protocol.Https
-            in listOf("ssh") -> Protocol.Ssh
+            in listOf("ssh", null) -> Protocol.Ssh
             else -> return UpdateConnectionSettingsResult.FailedToParseUrl
         }
         if (newAuthMode != AuthMode.None && parsedUrl.user.isNullOrBlank())

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
@@ -108,6 +108,7 @@ object GitSettings {
         Valid,
         FailedToParseUrl,
         MissingUsername,
+        ProtocolMismatch,
     }
 
     fun updateConnectionSettingsIfValid(newProtocol: Protocol, newAuthMode: AuthMode, newUrl: String, newBranch: String): UpdateConnectionSettingsResult {
@@ -118,6 +119,10 @@ object GitSettings {
         }
         if (newAuthMode != AuthMode.None && parsedUrl.user.isNullOrBlank())
             return UpdateConnectionSettingsResult.MissingUsername
+        when (newProtocol) {
+            Protocol.Https -> if (parsedUrl.scheme !in listOf("http", "https")) return UpdateConnectionSettingsResult.ProtocolMismatch
+            Protocol.Ssh -> if (parsedUrl.scheme !in listOf(null, "git")) return UpdateConnectionSettingsResult.ProtocolMismatch
+        }
 
         url = newUrl
         protocol = newProtocol

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
@@ -102,7 +102,6 @@ object GitSettings {
         class AuthModeMismatch(val newProtocol: Protocol, val validModes: List<AuthMode>) : UpdateConnectionSettingsResult()
         object Valid : UpdateConnectionSettingsResult()
         object FailedToParseUrl : UpdateConnectionSettingsResult()
-        object ProtocolMismatch : UpdateConnectionSettingsResult()
     }
 
     fun updateConnectionSettingsIfValid(newAuthMode: AuthMode, newUrl: String, newBranch: String): UpdateConnectionSettingsResult {

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
@@ -32,6 +32,7 @@ object PreferenceKeys {
     const val GIT_REMOTE_LOCATION = "git_remote_location"
     @Deprecated("Use GIT_REMOTE_URL instead")
     const val GIT_REMOTE_PORT = "git_remote_port"
+    @Deprecated("Use GIT_REMOTE_URL instead")
     const val GIT_REMOTE_PROTOCOL = "git_remote_protocol"
     const val GIT_DELETE_REPO = "git_delete_repo"
     @Deprecated("Use GIT_REMOTE_URL instead")

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -29,42 +29,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/label_server_protocol"
-            style="@style/TextAppearance.MaterialComponents.Headline6"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/server_protocol"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/server_label" />
-
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/protocol_group"
-            style="@style/TextAppearance.MaterialComponents.Headline1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_server_protocol"
-            app:selectionRequired="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/protocol_ssh"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clone_protocol_ssh" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/protocol_https"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clone_protocol_https" />
-        </com.google.android.material.button.MaterialButtonToggleGroup>
-
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/label_server_url"
             android:layout_width="0dp"
@@ -73,7 +37,7 @@
             android:hint="@string/server_url"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/protocol_group">
+            app:layout_constraintTop_toBottomOf="@id/server_label">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/server_url"
@@ -105,7 +69,43 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/label_connection_mode"
+            android:id="@+id/label_server_protocol"
+            style="@style/TextAppearance.MaterialComponents.Headline6"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/server_protocol"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_server_branch" />
+
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/protocol_group"
+            style="@style/TextAppearance.MaterialComponents.Headline1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_server_protocol"
+            app:selectionRequired="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/protocol_ssh"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/clone_protocol_ssh" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/protocol_https"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/clone_protocol_https" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/label_auth_mode"
             style="@style/TextAppearance.MaterialComponents.Headline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -114,7 +114,7 @@
             android:layout_marginBottom="16dp"
             android:text="@string/connection_mode"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_server_branch" />
+            app:layout_constraintTop_toBottomOf="@id/protocol_group" />
 
         <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/auth_mode_group"
@@ -123,7 +123,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_connection_mode"
+            app:layout_constraintTop_toBottomOf="@id/label_auth_mode"
             app:singleSelection="true">
 
             <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -44,8 +44,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:imeOptions="actionNext"
-                android:nextFocusForward="@id/server_branch"
-                android:inputType="textWebEmailAddress" />
+                android:inputType="textWebEmailAddress"
+                android:nextFocusForward="@id/server_branch" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -55,54 +55,18 @@
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:hint="@string/server_branch"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/label_server_url">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/server_branch"
-                android:imeOptions="actionDone"
                 android:layout_width="match_parent"
-                android:inputType="textNoSuggestions"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:inputType="textNoSuggestions" />
 
         </com.google.android.material.textfield.TextInputLayout>
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/label_server_protocol"
-            style="@style/TextAppearance.MaterialComponents.Headline6"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:text="@string/server_protocol"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_server_branch" />
-
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/protocol_group"
-            style="@style/TextAppearance.MaterialComponents.Headline1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_server_protocol"
-            app:selectionRequired="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/protocol_ssh"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clone_protocol_ssh" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/protocol_https"
-                style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clone_protocol_https" />
-        </com.google.android.material.button.MaterialButtonToggleGroup>
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/label_auth_mode"
@@ -114,7 +78,7 @@
             android:layout_marginBottom="16dp"
             android:text="@string/connection_mode"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/protocol_group" />
+            app:layout_constraintTop_toBottomOf="@id/label_server_branch" />
 
         <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/auth_mode_group"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <string name="git_server_config_save_missing_username_https">Please specify the HTTPS username in the form https://username@example.com/…</string>
     <string name="git_server_config_save_missing_username_ssh">Please specify the SSH username in the form username@example.com:…</string>
     <string name="git_server_config_save_protocol_mismatch">The provided repository URL\'s scheme does not match the selected protocol</string>
+    <string name="git_server_config_save_auth_mode_mismatch">Valid authentication modes for %1$s: %2$s</string>
     <string name="git_config_error_hostname_empty">empty hostname</string>
     <string name="git_config_error_generic">please verify your settings and try again</string>
     <string name="git_config_error_nonnumeric_port">port must be numeric</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,7 +330,6 @@
     <string name="git_server_config_save_error">The provided repository URL is not valid</string>
     <string name="git_server_config_save_missing_username_https">Please specify the HTTPS username in the form https://username@example.com/…</string>
     <string name="git_server_config_save_missing_username_ssh">Please specify the SSH username in the form username@example.com:…</string>
-    <string name="git_server_config_save_protocol_mismatch">The provided repository URL\'s scheme does not match the selected protocol</string>
     <string name="git_server_config_save_auth_mode_mismatch">Valid authentication modes for %1$s: %2$s</string>
     <string name="git_config_error_hostname_empty">empty hostname</string>
     <string name="git_config_error_generic">please verify your settings and try again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,7 @@
     <string name="git_server_config_save_error">The provided repository URL is not valid</string>
     <string name="git_server_config_save_missing_username_https">Please specify the HTTPS username in the form https://username@example.com/…</string>
     <string name="git_server_config_save_missing_username_ssh">Please specify the SSH username in the form username@example.com:…</string>
+    <string name="git_server_config_save_protocol_mismatch">The provided repository URL\'s scheme does not match the selected protocol</string>
     <string name="git_config_error_hostname_empty">empty hostname</string>
     <string name="git_config_error_generic">please verify your settings and try again</string>
     <string name="git_config_error_nonnumeric_port">port must be numeric</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
~~Ensure that the Git server protocol is not at odds with the URL scheme.~~
    
~~Also move the Protocol switches below the URL to make it clear that the URL should be entered first.~~

~~@msfjarvis We could get rid of the protocol switch alltogether and just extract that information from the URL. I just don't know whether combined with the auth mode choice this wouldn't make the UI more confusing for users.~~
Get rid of the explicit Git server protocol choice which is implicitly available from the repository URL.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
