### PR TITLE
Delete HTTPS instead of SSH key password on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 -   Password creation UI will scroll if it does not fit on the screen
 -   Git server protocol and authentication mode are only updated when explicitly saved
+-   Delete stored HTTPS password on connection errors (such as failed authentication)
 
 ## [1.11.2] - 2020-08-24
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -151,7 +151,7 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
     open fun onError(err: Exception) {
         // Clear various auth related fields on failure
         callingActivity.getEncryptedPrefs("git_operation").edit {
-            remove(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE)
+            remove(PreferenceKeys.HTTPS_PASSWORD)
         }
         callingActivity.sharedPrefs.edit { remove(PreferenceKeys.SSH_OPENKEYSTORE_KEYID) }
         d(err)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Since #995 (more specifically [this line](https://github.com/android-password-store/Android-Password-Store/pull/995/files#diff-dd33817c7095cf708bd0f776626e3738L160)), we are removing the SSH key passphrase instead of the HTTPS password. This is just plain wrong and appears to have slipped in during a merge.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Verified that the stored HTTPS password is removed when it causes an error due to failed authentication.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
