### PR TITLE
Do not return stored password on first retry

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/CredentialFinder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/CredentialFinder.kt
@@ -48,9 +48,9 @@ class CredentialFinder(
             }
             else -> throw IllegalStateException("Only SshKey and Password connection mode ask for passwords")
         }
-        val storedCredential = gitOperationPrefs.getString(credentialPref, null)
         if (isRetry)
             gitOperationPrefs.edit { remove(credentialPref) }
+        val storedCredential = gitOperationPrefs.getString(credentialPref, null)
         if (storedCredential == null) {
             val layoutInflater = LayoutInflater.from(callingActivity)
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Do not return the stored password when asked for a retry.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are currently returning an incorrect stored password even though we know it's incorrect and should really ask the user for a new entry.
This issue has been present for a few stable versions now, but only becomes relevant when using HTTPS authentication with servers that return a `WWW-Authenticate` header on failed authentication attempts. Gitea doesn't do this, I don't know who does, so it's not clear whether we should backport this or not.

Note that this never affects SSH passphrases since we get infinite retries there and this just eats up a single one.

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
