### PR TITLE
Remember HTTPS password throughout a sync operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 -   Password creation UI will scroll if it does not fit on the screen
 -   Git server protocol and authentication mode are only updated when explicitly saved
+-   Remember HTTPS password during a sync operation
 
 ## [1.11.2] - 2020-08-24
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Remember the HTTPS password throughout a sync operation.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current state could be viewed as having just a UI issue (the second prompt is marked with the "Wrong passphrase" error), but since it counts as a retry in our `PasswordFinder` implementation, this also removes the stored passphrase, which is a bit more of a nuisance. I'm labeling this as backport for that reason, but am not a 100% sure.

## :green_heart: How did you test it?
Sync operations succeed with only a single password prompt.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
