### PR TITLE
Prepare v1.11.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.11.3] - 2020-08-27
+
 ### Fixed
 
 -   Delete stored HTTPS password on connection errors (such as failed authentication)
@@ -315,7 +317,9 @@ All notable changes to this project will be documented in this file.
 
 -   Fix elements overlapping.
 
-[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/1.11.2...HEAD
+[Unreleased]: https://github.com/android-password-store/Android-Password-Store/compare/1.11.3...HEAD
+
+[1.11.3]: https://github.com/android-password-store/Android-Password-Store/compare/1.11.2...1.11.3
 
 [1.11.2]: https://github.com/android-password-store/Android-Password-Store/compare/1.11.1...1.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+-   Delete stored HTTPS password on connection errors (such as failed authentication)
+
 ## [1.11.2] - 2020-08-24
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,6 @@ android {
     flavorDimensions("free")
     productFlavors {
         create("free") {
-            versionNameSuffix = "-free"
         }
         create("nonFree") {
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
 
     defaultConfig {
         applicationId = "dev.msfjarvis.aps"
-        versionCode = 11120
-        versionName = "1.11.2"
+        versionCode = 11130
+        versionName = "1.11.3"
     }
 
     lintOptions {

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -51,7 +51,9 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
     protected val git = Git(repository)
     protected val remoteBranch = GitSettings.branch
 
-    private class PasswordFinderCredentialsProvider(private val passwordFinder: PasswordFinder) : CredentialsProvider() {
+    private class HttpsCredentialsProvider(private val passwordFinder: PasswordFinder) : CredentialsProvider() {
+
+        private var cachedPassword: CharArray? = null
 
         override fun isInteractive() = true
 
@@ -59,7 +61,11 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
             for (item in items) {
                 when (item) {
                     is CredentialItem.Username -> item.value = uri?.user
-                    is CredentialItem.Password -> item.value = passwordFinder.reqPassword(null)
+                    is CredentialItem.Password -> {
+                        item.value = cachedPassword?.clone() ?: passwordFinder.reqPassword(null).also {
+                            cachedPassword = it.clone()
+                        }
+                    }
                     else -> UnsupportedCredentialItem(uri, item.javaClass.name)
                 }
             }
@@ -69,12 +75,17 @@ abstract class GitOperation(gitDir: File, internal val callingActivity: Fragment
         override fun supports(vararg items: CredentialItem) = items.all {
             it is CredentialItem.Username || it is CredentialItem.Password
         }
+
+        override fun reset(uri: URIish?) {
+            cachedPassword?.fill(0.toChar())
+            cachedPassword = null
+        }
     }
 
     private fun withPasswordAuthentication(passwordFinder: InteractivePasswordFinder): GitOperation {
         val sessionFactory = SshjSessionFactory(SshAuthData.Password(passwordFinder), hostKeyFile)
         SshSessionFactory.setInstance(sessionFactory)
-        this.provider = PasswordFinderCredentialsProvider(passwordFinder)
+        this.provider = HttpsCredentialsProvider(passwordFinder)
         return this
     }
 


### PR DESCRIPTION
Backports #1062, strips the `-free` version suffix.
