### PR TITLE
github: update workflows to use peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -30,18 +30,10 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email noreply@github.com
 
-      - name: Commit changelog
-        run: |
-          git add CHANGELOG.md
-          git commit --message "Prepare release ${{ env.RELEASE_VERSION }}"
-
-      - name: Push new branch
-        run: git push origin release-${{ env.RELEASE_VERSION }}
-
-      - name: Create pull request
-        uses: thomaseizinger/create-pull-request@1.0.0
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          head: release-${{ env.RELEASE_VERSION }}
+          commit-message: "Prepare release ${{ env.RELEASE_VERSION }}"
+          branch: release-${{ env.RELEASE_VERSION }}
           base: release
           title: Release ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -21,19 +21,12 @@ jobs:
       - name: Compare list changes
         run: if [[ $(git diff --binary --stat) != '' ]]; then echo "::set-env name=UPDATED::true"; fi
 
-      - name: Commit changes
-        if: env.UPDATED == 'true'
-        run: |
-          git checkout -b bot/update-psl
-          git add app/src/main/assets/publicsuffixes
-          git commit --message "Update Public Suffix List data"
-
-      - name: Create update PR
-        uses: thomaseizinger/create-pull-request@1.0.0
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
         if: env.UPDATED == 'true'
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          head: bot/update-psl
+          commit-message: Update Public Suffix List data
+          branch: bot/update-psl
           base: develop
           title: 'Update Public Suffix List data'
-          body: 'Updates Public Suffix List from https://publicsuffix.org/list/'
+          assignees: msfjarvis


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Updates workflows to use `peter-evans/create-pull-request@v3` for creating pull requests.

## :bulb: Motivation and Context

The Action we were previously using has been consistently failing us for months and I find
this a much higher quality option that actually respects semver.

## :green_heart: How did you test it?

https://github.com/msfjarvis/Android-Password-Store/pull/3

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
