### PR TITLE
Prevent double tap events during password selection

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -40,7 +40,7 @@ object Dependencies {
         const val material = "com.google.android.material:material:1.3.0-alpha02"
         const val preference = "androidx.preference:preference:1.1.1"
         const val recycler_view = "androidx.recyclerview:recyclerview:1.2.0-alpha05"
-        const val recycler_view_selection = "androidx.recyclerview:recyclerview-selection:1.1.0-rc01"
+        const val recycler_view_selection = "androidx.recyclerview:recyclerview-selection:1.1.0-rc02"
         const val security = "androidx.security:security-crypto:1.1.0-alpha02"
         const val swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01"
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
The upstream bug that led to failed selections of password items right under each other when tapped in quick succession has now been fixed.

I would have said that this is too minor to warrant inclusion in the changelog, but am open to add it anyway.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Selection works much better now.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
