### PR TITLE
Remove BaseGitActivity's onOptionsItemSelected override

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -4,7 +4,6 @@
  */
 package com.zeapo.pwdstore.git
 
-import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import com.github.ajalt.timberkt.Timber.tag
@@ -34,16 +33,6 @@ import net.schmizz.sshj.userauth.UserAuthException
  * tasks and makes sense to be held here.
  */
 abstract class BaseGitActivity : AppCompatActivity() {
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                finish()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
 
     /**
      * Attempt to launch the requested Git operation.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Stop overriding menu item behavior from BaseGitActivity

## :bulb: Motivation and Context
All inheriting classes should be allowed to handle their own navigation

## :green_heart: How did you test it?
Verified I can navigate in password list with both the software back button as well as the toolbar back button

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
