### PR TITLE
Add migration to new SshKey backend

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
@@ -101,14 +101,16 @@ private fun migrateToHideAll(context: Context) {
 
 private fun migrateToSshKey(context: Context) {
     val privateKeyFile = File(context.filesDir, ".ssh_key")
-    if (!SshKey.exists && privateKeyFile.exists()) {
+    if (context.sharedPrefs.contains(PreferenceKeys.USE_GENERATED_KEY) &&
+        !SshKey.exists &&
+        privateKeyFile.exists()) {
         // Currently uses a private key imported or generated with an old version of Password Store.
         // Generated keys come with a public key which the user should still be able to view after
         // the migration (not possible for regular imported keys), hence the special case.
-        val isLegacyGeneratedKey = context.sharedPrefs.getBoolean("use_generated_key", false)
-        SshKey.import(DocumentFile.fromFile(privateKeyFile).uri, isLegacyGeneratedKey)
+        val isGeneratedKey = context.sharedPrefs.getBoolean(PreferenceKeys.USE_GENERATED_KEY, false)
+        SshKey.useLegacyKey(isGeneratedKey)
         context.sharedPrefs.edit {
-            remove("use_generated_key")
+            remove(PreferenceKeys.USE_GENERATED_KEY)
         }
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/Migrations.kt
@@ -8,7 +8,6 @@ package com.zeapo.pwdstore
 
 import android.content.Context
 import androidx.core.content.edit
-import androidx.documentfile.provider.DocumentFile
 import com.github.ajalt.timberkt.e
 import com.github.ajalt.timberkt.i
 import com.zeapo.pwdstore.git.config.GitSettings

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -46,7 +46,6 @@ import com.zeapo.pwdstore.crypto.BasePgpActivity.Companion.getLongName
 import com.zeapo.pwdstore.crypto.DecryptActivity
 import com.zeapo.pwdstore.crypto.PasswordCreationActivity
 import com.zeapo.pwdstore.git.BaseGitActivity
-import com.zeapo.pwdstore.git.GitServerConfigActivity
 import com.zeapo.pwdstore.git.config.AuthMode
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.ui.dialogs.FolderCreationDialogFragment
@@ -87,12 +86,6 @@ class PasswordStore : BaseGitActivity() {
 
     private val model: SearchableRepositoryViewModel by viewModels {
         ViewModelProvider.AndroidViewModelFactory(application)
-    }
-
-    private val listRefreshAction = registerForActivityResult(StartActivityForResult()) { result ->
-        if (result.resultCode == RESULT_OK) {
-            refreshPasswordList()
-        }
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -10,8 +10,8 @@ import com.github.ajalt.timberkt.Timber.tag
 import com.github.ajalt.timberkt.d
 import com.github.ajalt.timberkt.e
 import com.github.michaelbull.result.Err
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.github.michaelbull.result.Result
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.git.operation.BreakOutOfDetached

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -7,6 +7,7 @@ package com.zeapo.pwdstore.git
 
 import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
+import com.github.michaelbull.result.Result
 import com.google.android.material.snackbar.Snackbar
 import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.GitException.PullException
@@ -14,7 +15,6 @@ import com.zeapo.pwdstore.git.GitException.PushException
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.git.operation.GitOperation
 import com.zeapo.pwdstore.utils.snackbar
-import com.github.michaelbull.result.Result
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.CommitCommand

--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshKey.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshKey.kt
@@ -172,7 +172,7 @@ object SshKey {
         type = null
     }
 
-    fun import(uri: Uri, isLegacyGeneratedKey: Boolean = false) {
+    fun import(uri: Uri) {
         // First check whether the content at uri is likely an SSH private key.
         val fileSize = context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
             ?.use { cursor ->
@@ -203,7 +203,12 @@ object SshKey {
         // Canonicalize line endings to '\n'.
         privateKeyFile.writeText(lines.joinToString("\n"))
 
-        type = if (isLegacyGeneratedKey) Type.LegacyGenerated else Type.Imported
+        type = Type.Imported
+    }
+
+    @Deprecated("To be used only in Migrations.kt")
+    fun useLegacyKey(isGenerated: Boolean) {
+        type = if (isGenerated) Type.LegacyGenerated else Type.Imported
     }
 
     @Suppress("BlockingMethodInNonBlockingContext")

--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshKey.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshKey.kt
@@ -128,6 +128,7 @@ object SshKey {
         Imported("imported"),
         KeystoreNative("keystore_native"),
         KeystoreWrappedEd25519("keystore_wrapped_ed25519"),
+
         // Behaves like `Imported`, but allows to view the public key.
         LegacyGenerated("legacy_generated"),
         ;

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -178,7 +178,7 @@ open class PasswordRepository protected constructor() {
             val dir = getRepositoryDirectory()
             // uninitialize the repo if the dir does not exist or is absolutely empty
             settings.edit {
-                if (!dir.exists() || !dir.isDirectory || dir.listFiles()?.isEmpty() == true) {
+                if (!dir.exists() || !dir.isDirectory || requireNotNull(dir.listFiles()).isEmpty()) {
                     putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)
                 } else {
                     putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true)

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
@@ -76,4 +76,7 @@ object PreferenceKeys {
     const val SSH_OPENKEYSTORE_CLEAR_KEY_ID = "ssh_openkeystore_clear_keyid"
     const val SSH_OPENKEYSTORE_KEYID = "ssh_openkeystore_keyid"
     const val SSH_SEE_KEY = "ssh_see_key"
+
+    @Deprecated("To be used only in Migrations.kt")
+    const val USE_GENERATED_KEY = "use_generated_key"
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Adds a migration path from legacy generated/imported keys to the new centrally managed `SshKey`.

Imported keys can be reimported, generated keys require special casing as users should still be able to see the public key.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/android-password-store/Android-Password-Store/pull/1070#issuecomment-686944260.

## :green_heart: How did you test it?
Not yet

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
