### PR TITLE
Assorted UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 -   Git server protocol and authentication mode are only updated when explicitly saved
 -   Remember HTTPS password during a sync operation
+-   Unable to use show/hide password option for password/passphrase after first attempt was wrong
 
 ## [1.11.3] - 2020-08-27
 

--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -81,6 +81,10 @@ class OnboardingActivity : AppCompatActivity() {
         }
     }
 
+    override fun onBackPressed() {
+        finishAffinity()
+    }
+
     /**
      * Clones a remote Git repository to the app's private directory
      */

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/CredentialFinder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/CredentialFinder.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import androidx.annotation.StringRes
 import androidx.core.content.edit
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -61,8 +62,11 @@ class CredentialFinder(
             editCredential.setHint(hintRes)
             val rememberCredential = dialogView.findViewById<MaterialCheckBox>(R.id.git_auth_remember_credential)
             rememberCredential.setText(rememberRes)
-            if (isRetry)
+            if (isRetry) {
                 credentialLayout.error = callingActivity.resources.getString(errorRes)
+                // Reset error when user starts entering a password
+                editCredential.doOnTextChanged { _, _, _, _ -> credentialLayout.error = null }
+            }
             MaterialAlertDialogBuilder(callingActivity).run {
                 setTitle(R.string.passphrase_dialog_title)
                 setMessage(messageRes)

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -176,6 +176,9 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
                 }
             } else {
                 onMissingSshKeyFile()
+                // This would correctly cancel the operation but won't surface a user-visible
+                // error, allowing users to make the SSH key selection.
+                return Err(SSHException(DisconnectReason.AUTH_CANCELLED_BY_USER))
             }
             AuthMode.OpenKeychain -> registerAuthProviders(SshAuthData.OpenKeychain(callingActivity))
             AuthMode.Password -> {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Contains three fixes for separate UX problems

## :bulb: Motivation and Context

- CredentialFinder: allow seeing password when retrying

This change resets the error field when the user starts typing a password/passphrase during a retry, so that the show/hide toggle is visible again.

- GitOperation: bail out early when SSH key is missing

Currently we do not interrupt the execution flow in `executeAfterAuthentication` if a SSH key is missing which causes the operation to error out before the user can actually generate or import one. This fixes that by returning a cancellation error that is silently swallowed by the default error handler and allows the user to continue.

- OnboardingActivity: finish all activities in onBackPressed

When `onBackPressed` is invoked in `OnboardingActivity`, it will `finish` and return to `PasswordStore`, which will then detect that a repository has not been created yet and start `OnboardingActivity` once again, creating an infinite loop. This change mitigates that problem by finishing all open activities when `onBackPressed` is called in `OnboardingActivity`.


## :green_heart: How did you test it?

Manually verified all changes work as documented here

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
