### PR TITLE
DecryptActivity: properly calculate remaining OTP time on first pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 -   Git server protocol and authentication mode are only updated when explicitly saved
 -   Remember HTTPS password during a sync operation
 -   Unable to use show/hide password option for password/passphrase after first attempt was wrong
+-   TOTP values shown might some times be stale and considered invalid by sites
 
 ## [1.11.3] - 2020-08-27
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
@@ -194,6 +194,13 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
                                             )
                                         }
                                         launch(Dispatchers.IO) {
+                                            // Calculate the actual remaining time for the first pass
+                                            // then return to the standard 30 second affair.
+                                            val remainingTime = entry.totpPeriod - (System.currentTimeMillis() % entry.totpPeriod)
+                                            withContext(Dispatchers.Main) {
+                                                otpText.setText(entry.calculateTotpCode() ?: "Error")
+                                            }
+                                            delay(remainingTime.seconds)
                                             repeat(Int.MAX_VALUE) {
                                                 val code = entry.calculateTotpCode() ?: "Error"
                                                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Calculate first TOTP delay manually

## :bulb: Motivation and Context
We default to 30 seconds for each recalculation but the first run might not have 30 seconds left in its period, making the value go stale much earlier. While most websites offer another 30 seconds of validity for TOTP codes, many do not, thus making it hard to enter a correct OTP. This change corrects the period for the first value to correctly be calculated from the current time and interval so that we don't keep a stale value on screen.

## :green_heart: How did you test it?

- Verified calculated delay never breaches 30 seconds
- Verified that the value is recalculated in the number of seconds that were calculated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
