### PR TITLE
PasswordRepository: add custom FS factory for symlink capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 -   Remember HTTPS password during a sync operation
 -   Unable to use show/hide password option for password/passphrase after first attempt was wrong
 -   TOTP values shown might some times be stale and considered invalid by sites
+-   Symlinks are no longer clobbered by the app (only available on Android 8 and above)
 
 ## [1.11.3] - 2020-08-27
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Adds a custom FS factory for optional symlink support on Android 8 and above.

## :bulb: Motivation and Context
Fixes #636

## :green_heart: How did you test it?
Verified app doesn't crash on API 23 and correctly resolves symlinks on API 30.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
