### PR TITLE
Fix behavior on failing Git operations

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -110,7 +110,11 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
                                 binding.swipeRefresher.isRefreshing = false
                                 refreshPasswordList()
                             },
-                            failure = ::finishAfterPromptOnErrorHandler,
+                            failure = { err ->
+                                promptOnErrorHandler(err) {
+                                    binding.swipeRefresher.isRefreshing = false
+                                }
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -315,7 +315,7 @@ class PasswordStore : BaseGitActivity() {
     private fun runGitOperation(operation: Int) = lifecycleScope.launch {
         launchGitOperation(operation).fold(
             success = { refreshPasswordList() },
-            failure = ::finishAfterPromptOnErrorHandler,
+            failure = ::promptOnErrorHandler
         )
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -61,7 +61,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
         finish()
     }
 
-    fun finishAfterPromptOnErrorHandler(err: Throwable) {
+    fun promptOnErrorHandler(err: Throwable, onPromptDone: () -> Unit = {}) {
         val error = rootCauseException(err)
         if (!isExplicitlyUserInitiatedError(error)) {
             getEncryptedPrefs("git_operation").edit {
@@ -69,12 +69,17 @@ abstract class BaseGitActivity : AppCompatActivity() {
             }
             sharedPrefs.edit { remove(PreferenceKeys.SSH_OPENKEYSTORE_KEYID) }
             d(error)
-            MaterialAlertDialogBuilder(this)
-                .setTitle(resources.getString(R.string.jgit_error_dialog_title))
-                .setMessage(ErrorMessages[error])
-                .setPositiveButton(resources.getString(R.string.dialog_ok)) { _, _ ->
-                    finish()
-                }.show()
+            MaterialAlertDialogBuilder(this).run {
+                setTitle(resources.getString(R.string.jgit_error_dialog_title))
+                setMessage(ErrorMessages[error])
+                setPositiveButton(resources.getString(R.string.dialog_ok)) { _, _ -> }
+                setOnDismissListener {
+                    onPromptDone()
+                }
+                show()
+            }
+        } else {
+            onPromptDone()
         }
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
@@ -81,28 +81,36 @@ class GitConfigActivity : BaseGitActivity() {
         binding.gitAbortRebase.setOnClickListener {
             lifecycleScope.launch {
                 launchGitOperation(BREAK_OUT_OF_DETACHED).fold(
-                    success = {
-                        MaterialAlertDialogBuilder(this@GitConfigActivity)
-                            .setTitle(resources.getString(R.string.git_abort_and_push_title))
-                            .setMessage(resources.getString(
-                                R.string.git_break_out_of_detached_success,
-                                GitSettings.branch,
-                                "conflicting-${GitSettings.branch}-...",
-                            ))
-                            .setOnCancelListener { finish() }
-                            .setPositiveButton(resources.getString(R.string.dialog_ok)) { _, _ ->
-                                finish()
-                            }.show()
-                    },
-                    failure = ::finishAfterPromptOnErrorHandler,
+                  success = {
+                      MaterialAlertDialogBuilder(this@GitConfigActivity).run {
+                          setTitle(resources.getString(R.string.git_abort_and_push_title))
+                          setMessage(resources.getString(
+                            R.string.git_break_out_of_detached_success,
+                            GitSettings.branch,
+                            "conflicting-${GitSettings.branch}-...",
+                          ))
+                          setOnDismissListener() { finish() }
+                          setPositiveButton(resources.getString(R.string.dialog_ok)) { _, _ -> }
+                          show()
+                      }
+                  },
+                  failure = { err ->
+                      promptOnErrorHandler(err) {
+                          finish()
+                      }
+                  },
                 )
             }
         }
         binding.gitResetToRemote.setOnClickListener {
             lifecycleScope.launch {
                 launchGitOperation(REQUEST_RESET).fold(
-                    success = ::finishOnSuccessHandler,
-                    failure = ::finishAfterPromptOnErrorHandler,
+                  success = ::finishOnSuccessHandler,
+                  failure = { err ->
+                      promptOnErrorHandler(err) {
+                          finish()
+                      }
+                  },
                 )
             }
         }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -130,7 +130,11 @@ class GitServerConfigActivity : BaseGitActivity() {
                                     setResult(RESULT_OK)
                                     finish()
                                 },
-                                failure = ::finishAfterPromptOnErrorHandler,
+                                failure = { err ->
+                                    promptOnErrorHandler(err) {
+                                        finish()
+                                    }
+                                }
                             )
                         }
                     }.onFailure { e ->
@@ -160,7 +164,11 @@ class GitServerConfigActivity : BaseGitActivity() {
                         setResult(RESULT_OK)
                         finish()
                     },
-                    failure = ::finishAfterPromptOnErrorHandler,
+                    failure = { err ->
+                        promptOnErrorHandler(err) {
+                            finish()
+                        }
+                    },
                 )
             }
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Fixes the swipe refresher state and finish behavior after a Git operation runs into an error.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We were not correctly finishing/resetting UI state on error.

## :green_heart: How did you test it?
Lightly, please go over the typical use cases.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
