### PR TITLE
Use same checks as BiometricAuthenticator in UserPreference

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_final_newline = true
 
 [*.{java,kt,kts,xml}]
 indent_size = 4
-ij_continuation_indent_size = 2
+ij_continuation_indent_size = 4
 
 [*.{kt,kts}]
 kotlin_imports_layout=ascii

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -281,9 +281,9 @@ class UserPreference : AppCompatActivity() {
             findPreference<CheckBoxPreference>(PreferenceKeys.ENABLE_DEBUG_LOGGING)?.isVisible = !BuildConfig.ENABLE_DEBUG_FEATURES
 
             findPreference<CheckBoxPreference>(PreferenceKeys.BIOMETRIC_AUTH)?.apply {
-                val isFingerprintSupported = BiometricManager.from(requireContext())
-                    .canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL) == BiometricManager.BIOMETRIC_SUCCESS
-                if (!isFingerprintSupported) {
+                val canAuthenticate = BiometricAuthenticator.canAuthenticate(prefsActivity)
+
+                if (!canAuthenticate) {
                     isEnabled = false
                     isChecked = false
                     summary = getString(R.string.biometric_auth_summary_error)

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -24,7 +24,6 @@ import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.biometric.BiometricManager
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.documentfile.provider.DocumentFile

--- a/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/BiometricAuthenticator.kt
@@ -34,9 +34,9 @@ object BiometricAuthenticator {
     }
 
     fun authenticate(
-      activity: FragmentActivity,
-      @StringRes dialogTitleRes: Int = R.string.biometric_prompt_title,
-      callback: (Result) -> Unit
+        activity: FragmentActivity,
+        @StringRes dialogTitleRes: Int = R.string.biometric_prompt_title,
+        callback: (Result) -> Unit
     ) {
         val authCallback = object : BiometricPrompt.AuthenticationCallback() {
             override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
@@ -68,9 +68,9 @@ object BiometricAuthenticator {
         val deviceHasKeyguard = activity.getSystemService<KeyguardManager>()?.isDeviceSecure == true
         if (canAuthenticate(activity) || deviceHasKeyguard) {
             val promptInfo = BiometricPrompt.PromptInfo.Builder()
-              .setTitle(activity.getString(dialogTitleRes))
-              .setAllowedAuthenticators(validAuthenticators)
-              .build()
+                .setTitle(activity.getString(dialogTitleRes))
+                .setAllowedAuthenticators(validAuthenticators)
+                .build()
             BiometricPrompt(activity, ContextCompat.getMainExecutor(activity.applicationContext), authCallback).authenticate(promptInfo)
         } else {
             callback(Result.HardwareUnavailableOrDisabled)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
UserPreference.kt was not using the same checks as BiometricAuthenticator.

## :bulb: Motivation and Context


## :green_heart: How did you test it?
UserPreference.kt allows me to enable BiometricPrompt.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

## :camera_flash: Screenshots / GIFs
