### PR TITLE
Fix directory selection in onboarding if storage permissions are granted

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -21,7 +21,7 @@ import com.zeapo.pwdstore.git.BaseGitActivity
 import com.zeapo.pwdstore.git.GitServerConfigActivity
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
-import com.zeapo.pwdstore.utils.checkRuntimePermission
+import com.zeapo.pwdstore.utils.isPermissionGranted
 import com.zeapo.pwdstore.utils.getString
 import com.zeapo.pwdstore.utils.listFilesRecursively
 import com.zeapo.pwdstore.utils.sharedPrefs
@@ -116,7 +116,7 @@ class OnboardingActivity : AppCompatActivity() {
         settings.edit { putBoolean(PreferenceKeys.GIT_EXTERNAL, true) }
         val externalRepo = settings.getString(PreferenceKeys.GIT_EXTERNAL_REPO)
         if (externalRepo == null) {
-            if (!checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                 registerForActivityResult(RequestPermission()) { granted ->
                     if (granted) {
                         externalDirectorySelectAction.launch(Intent(this, UserPreference::class.java).apply {
@@ -130,7 +130,7 @@ class OnboardingActivity : AppCompatActivity() {
                 .setTitle(resources.getString(R.string.directory_selected_title))
                 .setMessage(resources.getString(R.string.directory_selected_message, externalRepo))
                 .setPositiveButton(resources.getString(R.string.use)) { _, _ ->
-                    if (!checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                         registerForActivityResult(RequestPermission()) { granted ->
                             if (granted) {
                                 initializeRepositoryInfo()
@@ -141,7 +141,7 @@ class OnboardingActivity : AppCompatActivity() {
                     }
                 }
                 .setNegativeButton(resources.getString(R.string.change)) { _, _ ->
-                    if (!checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                         registerForActivityResult(RequestPermission()) { granted ->
                             if (granted) {
                                 repositoryInitAction.launch(Intent(this, UserPreference::class.java).apply {
@@ -202,7 +202,7 @@ class OnboardingActivity : AppCompatActivity() {
     private fun initializeRepositoryInfo() {
         val externalRepo = settings.getBoolean(PreferenceKeys.GIT_EXTERNAL, false)
         val externalRepoPath = settings.getString(PreferenceKeys.GIT_EXTERNAL_REPO)
-        if (externalRepo && !checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        if (externalRepo && !isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             return
         }
         if (externalRepo && externalRepoPath != null) {

--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -149,6 +149,10 @@ class OnboardingActivity : AppCompatActivity() {
                                 })
                             }
                         }.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    } else {
+                        repositoryInitAction.launch(Intent(this, UserPreference::class.java).apply {
+                            putExtra("operation", "git_external")
+                        })
                     }
                 }
                 .show()

--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -119,9 +119,7 @@ class OnboardingActivity : AppCompatActivity() {
             if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                 registerForActivityResult(RequestPermission()) { granted ->
                     if (granted) {
-                        externalDirectorySelectAction.launch(Intent(this, UserPreference::class.java).apply {
-                            putExtra("operation", "git_external")
-                        })
+                        externalDirectorySelectAction.launch(UserPreference.createDirectorySelectionIntent(this))
                     }
                 }.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
             }
@@ -144,15 +142,11 @@ class OnboardingActivity : AppCompatActivity() {
                     if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                         registerForActivityResult(RequestPermission()) { granted ->
                             if (granted) {
-                                repositoryInitAction.launch(Intent(this, UserPreference::class.java).apply {
-                                    putExtra("operation", "git_external")
-                                })
+                                repositoryInitAction.launch(UserPreference.createDirectorySelectionIntent(this))
                             }
                         }.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     } else {
-                        repositoryInitAction.launch(Intent(this, UserPreference::class.java).apply {
-                            putExtra("operation", "git_external")
-                        })
+                        repositoryInitAction.launch(UserPreference.createDirectorySelectionIntent(this))
                     }
                 }
                 .show()

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -60,7 +60,7 @@ import com.zeapo.pwdstore.utils.PasswordRepository.Companion.initialize
 import com.zeapo.pwdstore.utils.PasswordRepository.Companion.isInitialized
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.base64
-import com.zeapo.pwdstore.utils.checkRuntimePermission
+import com.zeapo.pwdstore.utils.isPermissionGranted
 import com.zeapo.pwdstore.utils.commitChange
 import com.zeapo.pwdstore.utils.contains
 import com.zeapo.pwdstore.utils.getString
@@ -115,7 +115,7 @@ class PasswordStore : BaseGitActivity() {
         // prevent attempt to create password list fragment
         var savedInstance = savedInstanceState
         if (savedInstanceState != null && (!settings.getBoolean(PreferenceKeys.GIT_EXTERNAL, false) ||
-                !checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
+                !isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
             savedInstance = null
         }
         super.onCreate(savedInstance)
@@ -324,7 +324,7 @@ class PasswordStore : BaseGitActivity() {
      * is true if the permission has been granted.
      */
     private fun hasRequiredStoragePermissions(): Boolean {
-        return if (!checkRuntimePermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        return if (!isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             Snackbar.make(
                 findViewById(R.id.main_layout),
                 getString(R.string.access_sdcard_text),

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -348,13 +348,11 @@ class PasswordStore : BaseGitActivity() {
     private fun checkLocalRepository() {
         val repo = initialize()
         if (repo == null) {
-            val intent = Intent(activity, UserPreference::class.java)
-            intent.putExtra("operation", "git_external")
             registerForActivityResult(StartActivityForResult()) { result ->
                 if (result.resultCode == RESULT_OK) {
                     checkLocalRepository()
                 }
-            }.launch(intent)
+            }.launch(UserPreference.createDirectorySelectionIntent(this))
         } else {
             checkLocalRepository(getRepositoryDirectory())
         }

--- a/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/UserPreference.kt
@@ -678,6 +678,12 @@ class UserPreference : AppCompatActivity() {
 
         private const val TAG = "UserPreference"
 
+        fun createDirectorySelectionIntent(context: Context): Intent {
+            return Intent(context, UserPreference::class.java).run {
+                putExtra("operation", "git_external")
+            }
+        }
+
         /**
          * Set custom dictionary summary
          */

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -135,7 +135,7 @@ suspend fun FragmentActivity.commitChange(
     }.execute()
 }
 
-fun FragmentActivity.checkRuntimePermission(permission: String): Boolean {
+fun FragmentActivity.isPermissionGranted(permission: String): Boolean {
     return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Fixes directory selection for the case where storage permission is already granted during onboarding. Also renames the permission check method to have a more descriptive name and adds a static method to `UserPreference` for the external directory selection intent to replace multiple open-coded instances across the codebase.

## :bulb: Motivation and Context
Without this fix if you previously granted storage permissions to Password Store and now wish to change the external directory path, you would not be prompted to make a selection and repository init would not happen.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
