### PR TITLE
Autofill: add kiwi as a supported browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   Allow sorting by recently used
--   Add [Bromite](https://www.bromite.org/) and [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android) to supported browsers list for Autofill
+-   Add [Bromite](https://www.bromite.org/), [Ungoogled Chromium](https://git.droidware.info/wchen342/ungoogled-chromium-android) and [Kiwi](https://kiwibrowser.com/) to supported browsers list for Autofill
 -   Add ability to view the Git commit log
 -   Allow generating ECDSA and ED25519 keys for SSH
 -   Add support for multiple/fallback authentication methods for SSH
--   Add [Kiwi](https://kiwibrowser.com/) to supported browsers list for Autofill
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 -   Add ability to view the Git commit log
 -   Allow generating ECDSA and ED25519 keys for SSH
 -   Add support for multiple/fallback authentication methods for SSH
+-   Add [Kiwi](https://kiwibrowser.com/) to supported browsers list for Autofill
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/FeatureAndTrustDetection.kt
@@ -78,6 +78,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH = mapOf(
     "org.torproject.torbrowser" to "IAYfBF5zfGc3XBd5TP7bQ2oDzsa6y3y5+WZCIFyizsg=",
     "org.ungoogled.chromium.stable" to "29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk=",
     "org.ungoogled.chromium.extensions.stable" to "29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk=",
+    "com.kiwibrowser.browser" to "wGnqlmMy6R4KDDzFd+b1Cf49ndr3AVrQxcXvj9o/hig=",
 )
 
 private fun isTrustedBrowser(context: Context, appPackage: String): Boolean {
@@ -168,6 +169,7 @@ private val FLAKY_BROWSERS = listOf(
     "com.chrome.dev",
     "org.bromite.bromite",
     "org.ungoogled.chromium.stable",
+    "com.kiwibrowser.browser",
 )
 
 enum class BrowserAutofillSupportLevel {

--- a/app/src/main/res/xml/oreo_autofill_service.xml
+++ b/app/src/main/res/xml/oreo_autofill_service.xml
@@ -25,4 +25,5 @@
         android:name="org.mozilla.firefox_beta"
         android:maxLongVersionCode="679999" />
     <compatibility-package android:name="org.ungoogled.chromium.stable" />
+    <compatibility-package android:name="com.kiwibrowser.browser" />
 </autofill-service>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Added [Kiwi](https://kiwibrowser.com/)(com.kiwibrowser.browser) as a supported browser for Autofill. Kiwi is an open-source browser with interesting features including native Chromium extension support, ad-blocking and dark mode.


## :bulb: Motivation and Context
This makes yet another popular hacker's browser supported with PasswordStore.


## :green_heart: How did you test it?
- Compiled the project & built the APK through Android Studio.
- Loaded the APK on Android, but prompt on Kiwi is intermittently working ⚠️.

If someone could help me debug this more, would be great, thanks!

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
