### PR TITLE
Disable SSH multiplexing if not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   Unable to use show/hide password option for password/passphrase after first attempt was wrong
 -   TOTP values shown might some times be stale and considered invalid by sites
 -   Symlinks are no longer clobbered by the app (only available on Android 8 and above)
+-   Workaround lack of SSH connection reuse capabilities on some Git hosts like Bitbucket
 
 ## [1.11.3] - 2020-08-27
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -61,7 +61,8 @@ abstract class BaseGitActivity : AppCompatActivity() {
                 return Err(IllegalArgumentException("$operation is not a valid Git operation"))
             }
         }
-        return op.executeAfterAuthentication(GitSettings.authMode).mapError { err ->
+        return op.executeAfterAuthentication(GitSettings.authMode).mapError { throwable ->
+            val err = rootCauseException(throwable)
             if (err.message?.contains("cannot open additional channels") == true) {
                 GitSettings.useMultiplexing = false
                 SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")

--- a/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/config/GitSettings.kt
@@ -73,7 +73,9 @@ object GitSettings {
             }
             if (PasswordRepository.isInitialized)
                 PasswordRepository.addRemote("origin", value, true)
-            // When the server changes, remote password and host key file should be deleted.
+            // When the server changes, remote password, multiplexing support and host key file
+            // should be deleted/reset.
+            useMultiplexing = true
             encryptedSettings.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
             File("${Application.instance.filesDir}/.host_key").delete()
         }
@@ -96,6 +98,13 @@ object GitSettings {
         private set(value) {
             settings.edit {
                 putString(PreferenceKeys.GIT_BRANCH_NAME, value)
+            }
+        }
+    var useMultiplexing
+        get() = settings.getBoolean(PreferenceKeys.GIT_REMOTE_USE_MULTIPLEXING, true)
+        set(value) {
+            settings.edit {
+                putBoolean(PreferenceKeys.GIT_REMOTE_USE_MULTIPLEXING, value)
             }
         }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
@@ -9,7 +9,24 @@ import org.eclipse.jgit.api.GitCommand
 
 class PullOperation(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
 
+    /**
+     * The story of why the pull operation is committing files goes like this: Once upon a time when
+     * the world was burning and Blade Runner 2049 was real life (in the worst way), we were made
+     * aware that Bitbucket is actually bad, and disables a neat OpenSSH feature called multiplexing.
+     * So now, rather than being able to do a [SyncOperation], we'd have to first do a [PullOperation]
+     * and then a [PushOperation]. To make the behavior identical despite this suboptimal situation,
+     * we opted to replicate [SyncOperation]'s committing flow within [PullOperation] so it can be
+     * safely executed in tandem with [PullOperation], almost exactly replicating [SyncOperation]
+     * but running two consecutive SSH connections as opposed to just one.
+     */
     override val commands: Array<GitCommand<out Any>> = arrayOf(
+        // Stage all files
+        git.add().addFilepattern("."),
+        // Populate the changed files count
+        git.status(),
+        // Commit everything! If needed, obviously.
+        git.commit().setAll(true).setMessage("[Android Password Store] Sync"),
+        // Pull and rebase on top of the remote branch
         git.pull().setRebase(true).setRemote("origin"),
     )
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
@@ -15,9 +15,8 @@ class PullOperation(callingActivity: AppCompatActivity) : GitOperation(callingAc
      * aware that Bitbucket is actually bad, and disables a neat OpenSSH feature called multiplexing.
      * So now, rather than being able to do a [SyncOperation], we'd have to first do a [PullOperation]
      * and then a [PushOperation]. To make the behavior identical despite this suboptimal situation,
-     * we opted to replicate [SyncOperation]'s committing flow within [PullOperation] so it can be
-     * safely executed in tandem with [PullOperation], almost exactly replicating [SyncOperation]
-     * but running two consecutive SSH connections as opposed to just one.
+     * we opted to replicate [SyncOperation]'s committing flow within [PullOperation], almost exactly
+     * replicating [SyncOperation] but leaving the pushing part to [PushOperation].
      */
     override val commands: Array<GitCommand<out Any>> = arrayOf(
         // Stage all files

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
@@ -32,6 +32,7 @@ object PreferenceKeys {
 
     @Deprecated("Use GIT_REMOTE_URL instead")
     const val GIT_REMOTE_LOCATION = "git_remote_location"
+    const val GIT_REMOTE_USE_MULTIPLEXING = "git_remote_use_multiplexing"
 
     @Deprecated("Use GIT_REMOTE_URL instead")
     const val GIT_REMOTE_PORT = "git_remote_port"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Fall back to single channel SSH connections if the server (looking at you, Bitbucket) does not support multiplexing.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix #1092 when it's done.

## :green_heart: How did you test it?
~~Not yet.~~ Create a private Bitbucket repository, clone it to the device, attempt to synchronize after creating a new password and get the error about broken multiplexing then trying again correctly uses a pull + push separately.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
