### PR TITLE
Correctly count children in password list

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
@@ -57,9 +57,7 @@ open class PasswordItemRecyclerAdapter :
             name.text = spannable
             if (item.type == PasswordItem.TYPE_CATEGORY) {
                 folderIndicator.visibility = View.VISIBLE
-                val count = with(item.file) {
-                    listFiles { path -> path.isDirectory || path.extension == "gpg" }
-                }?.size ?: 0
+                val count = item.file.listFiles { path -> path.isDirectory || path.extension == "gpg" }?.size ?: 0
                 childCount.visibility = if (count > 0) View.VISIBLE else View.GONE
                 childCount.text = "$count"
             } else {

--- a/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/adapters/PasswordItemRecyclerAdapter.kt
@@ -17,9 +17,6 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.SearchableRepositoryAdapter
 import com.zeapo.pwdstore.stableId
 import com.zeapo.pwdstore.utils.PasswordItem
-import com.zeapo.pwdstore.utils.PreferenceKeys
-import com.zeapo.pwdstore.utils.sharedPrefs
-import java.io.File
 
 open class PasswordItemRecyclerAdapter :
     SearchableRepositoryAdapter<PasswordItemRecyclerAdapter.PasswordItemViewHolder>(
@@ -49,8 +46,6 @@ open class PasswordItemRecyclerAdapter :
         lateinit var itemDetails: ItemDetailsLookup.ItemDetails<String>
 
         fun bind(item: PasswordItem) {
-            val settings = itemView.context.sharedPrefs
-            val showHidden = settings.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false)
             val parentPath = item.fullPathToParent.replace("(^/)|(/$)".toRegex(), "")
             val source = if (parentPath.isNotEmpty()) {
                 "$parentPath\n$item"
@@ -62,10 +57,9 @@ open class PasswordItemRecyclerAdapter :
             name.text = spannable
             if (item.type == PasswordItem.TYPE_CATEGORY) {
                 folderIndicator.visibility = View.VISIBLE
-                val children = with(item.file) {
-                    if (showHidden) listFiles() else listFiles { pathname -> pathname.isDirectory && !pathname.isHidden }
-                } ?: emptyArray<File>()
-                val count = children.size
+                val count = with(item.file) {
+                    listFiles { path -> path.isDirectory || path.extension == "gpg" }
+                }?.size ?: 0
                 childCount.visibility = if (count > 0) View.VISIBLE else View.GONE
                 childCount.text = "$count"
             } else {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Fixes counting of child items for directories in password list

## :bulb: Motivation and Context
Currently the child count is very broken and ignores all non-directory elements until show all files is toggled.

## :green_heart: How did you test it?
Verified putting 2 passwords in a directory now correctly shows 2 as child count as opposed to nothing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
