### PR TITLE
Continue onboarding if permissions are granted prematurely

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -122,6 +122,10 @@ class OnboardingActivity : AppCompatActivity() {
                         externalDirectorySelectAction.launch(UserPreference.createDirectorySelectionIntent(this))
                     }
                 }.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            } else {
+                // Unlikely we have storage permissions without user ever selecting a directory,
+                // but let's not assume.
+                externalDirectorySelectAction.launch(UserPreference.createDirectorySelectionIntent(this))
             }
         } else {
             MaterialAlertDialogBuilder(this)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Continue with external repo onboarding if permissions are granted before a directory selection is made.

## :bulb: Motivation and Context
Solves the unlikely case where user grants storage permission from Android Settings before ever opening the app.

## :green_heart: How did you test it?
Verified that installing a debug build, granting permissions through `adb shell` and then launching the app prompted me to select a directory.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
