### PR TITLE
Add tentative workaround for dialog crashes and refactor Git-related code

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/OnboardingActivity.kt
@@ -17,7 +17,6 @@ import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.databinding.ActivityOnboardingBinding
-import com.zeapo.pwdstore.git.BaseGitActivity
 import com.zeapo.pwdstore.git.GitServerConfigActivity
 import com.zeapo.pwdstore.utils.PasswordRepository
 import com.zeapo.pwdstore.utils.PreferenceKeys
@@ -92,9 +91,7 @@ class OnboardingActivity : AppCompatActivity() {
      */
     private fun cloneToHiddenDir() {
         settings.edit { putBoolean(PreferenceKeys.GIT_EXTERNAL, false) }
-        cloneAction.launch(Intent(this, GitServerConfigActivity::class.java).apply {
-            putExtra(BaseGitActivity.REQUEST_ARG_OP, BaseGitActivity.REQUEST_CLONE)
-        })
+        cloneAction.launch(GitServerConfigActivity.createCloneIntent(this))
     }
 
     /**

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -5,7 +5,6 @@
 package com.zeapo.pwdstore
 
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.os.Parcelable
@@ -90,9 +89,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
             } else if (!PasswordRepository.isGitRepo()) {
                 Snackbar.make(binding.root, getString(R.string.clone_git_repo), Snackbar.LENGTH_INDEFINITE)
                     .setAction(R.string.clone_button) {
-                        val intent = Intent(context, GitServerConfigActivity::class.java)
-                        intent.putExtra(BaseGitActivity.REQUEST_ARG_OP, BaseGitActivity.REQUEST_CLONE)
-                        swipeResult.launch(intent)
+                        swipeResult.launch(GitServerConfigActivity.createCloneIntent(requireContext()))
                     }
                     .show()
                 binding.swipeRefresher.isRefreshing = false
@@ -100,8 +97,8 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
                 // When authentication is set to AuthMode.None then the only git operation we can
                 // run is a pull, so automatically fallback to that.
                 val operationId = when (GitSettings.authMode) {
-                    AuthMode.None -> BaseGitActivity.REQUEST_PULL
-                    else -> BaseGitActivity.REQUEST_SYNC
+                    AuthMode.None -> BaseGitActivity.GitOp.PULL
+                    else -> BaseGitActivity.GitOp.SYNC
                 }
                 requireStore().apply {
                     lifecycleScope.launch {

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -272,7 +272,7 @@ class PasswordStore : BaseGitActivity() {
                     initBefore.show()
                     return false
                 }
-                runGitOperation(REQUEST_PUSH)
+                runGitOperation(GitOp.PUSH)
                 return true
             }
             R.id.git_pull -> {
@@ -280,7 +280,7 @@ class PasswordStore : BaseGitActivity() {
                     initBefore.show()
                     return false
                 }
-                runGitOperation(REQUEST_PULL)
+                runGitOperation(GitOp.PULL)
                 return true
             }
             R.id.git_sync -> {
@@ -288,7 +288,7 @@ class PasswordStore : BaseGitActivity() {
                     initBefore.show()
                     return false
                 }
-                runGitOperation(REQUEST_SYNC)
+                runGitOperation(GitOp.SYNC)
                 return true
             }
             R.id.refresh -> {
@@ -312,7 +312,7 @@ class PasswordStore : BaseGitActivity() {
             searchItem.collapseActionView()
     }
 
-    private fun runGitOperation(operation: Int) = lifecycleScope.launch {
+    private fun runGitOperation(operation: GitOp) = lifecycleScope.launch {
         launchGitOperation(operation).fold(
             success = { refreshPasswordList() },
             failure = { promptOnErrorHandler(it) },
@@ -520,7 +520,6 @@ class PasswordStore : BaseGitActivity() {
         val intent = Intent(this, SelectFolderActivity::class.java)
         val fileLocations = values.map { it.file.absolutePath }.toTypedArray()
         intent.putExtra("Files", fileLocations)
-        intent.putExtra(REQUEST_ARG_OP, "SELECTFOLDER")
         registerForActivityResult(StartActivityForResult()) { result ->
             val intentData = result.data ?: return@registerForActivityResult
             val filesToMove = requireNotNull(intentData.getStringArrayExtra("Files"))

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -315,7 +315,7 @@ class PasswordStore : BaseGitActivity() {
     private fun runGitOperation(operation: Int) = lifecycleScope.launch {
         launchGitOperation(operation).fold(
             success = { refreshPasswordList() },
-            failure = ::promptOnErrorHandler
+            failure = { promptOnErrorHandler(it) },
         )
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -52,7 +52,7 @@ abstract class BaseGitActivity : AppCompatActivity() {
             return launchGitOperation(REQUEST_PULL).andThen { launchGitOperation(REQUEST_PUSH) }
         }
         val op = when (operation) {
-            REQUEST_CLONE, GitOperation.GET_SSH_KEY_FROM_CLONE -> CloneOperation(this, GitSettings.url!!)
+            REQUEST_CLONE -> CloneOperation(this, GitSettings.url!!)
             REQUEST_PULL -> PullOperation(this)
             REQUEST_PUSH -> PushOperation(this)
             REQUEST_SYNC -> SyncOperation(this)

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -6,9 +6,7 @@ package com.zeapo.pwdstore.git
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
-import com.github.ajalt.timberkt.Timber.tag
 import com.github.ajalt.timberkt.d
-import com.github.ajalt.timberkt.e
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
@@ -18,7 +16,6 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.git.config.GitSettings
 import com.zeapo.pwdstore.git.operation.BreakOutOfDetached
 import com.zeapo.pwdstore.git.operation.CloneOperation
-import com.zeapo.pwdstore.git.operation.GitOperation
 import com.zeapo.pwdstore.git.operation.PullOperation
 import com.zeapo.pwdstore.git.operation.PushOperation
 import com.zeapo.pwdstore.git.operation.ResetToRemoteOperation
@@ -39,29 +36,37 @@ import net.schmizz.sshj.userauth.UserAuthException
 abstract class BaseGitActivity : AppCompatActivity() {
 
     /**
+     * Enum of possible Git operations than can be run through [launchGitOperation].
+     */
+    enum class GitOp {
+        BREAK_OUT_OF_DETACHED,
+        CLONE,
+        PULL,
+        PUSH,
+        RESET,
+        SYNC,
+    }
+
+    /**
      * Attempt to launch the requested Git operation.
      * @param operation The type of git operation to launch
      */
-    suspend fun launchGitOperation(operation: Int): Result<Unit, Throwable> {
+    suspend fun launchGitOperation(operation: GitOp): Result<Unit, Throwable> {
         if (GitSettings.url == null) {
             return Err(IllegalStateException("Git url is not set!"))
         }
-        if (operation == REQUEST_SYNC && !GitSettings.useMultiplexing) {
+        if (operation == GitOp.SYNC && !GitSettings.useMultiplexing) {
             // If the server does not support multiple SSH channels per connection, we cannot run
             // a sync operation without reconnecting and thus break sync into its two parts.
-            return launchGitOperation(REQUEST_PULL).andThen { launchGitOperation(REQUEST_PUSH) }
+            return launchGitOperation(GitOp.PULL).andThen { launchGitOperation(GitOp.PUSH) }
         }
         val op = when (operation) {
-            REQUEST_CLONE -> CloneOperation(this, GitSettings.url!!)
-            REQUEST_PULL -> PullOperation(this)
-            REQUEST_PUSH -> PushOperation(this)
-            REQUEST_SYNC -> SyncOperation(this)
-            BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(this)
-            REQUEST_RESET -> ResetToRemoteOperation(this)
-            else -> {
-                tag(TAG).e { "Operation not recognized : $operation" }
-                return Err(IllegalArgumentException("$operation is not a valid Git operation"))
-            }
+            GitOp.CLONE -> CloneOperation(this, GitSettings.url!!)
+            GitOp.PULL -> PullOperation(this)
+            GitOp.PUSH -> PushOperation(this)
+            GitOp.SYNC -> SyncOperation(this)
+            GitOp.BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(this)
+            GitOp.RESET -> ResetToRemoteOperation(this)
         }
         return op.executeAfterAuthentication(GitSettings.authMode).mapError { throwable ->
             val err = rootCauseException(throwable)
@@ -133,17 +138,5 @@ abstract class BaseGitActivity : AppCompatActivity() {
             rootCause = rootCause.cause ?: break
         }
         return rootCause
-    }
-
-    companion object {
-
-        const val REQUEST_ARG_OP = "OPERATION"
-        const val REQUEST_PULL = 101
-        const val REQUEST_PUSH = 102
-        const val REQUEST_CLONE = 103
-        const val REQUEST_SYNC = 104
-        const val BREAK_OUT_OF_DETACHED = 105
-        const val REQUEST_RESET = 106
-        const val TAG = "AbstractGitActivity"
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitConfigActivity.kt
@@ -91,7 +91,7 @@ class GitConfigActivity : BaseGitActivity() {
         }
         binding.gitAbortRebase.setOnClickListener {
             lifecycleScope.launch {
-                launchGitOperation(BREAK_OUT_OF_DETACHED).fold(
+                launchGitOperation(GitOp.BREAK_OUT_OF_DETACHED).fold(
                   success = {
                       MaterialAlertDialogBuilder(this@GitConfigActivity).run {
                           setTitle(resources.getString(R.string.git_abort_and_push_title))
@@ -115,7 +115,7 @@ class GitConfigActivity : BaseGitActivity() {
         }
         binding.gitResetToRemote.setOnClickListener {
             lifecycleScope.launch {
-                launchGitOperation(REQUEST_RESET).fold(
+                launchGitOperation(GitOp.RESET).fold(
                   success = ::finishOnSuccessHandler,
                   failure = { err ->
                       promptOnErrorHandler(err) {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -190,7 +190,7 @@ class GitServerConfigActivity : BaseGitActivity() {
                         setResult(RESULT_OK)
                         finish()
                     },
-                    failure = ::promptOnErrorHandler,
+                    failure = { promptOnErrorHandler(it) },
                 )
             }
         }

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -4,6 +4,8 @@
  */
 package com.zeapo.pwdstore.git
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.view.MenuItem
@@ -42,7 +44,7 @@ class GitServerConfigActivity : BaseGitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val isClone = intent?.extras?.getInt(REQUEST_ARG_OP) ?: -1 == REQUEST_CLONE
+        val isClone = intent?.extras?.getBoolean("cloning") ?: false
         if (isClone) {
             binding.saveButton.text = getString(R.string.clone_button)
         }
@@ -151,7 +153,7 @@ class GitServerConfigActivity : BaseGitActivity() {
                                 localDir.deleteRecursively()
                             }
                             snackbar.dismiss()
-                            launchGitOperation(REQUEST_CLONE).fold(
+                            launchGitOperation(GitOp.CLONE).fold(
                                 success = {
                                     setResult(RESULT_OK)
                                     finish()
@@ -185,13 +187,21 @@ class GitServerConfigActivity : BaseGitActivity() {
                 MaterialAlertDialogBuilder(this).setMessage(e.message).show()
             }
             lifecycleScope.launch {
-                launchGitOperation(REQUEST_CLONE).fold(
+                launchGitOperation(GitOp.CLONE).fold(
                     success = {
                         setResult(RESULT_OK)
                         finish()
                     },
                     failure = { promptOnErrorHandler(it) },
                 )
+            }
+        }
+    }
+
+    companion object {
+        fun createCloneIntent(context: Context): Intent {
+            return Intent(context, GitServerConfigActivity::class.java).apply {
+                putExtra("cloning", true)
             }
         }
     }

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -202,9 +202,4 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
             sshSessionFactory?.close()
         }
     }
-
-    companion object {
-
-        const val GET_SSH_KEY_FROM_CLONE = 201
-    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Ensures the dialog in the default GIt error handler always runs on the main thread and refactors launchGitOperation to use an enum for possible values as opposed to open-coded ints.

## :bulb: Motivation and Context
We have a large set of crashes around the error dialog and not a lot of actionable information. This is first in a series of bandaids that we will apply and monitor the situation.

## :green_heart: How did you test it?
Git operations run and fail correctly 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
