### PR TITLE
github: remove nonFree flavor from tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         api-level: [23, 29]
-        variant: [freeDebug, nonFreeDebug]
     steps:
 
     - name: Check if relevant files have changed
@@ -67,10 +66,10 @@ jobs:
 
     - name: Run unit tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      run: ./gradlew test${{ matrix.variant }} lint${{ matrix.variant}} -Dpre-dex=false
+      run: ./gradlew testFreeDebug lintFreeDebug
 
-    - name: Run instrumentation tests on free flavor
-      if: ${{ steps.service-changed.outputs.result == 'true' && matrix.variant == 'freeDebug' }}
+    - name: Run instrumentation tests
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: reactivecircus/android-emulator-runner@v2.11.0
       with:
         api-level: ${{ matrix.api-level }}
@@ -80,18 +79,6 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global window_animation_scale 0
           ./gradlew :app:connectedFreeDebugAndroidTest
-
-    - name: Run instrumentation tests on nonFree flavor
-      if: ${{ steps.service-changed.outputs.result == 'true' && matrix.variant == 'nonFreeDebug' }}
-      uses: reactivecircus/android-emulator-runner@v2.11.0
-      with:
-        api-level: ${{ matrix.api-level }}
-        target: default
-        script: |
-          adb shell settings put global animator_duration_scale 0
-          adb shell settings put global transition_animation_scale 0
-          adb shell settings put global window_animation_scale 0
-          ./gradlew :app:connectedNonFreeDebugAndroidTest
 
     - name: (Fail-only) upload test report
       if: failure()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Remove the nonFree flavor from the tests run in pull requests.

## :bulb: Motivation and Context
There is no functional difference between free and nonFree flavors within our tests so running these extra jobs
simply serves to slow us down.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
