### PR TITLE
Revert "github: remove ci-gradle.properties"

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,6 @@
+#
+# Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -17,6 +17,9 @@ jobs:
       env:
         ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
 
+    - name: Copy CI gradle.properties
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
     - name: Generate cache key
       run: ./.github/checksum.sh checksum.txt
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,10 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: actions/checkout@v2
 
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
     - name: Generate cache key
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       run: ./.github/checksum.sh checksum.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
       env:
         ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
 
+    - name: Copy CI gradle.properties
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
     - name: Generate cache key
       run: ./.github/checksum.sh checksum.txt
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Restores the `ci-gradle.properties` file that limits JVM heap usage for Gradle

## :bulb: Motivation and Context
Our previous snapshot deployment failed because the runner [ran out of memory](https://pipelines.actions.githubusercontent.com/eRaLlgv7QgiQrEiMWvOVzCfcXl8ehv3iNil9w7DRw7wdT9P1kT/_apis/pipelines/1/runs/2741/signedlogcontent/3?urlExpires=2020-09-21T07%3A46%3A57.1297541Z&urlSigningMethod=HMACV1&urlSignature=6e1r7tlUIn9E2EuEm2i4skqgQwZ4jCmO9ARlGZ6a3SU%3D)

## :green_heart: How did you test it?
:shrug: this is the only change that could have broken it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
