### PR TITLE
Resolve broken unauthenticated access flow

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -56,16 +56,16 @@ class GitServerConfigActivity : BaseGitActivity() {
 
         binding.authModeGroup.apply {
             when (newAuthMode) {
-                AuthMode.SshKey -> check(R.id.auth_mode_ssh_key)
-                AuthMode.Password -> check(R.id.auth_mode_password)
-                AuthMode.OpenKeychain -> check(R.id.auth_mode_open_keychain)
-                AuthMode.None -> uncheck(checkedButtonId)
+                AuthMode.SshKey -> check(binding.authModeSshKey.id)
+                AuthMode.Password -> check(binding.authModePassword.id)
+                AuthMode.OpenKeychain -> check(binding.authModeOpenKeychain.id)
+                AuthMode.None -> check(View.NO_ID)
             }
             addOnButtonCheckedListener { _, _, _ ->
                 when (checkedButtonId) {
-                    R.id.auth_mode_ssh_key -> newAuthMode = AuthMode.SshKey
-                    R.id.auth_mode_open_keychain -> newAuthMode = AuthMode.OpenKeychain
-                    R.id.auth_mode_password -> newAuthMode = AuthMode.Password
+                    binding.authModeSshKey.id -> newAuthMode = AuthMode.SshKey
+                    binding.authModeOpenKeychain.id -> newAuthMode = AuthMode.OpenKeychain
+                    binding.authModePassword.id -> newAuthMode = AuthMode.Password
                     View.NO_ID -> newAuthMode = AuthMode.None
                 }
             }
@@ -80,10 +80,14 @@ class GitServerConfigActivity : BaseGitActivity() {
                 binding.authModeSshKey.isVisible = false
                 binding.authModeOpenKeychain.isVisible = false
                 binding.authModePassword.isVisible = true
+                if (binding.authModeGroup.checkedButtonId != binding.authModePassword.id)
+                    binding.authModeGroup.check(View.NO_ID)
             } else {
                 binding.authModeSshKey.isVisible = true
                 binding.authModeOpenKeychain.isVisible = true
                 binding.authModePassword.isVisible = true
+                if (binding.authModeGroup.checkedButtonId == View.NO_ID)
+                    binding.authModeGroup.check(binding.authModeSshKey.id)
             }
         }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Manually check/uncheck auth mode buttons when they're automatically hidden by URL changes and refactor to use the `getId` method from the views rather than manually
entering their IDs.

## :bulb: Motivation and Context
Since we don't uncheck the buttons when hiding them this leaves us in a weird state where you start typing an HTTPS URL, and you see that Password is not checked and attempt to clone, yet get told that a username is missing. This problem is doubly aggravated by the fact that having a username with no password appears to completely break cloning (might warrant a separate investigation post this release). To fix this, we mark `View.NO_ID` checked when moving into HTTPS if password isn't already selected, and mark `authModeSshKey` when currently checked item is `View.NO_ID`

## :green_heart: How did you test it?
Verified I could onboard with `https://github.com/Android-Password-Store/pass-test` without needing to select authentication mode.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
