### PR TITLE
Restore settings button to onboarding screen

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/WelcomeFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/WelcomeFragment.kt
@@ -5,11 +5,13 @@
 
 package com.zeapo.pwdstore.ui.onboarding.fragments
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.Keep
 import androidx.fragment.app.Fragment
 import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.databinding.FragmentWelcomeBinding
 import com.zeapo.pwdstore.utils.performTransactionWithBackStack
 import com.zeapo.pwdstore.utils.viewBinding
@@ -23,5 +25,6 @@ class WelcomeFragment : Fragment(R.layout.fragment_welcome) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.letsGo.setOnClickListener { parentFragmentManager.performTransactionWithBackStack(CloneFragment.newInstance()) }
+        binding.settingsButton.setOnClickListener { startActivity(Intent(requireContext(), UserPreference::class.java)) }
     }
 }

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -5,6 +5,19 @@
     android:background="?attr/colorPrimary"
     android:orientation="vertical">
 
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/settings_button"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/action_settings"
+        android:textColor="?attr/colorOnPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/app_icon"
         android:layout_width="100dp"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Adds back the Settings button to our new onboarding flow that existed in the previous one

## :bulb: Motivation and Context
SSH key related changes are often required when re-entering onboarding after deleting an existing repository, and this simplifies
that process.

## :green_heart: How did you test it?
Visually confirmed visibility of button and confirmed functionality manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
![Screenshot of the newly added settings button](https://i.imgur.com/eUIF8IX.png)
