### PR TITLE
Unwrap root cause for InvalidRemoteException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+-  Some classes of errors would be swallowed by an unhelpful 'Invalid remote: origin' message
+
 ## [1.12.0] - 2020-09-24
 
 ### Added

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -128,11 +128,12 @@ abstract class BaseGitActivity : AppCompatActivity() {
      */
     private fun rootCauseException(throwable: Throwable): Throwable {
         var rootCause = throwable
-        // JGit's TransportException hides the more helpful SSHJ exceptions.
+        // JGit's InvalidRemoteException and TransportException hide the more helpful SSHJ exceptions.
         // Also, SSHJ's UserAuthException about exhausting available authentication methods hides
         // more useful exceptions.
         while ((rootCause is org.eclipse.jgit.errors.TransportException ||
                 rootCause is org.eclipse.jgit.api.errors.TransportException ||
+                rootCause is org.eclipse.jgit.api.errors.InvalidRemoteException ||
                 (rootCause is UserAuthException &&
                     rootCause.message == "Exhausted available authentication methods"))) {
             rootCause = rootCause.cause ?: break


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Expand root cause detection to also unwrap JGit's `org.eclipse.jgit.api.errors.InvalidRemoteException`. During investigation of #1120 I noticed this exception type was swallowing much more helpful errors.

## :bulb: Motivation and Context

As evident in this stacktrace, the real and more helpful exception is being swallowed by `InvalidRemoteException`.

```
 D  org.eclipse.jgit.api.errors.InvalidRemoteException: Invalid remote: origin
 D      at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:26)
 D      at org.eclipse.jgit.api.PullCommand.call(PullCommand.java:41)
 D      at com.zeapo.pwdstore.git.GitCommandExecutor$execute$2$result$1.invokeSuspend(GitCommandExecutor.kt:2)
 D      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:3)
 D      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:15)
 D      at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:1)
 D      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:13)
 D  Caused by: org.eclipse.jgit.errors.NoRemoteRepositoryException: ssh://msfjarvis@[fe80::dead:beef]:22/pass-repo: fatal: '/pass-repo'
    does not appear to be a git repository
 D      at org.eclipse.jgit.transport.TransportGitSsh.cleanNotFound(TransportGitSsh.java:14)
 D      at org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:20)
 D      at org.eclipse.jgit.transport.TransportGitSsh.openFetch(TransportGitSsh.java:1)
 D      at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:1)
 D      at org.eclipse.jgit.transport.Transport.fetch(Transport.java:20)
 D      at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:18)
```

## :green_heart: How did you test it?

Tested the same broken configuration before and after the patch, the first run resulted in the above stacktrace, the second one correctly threw the nested `org.eclipse.jgit.errors.NoRemoteRepositoryException`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
