### PR TITLE
Improve initial repository state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -  Some classes of errors would be swallowed by an unhelpful 'Invalid remote: origin' message
+-  Repositories created within APS would contain invalid `.gpg-id` files with no ability to fix them from the app
+
+### Added
+
+-  Add GPG key selection step to onboarding flow
 
 ## [1.12.0] - 2020-09-24
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/PasswordCreationActivity.kt
@@ -255,6 +255,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
 
     @OptIn(ExperimentalUnsignedTypes::class)
     private fun parseGpgIdentifier(identifier: String): GpgIdentifier? {
+        if (identifier.isEmpty()) return null
         // Match long key IDs:
         // FF22334455667788 or 0xFF22334455667788
         val maybeLongKeyId = identifier.removePrefix("0x").takeIf {
@@ -320,6 +321,9 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                 .filter { it.isNotBlank() }
                 .map { line ->
                     parseGpgIdentifier(line) ?: run {
+                        // The line being empty means this is most likely an empty `.gpg-id` file
+                        // we created. Skip the validation so we can make the user add a real ID.
+                        if (line.isEmpty()) return@run
                         if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {
                             snackbar(message = resources.getString(R.string.short_key_ids_unsupported))
                         } else {

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -51,8 +51,10 @@ class GitCommandExecutor(
                         // the previous status will eventually be used to avoid a commit
                         if (nbChanges > 0) {
                             withContext(Dispatchers.IO) {
+                                val name = GitSettings.authorName.ifEmpty { "root" }
+                                val email = GitSettings.authorEmail.ifEmpty { "localhost" }
                                 command
-                                    .setAuthor(PersonIdent(GitSettings.authorName, GitSettings.authorEmail))
+                                    .setAuthor(PersonIdent(name, email))
                                     .call()
                             }
                         }

--- a/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/KeySelectionFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/KeySelectionFragment.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.zeapo.pwdstore.ui.onboarding.fragments
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.crypto.GetKeyIdsActivity
+import com.zeapo.pwdstore.databinding.FragmentKeySelectionBinding
+import com.zeapo.pwdstore.utils.PasswordRepository
+import com.zeapo.pwdstore.utils.PreferenceKeys
+import com.zeapo.pwdstore.utils.commitChange
+import com.zeapo.pwdstore.utils.finish
+import com.zeapo.pwdstore.utils.sharedPrefs
+import com.zeapo.pwdstore.utils.viewBinding
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.msfjarvis.openpgpktx.util.OpenPgpApi
+
+class KeySelectionFragment : Fragment(R.layout.fragment_key_selection) {
+
+    private val settings by lazy { requireActivity().applicationContext.sharedPrefs }
+    private val binding by viewBinding(FragmentKeySelectionBinding::bind)
+
+    private val gpgKeySelectAction = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == AppCompatActivity.RESULT_OK) {
+            result.data?.getStringArrayExtra(OpenPgpApi.EXTRA_KEY_IDS)?.let { keyIds ->
+                lifecycleScope.launch {
+                    withContext(Dispatchers.IO) {
+                        val gpgIdentifierFile = File(PasswordRepository.getRepositoryDirectory(), ".gpg-id")
+                        gpgIdentifierFile.writeText(keyIds.joinToString("\n"))
+                    }
+                    settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
+                    requireActivity().commitChange(getString(
+                        R.string.git_commit_gpg_id,
+                        getString(R.string.app_name)
+                    ))
+                }
+            }
+        } else {
+            throw IllegalStateException("Failed to initialize repository state.")
+        }
+        finish()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.selectKey.setOnClickListener { gpgKeySelectAction.launch(Intent(requireContext(), GetKeyIdsActivity::class.java)) }
+    }
+
+    companion object {
+
+        fun newInstance() = KeySelectionFragment()
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/RepoLocationFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/RepoLocationFragment.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import com.github.ajalt.timberkt.d
+import com.github.ajalt.timberkt.e
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -26,14 +27,14 @@ import com.zeapo.pwdstore.utils.finish
 import com.zeapo.pwdstore.utils.getString
 import com.zeapo.pwdstore.utils.isPermissionGranted
 import com.zeapo.pwdstore.utils.listFilesRecursively
+import com.zeapo.pwdstore.utils.performTransactionWithBackStack
 import com.zeapo.pwdstore.utils.sharedPrefs
 import com.zeapo.pwdstore.utils.viewBinding
 import java.io.File
 
 class RepoLocationFragment : Fragment(R.layout.fragment_repo_location) {
 
-    private val firstRunActivity by lazy { requireActivity() }
-    private val settings by lazy { firstRunActivity.applicationContext.sharedPrefs }
+    private val settings by lazy { requireActivity().applicationContext.sharedPrefs }
     private val binding by viewBinding(FragmentRepoLocationBinding::bind)
     private val sortOrder: PasswordRepository.PasswordSortOrder
         get() = PasswordRepository.PasswordSortOrder.getSortOrder(settings)
@@ -151,18 +152,14 @@ class RepoLocationFragment : Fragment(R.layout.fragment_repo_location) {
             if (!PasswordRepository.isInitialized) {
                 PasswordRepository.initialize()
             }
-            if (File(localDir.absolutePath + "/.gpg-id").createNewFile()) {
-                settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
-            } else {
-                throw IllegalStateException("Failed to initialize repository state.")
-            }
+            parentFragmentManager.performTransactionWithBackStack(KeySelectionFragment.newInstance())
         }.onFailure { e ->
-            e.printStackTrace()
+            e(e)
             if (!localDir.delete()) {
                 d { "Failed to delete local repository: $localDir" }
             }
+            finish()
         }
-        finish()
     }
 
     private fun initializeRepositoryInfo() {

--- a/app/src/main/res/layout/fragment_key_selection.xml
+++ b/app/src/main/res/layout/fragment_key_selection.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorPrimary"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/app_icon"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="100dp"
+        android:contentDescription="@string/app_icon_hint"
+        android:src="@mipmap/ic_launcher"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/app_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_marginStart="16dp"
+        android:text="@string/app_name"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5"
+        android:textColor="@color/color_control_normal"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/app_icon"
+        app:layout_constraintStart_toEndOf="@id/app_icon"
+        app:layout_constraintTop_toTopOf="@+id/app_icon" />
+
+    <TextView
+        android:id="@+id/gpg_key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:text="@string/select_gpg_key_title"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4"
+        android:textColor="@color/color_control_normal"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toStartOf="@id/app_icon"
+        app:layout_constraintTop_toBottomOf="@id/app_icon" />
+
+    <TextView
+        android:id="@+id/gpg_key_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/select_gpg_key_message"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textColor="@color/color_control_normal"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/gpg_key"
+        app:layout_constraintTop_toBottomOf="@id/gpg_key" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/select_key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="48dp"
+        android:layout_marginEnd="16dp"
+        android:maxWidth="300dp"
+        android:minWidth="100dp"
+        android:text="@string/gpg_key_select"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/gpg_key_text" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,6 +400,9 @@
     <string name="select_repo_type_text">Select if you want to create a local repo or clone a remote repo.</string>
     <string name="clone_remote_repo">Clone Remote Repo</string>
     <string name="create_local_repo">Create Local Repo</string>
+    <string name="select_gpg_key_title">Select\nGPG\nKey</string>
+    <string name="select_gpg_key_message">Select a GPG key to initialize your store with</string>
+    <string name="gpg_key_select">Select key</string>
 
     <!-- SSH port validation -->
     <string name="ssh_scheme_needed_title">Potentially incorrect URL</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Make users select a GPG key ID when creating a new store and fix the default author/email to match the Git CLI.

## :bulb: Motivation and Context
We create an empty repository during init with an empty `.gpg-id` file which results in an unusable repository that
cannot be used to create passwords. This resolves that by ensuring the `.gpg-id` file contains a valid key ID. While
here, also fix the default Git author and email that were being set to empty strings which resulted in commits with the
author ` <>`. Since we do want them to remain empty by default so as to prompt the user to update them from the UI,
employ a small workaround to take correct defaults where they need to match Git.

## :green_heart: How did you test it?
Verified creating a new repository prompted me to select a key from OpenKeychain and the author was `root@localhost`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs

<details>
<summary>Key selection fragment</summary>

![screenshot-20201001-204556](https://user-images.githubusercontent.com/13348378/94828882-92ea5b00-0427-11eb-9536-b02e611aa06d.png)


</details>

