### PR TITLE
Allow matching password fields based on hints only

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
@@ -243,7 +243,7 @@ class FormField(
 
     // Password field heuristics (based only on the current field)
     private val isPossiblePasswordField =
-        notExcluded && (isAndroidPasswordField || isHtmlPasswordField)
+        notExcluded && (isAndroidPasswordField || isHtmlPasswordField || hasHintPassword)
     private val isCertainPasswordField = isPossiblePasswordField && hasHintPassword
     private val isLikelyPasswordField = isPossiblePasswordField &&
         (isCertainPasswordField || PASSWORD_HEURISTIC_TERMS.anyMatchesFieldInfo)


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Filling passwords is usually only offered for fields with a password
input type, which ensures that they are always properly masked. Certain
custom views (e.g., the Termux terminal view), may apply their own
masking that is not based on the standard views.

With this commit, we allow filling passwords into arbitrary fields as
long as they have an Autofill hint that indicates a password.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #889.

## :green_heart: How did you test it?
Checked that Autofill in Termux is now filling the password, not the username.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
