### PR TITLE
Exit tie breakers early in unique or no match case

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategyDsl.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategyDsl.kt
@@ -94,6 +94,10 @@ class SingleFieldMatcher(
 
     override fun match(fields: List<FormField>, alreadyMatched: List<FormField>): List<FormField>? {
         return fields.minus(alreadyMatched).filter { take(it, alreadyMatched) }.let { contestants ->
+            when (contestants.size) {
+                1 -> return@let listOf(contestants.single())
+                0 -> return@let null
+            }
             var current = contestants
             for ((i, tieBreaker) in tieBreakers.withIndex()) {
                 // Successively filter matched fields via tie breakers...
@@ -127,11 +131,15 @@ private class PairOfFieldsMatcher(
         return fields.minus(alreadyMatched).zipWithNext()
             .filter { it.first directlyPrecedes it.second }.filter { take(it, alreadyMatched) }
             .let { contestants ->
+                when (contestants.size) {
+                    1 -> return@let contestants.single().toList()
+                    0 -> return@let null
+                }
                 var current = contestants
                 for ((i, tieBreaker) in tieBreakers.withIndex()) {
                     val new = current.filter { tieBreaker(it, alreadyMatched) }
                     if (new.isEmpty()) {
-                        d { "Tie breaker #${i + 1}: Didn't match any field; skipping" }
+                        d { "Tie breaker #${i + 1}: Didn't match any pair of fields; skipping" }
                         continue
                     }
                     // and return if the available options have been narrowed to a single field.
@@ -140,7 +148,7 @@ private class PairOfFieldsMatcher(
                         current = new
                         break
                     }
-                    d { "Tie breaker #${i + 1}: Matched ${new.size} fields; continuing" }
+                    d { "Tie breaker #${i + 1}: Matched ${new.size} pairs of fields; continuing" }
                     current = new
                 }
                 current.singleOrNull()?.toList()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Tie breakers for Autofill fields should only be evaluated if there is
a need to, in particular not if only a single or no field is matched.

Apart from a potential minor performance improvement, this should not
cause any user-visible changes, but does simplify the log output
considerably.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
