### PR TITLE
Show new FillResponse right after publisher reset

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillResponseBuilder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/AutofillResponseBuilder.kt
@@ -15,12 +15,12 @@ import android.service.autofill.SaveInfo
 import android.widget.RemoteViews
 import androidx.annotation.RequiresApi
 import com.github.ajalt.timberkt.e
-import com.github.michaelbull.result.fold
 import com.github.androidpasswordstore.autofillparser.AutofillAction
 import com.github.androidpasswordstore.autofillparser.AutofillScenario
 import com.github.androidpasswordstore.autofillparser.Credentials
 import com.github.androidpasswordstore.autofillparser.FillableForm
 import com.github.androidpasswordstore.autofillparser.fillWith
+import com.github.michaelbull.result.fold
 import com.zeapo.pwdstore.autofill.oreo.ui.AutofillDecryptActivity
 import com.zeapo.pwdstore.autofill.oreo.ui.AutofillFilterView
 import com.zeapo.pwdstore.autofill.oreo.ui.AutofillPublisherChangedActivity
@@ -88,8 +88,13 @@ class AutofillResponseBuilder(form: FillableForm) {
         publisherChangedException: AutofillPublisherChangedException
     ): Dataset {
         val remoteView = makeWarningRemoteView(context)
+        // If the user decides to trust the new publisher, they can choose reset the list of
+        // matches. In this case we need to immediately show a new `FillResponse` as if the app were
+        // autofilled for the first time. This `FillResponse` needs to be returned as a result from
+        // `AutofillPublisherChangedActivity`, which is why we create and pass it on here.
+        val fillResponseAfterReset = makeFillResponse(context, emptyList())
         val intentSender = AutofillPublisherChangedActivity.makePublisherChangedIntentSender(
-            context, publisherChangedException
+            context, publisherChangedException, fillResponseAfterReset
         )
         return makePlaceholderDataset(remoteView, intentSender, AutofillAction.Match)
     }

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillPublisherChangedActivity.kt
@@ -12,8 +12,10 @@ import android.content.IntentSender
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.service.autofill.FillResponse
 import android.text.format.DateUtils
 import android.view.View
+import android.view.autofill.AutofillManager
 import androidx.appcompat.app.AppCompatActivity
 import com.github.ajalt.timberkt.e
 import com.github.androidpasswordstore.autofillparser.FormOrigin
@@ -33,14 +35,18 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
 
         private const val EXTRA_APP_PACKAGE =
             "com.zeapo.pwdstore.autofill.oreo.ui.EXTRA_APP_PACKAGE"
+        private const val EXTRA_FILL_RESPONSE_AFTER_RESET =
+            "com.zeapo.pwdstore.autofill.oreo.ui.EXTRA_FILL_RESPONSE_AFTER_RESET"
         private var publisherChangedRequestCode = 1
 
         fun makePublisherChangedIntentSender(
             context: Context,
-            publisherChangedException: AutofillPublisherChangedException
+            publisherChangedException: AutofillPublisherChangedException,
+            fillResponseAfterReset: FillResponse?,
         ): IntentSender {
             val intent = Intent(context, AutofillPublisherChangedActivity::class.java).apply {
                 putExtra(EXTRA_APP_PACKAGE, publisherChangedException.formOrigin.identifier)
+                putExtra(EXTRA_FILL_RESPONSE_AFTER_RESET, fillResponseAfterReset)
             }
             return PendingIntent.getActivity(
                 context, publisherChangedRequestCode++, intent, PendingIntent.FLAG_CANCEL_CURRENT
@@ -72,6 +78,10 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
             }
             resetButton.setOnClickListener {
                 AutofillMatcher.clearMatchesFor(this@AutofillPublisherChangedActivity, FormOrigin.App(appPackage))
+                val fillResponse = intent.getParcelableExtra<FillResponse>(EXTRA_FILL_RESPONSE_AFTER_RESET)
+                setResult(RESULT_OK, Intent().apply {
+                    putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, fillResponse)
+                })
                 finish()
             }
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
If Autofill shows a warning about an app whose publisher changed and the
user decides to trust the app and clear previous matches, they should
immediately be given the option to select a new match.

Previously, as AutofillPublisherChangedActivity did not return a
result, the old FillResponse with just a warning would be reused. We
now pass a useful response with no matches on to the activity, which
returns it after the user has chosen to reset the publisher info.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves https://github.com/android-password-store/Android-Password-Store/pull/1136#issuecomment-703851026. Arguably this is not a workaround, but how Autofill intends this to be done.

## :green_heart: How did you test it?
Verified that the Autofill UI offers to search for a password entry right after the reset.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
