### PR TITLE
Temporarily work around SSHJ compatibility issues

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjConfig.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjConfig.kt
@@ -214,9 +214,6 @@ class SshjConfig : ConfigImpl() {
         keyExchangeFactories = listOf(
             Curve25519SHA256.Factory(),
             FactoryLibSsh(),
-            ECDHNistP.Factory521(),
-            ECDHNistP.Factory384(),
-            ECDHNistP.Factory256(),
             DHGexSHA256.Factory(),
             // Sends "ext-info-c" with the list of key exchange algorithms. This is needed to get
             // rsa-sha2-* key types to work with some servers (e.g. GitHub).
@@ -230,10 +227,10 @@ class SshjConfig : ConfigImpl() {
             KeyAlgorithms.EdDSA25519(),
             KeyAlgorithms.RSASHA512(),
             KeyAlgorithms.RSASHA256(),
+            KeyAlgorithms.SSHRSA(),
             KeyAlgorithms.ECDSASHANistp521(),
             KeyAlgorithms.ECDSASHANistp384(),
             KeyAlgorithms.ECDSASHANistp256(),
-            KeyAlgorithms.SSHRSA(),
         ).map {
             OpenKeychainWrappedKeyAlgorithmFactory(it)
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Using ECDSA either as a key exchange or a host key algorithm fails with
SSHJ 0.30.0 on Android, but should again become possible in 0.31.0.

While we wait for the release, demote ECDSA in the list of key
algorithms (as it should still be available for public key auth) and
remove it from the list of key exchange algorithms.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1141.

## :green_heart: How did you test it?
I am now able to connect without using Curve25519 as kex algorithm.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Revert this when SSHJ 0.31.0 is released with the proper fix.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
