### PR TITLE
ProxyUtils: correctly handle the 'no proxy' case

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/utils/ProxyUtils.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/ProxyUtils.kt
@@ -32,7 +32,7 @@ object ProxyUtils {
                 val host = GitSettings.proxyHost
                 val port = GitSettings.proxyPort
                 return if (host == null || port == -1) {
-                    mutableListOf()
+                    mutableListOf(Proxy.NO_PROXY)
                 } else {
                     mutableListOf(Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(host, port)))
                 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Send a passthrough-style Proxy instance when none is configured, as opposed to an empty list.

## :bulb: Motivation and Context
Without a proxy configured, HTTPS operations would fail with an OOB read because JGit's `HttpSupport` class assumes that [at least one](https://github.com/eclipse/jgit/blob/stable-3.7/org.eclipse.jgit/src/org/eclipse/jgit/util/HttpSupport.java#L222) proxy is configured at all times. `java.net.Proxy` comes with the `NO_PROXY` field that is supposedly the [correct default](https://stackoverflow.com/a/17071687) value that we should have been using.

## :green_heart: How did you test it?
Verified I could clone an HTTPS repository without a proxy configured on a clean install of the app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
