### PR TITLE
Backport ActivityResultContracts refactor to release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [1.12.0] - 2020-09-24
 
+### Fixed
+
+-   Certain operations like folder creation with GPG keys would fail with `java.lang.IllegalStateException`.
+-   ECDSA key exchanges failed resulting in users being unable to clone repositories.
+
 ### Added
 
 -   Allow sorting by recently used

--- a/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/autofill/oreo/ui/AutofillFilterActivity.kt
@@ -79,6 +79,13 @@ class AutofillFilterView : AppCompatActivity() {
         ViewModelProvider.AndroidViewModelFactory(application)
     }
 
+    private val decryptAction = registerForActivityResult(StartActivityForResult()) { result ->
+        if (result.resultCode == RESULT_OK) {
+            setResult(RESULT_OK, result.data)
+        }
+        finish()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -197,12 +204,7 @@ class AutofillFilterView : AppCompatActivity() {
             item.file
         )
         // intent?.extras? is checked to be non-null in onCreate
-        registerForActivityResult(StartActivityForResult()) { result ->
-            if (result.resultCode == RESULT_OK) {
-                setResult(RESULT_OK, result.data)
-            }
-            finish()
-        }.launch(AutofillDecryptActivity.makeDecryptFileIntent(
+        decryptAction.launch(AutofillDecryptActivity.makeDecryptFileIntent(
             item.file,
             intent!!.extras!!,
             this

--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjConfig.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjConfig.kt
@@ -214,9 +214,6 @@ class SshjConfig : ConfigImpl() {
         keyExchangeFactories = listOf(
             Curve25519SHA256.Factory(),
             FactoryLibSsh(),
-            ECDHNistP.Factory521(),
-            ECDHNistP.Factory384(),
-            ECDHNistP.Factory256(),
             DHGexSHA256.Factory(),
             // Sends "ext-info-c" with the list of key exchange algorithms. This is needed to get
             // rsa-sha2-* key types to work with some servers (e.g. GitHub).
@@ -230,10 +227,10 @@ class SshjConfig : ConfigImpl() {
             KeyAlgorithms.EdDSA25519(),
             KeyAlgorithms.RSASHA512(),
             KeyAlgorithms.RSASHA256(),
+            KeyAlgorithms.SSHRSA(),
             KeyAlgorithms.ECDSASHANistp521(),
             KeyAlgorithms.ECDSASHANistp384(),
             KeyAlgorithms.ECDSASHANistp256(),
-            KeyAlgorithms.SSHRSA(),
         ).map {
             OpenKeychainWrappedKeyAlgorithmFactory(it)
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Backports cf03c554785ee822be3408edcfb81fa4cf03d0e5 and 0d2788ab54b7898c88e8dc03d88323d70781a795 for a v1.12.1 patch release

## :bulb: Motivation and Context
While I had to close the issue because the user failed to follow the issue template, the ActivityResultContracts bug appears legitimate and since we've already fixed it, might as well backport. Including 0d2788ab54b7898c88e8dc03d88323d70781a795 because it was requested when the change landed but by itself it wasn't worth a new release.

## :green_heart: How did you test it?

:shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
