### PR TITLE
Stylistic cleanups across the board

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -312,6 +312,12 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
         const val ACTION_KEY = "action"
         const val ACTION_FOLDER = "folder"
         const val ACTION_PASSWORD = "password"
+
+        fun newInstance(args: Bundle): PasswordFragment {
+            val fragment = PasswordFragment()
+            fragment.arguments = args
+            return fragment
+        }
     }
 
 

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -35,6 +35,7 @@ import com.zeapo.pwdstore.ui.dialogs.BasicBottomSheet
 import com.zeapo.pwdstore.ui.dialogs.ItemCreationBottomSheet
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
+import com.zeapo.pwdstore.utils.PasswordSortOrder
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.base64
 import com.zeapo.pwdstore.utils.getString
@@ -262,7 +263,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
         runCatching {
             listener = object : OnFragmentInteractionListener {
                 override fun onFragmentInteraction(item: PasswordItem) {
-                    if (settings.getString(PreferenceKeys.SORT_ORDER) == PasswordRepository.PasswordSortOrder.RECENTLY_USED.name) {
+                    if (settings.getString(PreferenceKeys.SORT_ORDER) == PasswordSortOrder.RECENTLY_USED.name) {
                         //save the time when password was used
                         val preferences = context.getSharedPreferences("recent_password_history", Context.MODE_PRIVATE)
                         preferences.edit {

--- a/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SearchableRepositoryViewModel.kt
@@ -28,6 +28,7 @@ import com.zeapo.pwdstore.autofill.oreo.AutofillPreferences
 import com.zeapo.pwdstore.autofill.oreo.DirectoryStructure
 import com.zeapo.pwdstore.utils.PasswordItem
 import com.zeapo.pwdstore.utils.PasswordRepository
+import com.zeapo.pwdstore.utils.PasswordSortOrder
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.sharedPrefs
 import java.io.File
@@ -87,16 +88,16 @@ private val CaseInsensitiveComparator = Collator.getInstance().apply {
 }
 
 private fun PasswordItem.Companion.makeComparator(
-    typeSortOrder: PasswordRepository.PasswordSortOrder,
+    typeSortOrder: PasswordSortOrder,
     directoryStructure: DirectoryStructure
 ): Comparator<PasswordItem> {
     return when (typeSortOrder) {
-        PasswordRepository.PasswordSortOrder.FOLDER_FIRST -> compareBy { it.type }
+        PasswordSortOrder.FOLDER_FIRST -> compareBy { it.type }
         // In order to let INDEPENDENT not distinguish between items based on their type, we simply
         // declare them all equal at this stage.
-        PasswordRepository.PasswordSortOrder.INDEPENDENT -> Comparator { _, _ -> 0 }
-        PasswordRepository.PasswordSortOrder.FILE_FIRST -> compareByDescending { it.type }
-        PasswordRepository.PasswordSortOrder.RECENTLY_USED -> PasswordRepository.PasswordSortOrder.RECENTLY_USED.comparator
+        PasswordSortOrder.INDEPENDENT -> Comparator { _, _ -> 0 }
+        PasswordSortOrder.FILE_FIRST -> compareByDescending { it.type }
+        PasswordSortOrder.RECENTLY_USED -> PasswordSortOrder.RECENTLY_USED.comparator
     }
         .then(compareBy(nullsLast(CaseInsensitiveComparator)) {
             directoryStructure.getIdentifierFor(it.file)
@@ -150,7 +151,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
         }
 
     private val typeSortOrder
-        get() = PasswordRepository.PasswordSortOrder.getSortOrder(settings)
+        get() = PasswordSortOrder.getSortOrder(settings)
     private val directoryStructure
         get() = AutofillPreferences.directoryStructure(getApplication())
     private val itemComparator

--- a/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/SelectFolderActivity.kt
@@ -31,7 +31,7 @@ class SelectFolderActivity : AppCompatActivity(R.layout.select_folder_layout) {
         supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
 
         supportFragmentManager.commit {
-            replace(R.id.pgp_handler_linearlayout, passwordList, "PasswordsList")
+            replace(R.id.pgp_handler_linearlayout, passwordList, PASSWORD_FRAGMENT_TAG)
         }
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -22,7 +22,6 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.crypto.BasePgpActivity
 import com.zeapo.pwdstore.crypto.GetKeyIdsActivity
 import com.zeapo.pwdstore.utils.PasswordRepository
-import com.zeapo.pwdstore.utils.PasswordRepository.Companion.getRepositoryDirectory
 import com.zeapo.pwdstore.utils.commitChange
 import com.zeapo.pwdstore.utils.requestInputFocusOnView
 import java.io.File
@@ -41,7 +40,7 @@ class FolderCreationDialogFragment : DialogFragment() {
                 val repo = PasswordRepository.getRepository(null)
                 if (repo != null) {
                     lifecycleScope.launch {
-                        val repoPath = getRepositoryDirectory().absolutePath
+                        val repoPath = PasswordRepository.getRepositoryDirectory().absolutePath
                         requireActivity().commitChange(
                             getString(
                                 R.string.git_commit_gpg_id,

--- a/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/RepoLocationFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/ui/onboarding/fragments/RepoLocationFragment.kt
@@ -22,6 +22,7 @@ import com.zeapo.pwdstore.R
 import com.zeapo.pwdstore.UserPreference
 import com.zeapo.pwdstore.databinding.FragmentRepoLocationBinding
 import com.zeapo.pwdstore.utils.PasswordRepository
+import com.zeapo.pwdstore.utils.PasswordSortOrder
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.finish
 import com.zeapo.pwdstore.utils.getString
@@ -36,8 +37,8 @@ class RepoLocationFragment : Fragment(R.layout.fragment_repo_location) {
 
     private val settings by lazy(LazyThreadSafetyMode.NONE) { requireActivity().applicationContext.sharedPrefs }
     private val binding by viewBinding(FragmentRepoLocationBinding::bind)
-    private val sortOrder: PasswordRepository.PasswordSortOrder
-        get() = PasswordRepository.PasswordSortOrder.getSortOrder(settings)
+    private val sortOrder: PasswordSortOrder
+        get() = PasswordSortOrder.getSortOrder(settings)
 
     private val repositoryInitAction = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == AppCompatActivity.RESULT_OK) {

--- a/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/Extensions.kt
@@ -6,7 +6,6 @@ package com.zeapo.pwdstore.utils
 
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.runCatching
-import com.zeapo.pwdstore.utils.PasswordRepository.Companion.getRepositoryDirectory
 import java.io.File
 import java.util.Date
 import org.eclipse.jgit.lib.ObjectId
@@ -50,10 +49,10 @@ fun File.contains(other: File): Boolean {
 
 /**
  * Checks if this [File] is in the password repository directory as given
- * by [getRepositoryDirectory]
+ * by [PasswordRepository.getRepositoryDirectory]
  */
 fun File.isInsideRepository(): Boolean {
-    return canonicalPath.contains(getRepositoryDirectory().canonicalPath)
+    return canonicalPath.contains(PasswordRepository.getRepositoryDirectory().canonicalPath)
 }
 
 /**

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -4,8 +4,6 @@
  */
 package com.zeapo.pwdstore.utils
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
@@ -17,7 +15,6 @@ import java.io.File
 import java.io.FileFilter
 import java.nio.file.Files
 import java.nio.file.LinkOption
-import java.util.Comparator
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
@@ -51,42 +48,6 @@ open class PasswordRepository protected constructor() {
 
         override fun detect(cygwinUsed: Boolean?): FS {
             return FS_POSIX_Java6_with_optional_symlinks()
-        }
-    }
-
-    enum class PasswordSortOrder(val comparator: Comparator<PasswordItem>) {
-
-        FOLDER_FIRST(Comparator { p1: PasswordItem, p2: PasswordItem ->
-            (p1.type + p1.name)
-                .compareTo(p2.type + p2.name, ignoreCase = true)
-        }),
-
-        INDEPENDENT(Comparator { p1: PasswordItem, p2: PasswordItem ->
-            p1.name.compareTo(p2.name, ignoreCase = true)
-        }),
-
-        RECENTLY_USED(Comparator { p1: PasswordItem, p2: PasswordItem ->
-            val recentHistory = Application.instance.getSharedPreferences("recent_password_history", Context.MODE_PRIVATE)
-            val timeP1 = recentHistory.getString(p1.file.absolutePath.base64())
-            val timeP2 = recentHistory.getString(p2.file.absolutePath.base64())
-            when {
-                timeP1 != null && timeP2 != null -> timeP2.compareTo(timeP1)
-                timeP1 != null && timeP2 == null -> return@Comparator -1
-                timeP1 == null && timeP2 != null -> return@Comparator 1
-                else -> p1.name.compareTo(p2.name, ignoreCase = true)
-            }
-        }),
-
-        FILE_FIRST(Comparator { p1: PasswordItem, p2: PasswordItem ->
-            (p2.type + p1.name).compareTo(p1.type + p2.name, ignoreCase = true)
-        });
-
-        companion object {
-
-            @JvmStatic
-            fun getSortOrder(settings: SharedPreferences): PasswordSortOrder {
-                return valueOf(settings.getString(PreferenceKeys.SORT_ORDER) ?: FOLDER_FIRST.name)
-            }
         }
     }
 

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordRepository.kt
@@ -7,9 +7,9 @@ package com.zeapo.pwdstore.utils
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
-import com.github.michaelbull.result.runCatching
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.runCatching
 import com.zeapo.pwdstore.Application
 import java.io.File
 import java.io.FileFilter
@@ -24,7 +24,7 @@ import org.eclipse.jgit.transport.URIish
 import org.eclipse.jgit.util.FS
 import org.eclipse.jgit.util.FS_POSIX_Java6
 
-open class PasswordRepository protected constructor() {
+object PasswordRepository {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private class FS_POSIX_Java6_with_optional_symlinks : FS_POSIX_Java6() {
@@ -51,191 +51,188 @@ open class PasswordRepository protected constructor() {
         }
     }
 
-    companion object {
+    private var repository: Repository? = null
+    private val settings by lazy(LazyThreadSafetyMode.NONE) { Application.instance.sharedPrefs }
+    private val filesDir
+        get() = Application.instance.filesDir
 
-        private var repository: Repository? = null
-        private val settings by lazy(LazyThreadSafetyMode.NONE) { Application.instance.sharedPrefs }
-        private val filesDir
-            get() = Application.instance.filesDir
-
-        /**
-         * Returns the git repository
-         *
-         * @param localDir needed only on the creation
-         * @return the git repository
-         */
-        @JvmStatic
-        fun getRepository(localDir: File?): Repository? {
-            if (repository == null && localDir != null) {
-                val builder = FileRepositoryBuilder()
-                repository = runCatching {
-                    builder.run {
-                        gitDir = localDir
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            fs = Java7FSFactory().detect(null)
-                        }
-                        readEnvironment()
-                    }.build()
-                }.getOrElse { e ->
-                    e.printStackTrace()
-                    null
-                }
-            }
-            return repository
-        }
-
-        @JvmStatic
-        val isInitialized: Boolean
-            get() = repository != null
-
-        @JvmStatic
-        fun isGitRepo(): Boolean {
-            if (repository != null) {
-                return repository!!.objectDatabase.exists()
-            }
-            return false
-        }
-
-        @JvmStatic
-        @Throws(Exception::class)
-        fun createRepository(localDir: File) {
-            localDir.delete()
-
-            Git.init().setDirectory(localDir).call()
-            getRepository(localDir)
-        }
-
-        // TODO add multiple remotes support for pull/push
-        @JvmStatic
-        fun addRemote(name: String, url: String, replace: Boolean = false) {
-            val storedConfig = repository!!.config
-            val remotes = storedConfig.getSubsections("remote")
-
-            if (!remotes.contains(name)) {
-                runCatching {
-                    val uri = URIish(url)
-                    val refSpec = RefSpec("+refs/head/*:refs/remotes/$name/*")
-
-                    val remoteConfig = RemoteConfig(storedConfig, name)
-                    remoteConfig.addFetchRefSpec(refSpec)
-                    remoteConfig.addPushRefSpec(refSpec)
-                    remoteConfig.addURI(uri)
-                    remoteConfig.addPushURI(uri)
-
-                    remoteConfig.update(storedConfig)
-
-                    storedConfig.save()
-                }.onFailure { e ->
-                    e.printStackTrace()
-                }
-            } else if (replace) {
-                runCatching {
-                    val uri = URIish(url)
-
-                    val remoteConfig = RemoteConfig(storedConfig, name)
-                    // remove the first and eventually the only uri
-                    if (remoteConfig.urIs.size > 0) {
-                        remoteConfig.removeURI(remoteConfig.urIs[0])
+    /**
+     * Returns the git repository
+     *
+     * @param localDir needed only on the creation
+     * @return the git repository
+     */
+    @JvmStatic
+    fun getRepository(localDir: File?): Repository? {
+        if (repository == null && localDir != null) {
+            val builder = FileRepositoryBuilder()
+            repository = runCatching {
+                builder.run {
+                    gitDir = localDir
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        fs = Java7FSFactory().detect(null)
                     }
-                    if (remoteConfig.pushURIs.size > 0) {
-                        remoteConfig.removePushURI(remoteConfig.pushURIs[0])
-                    }
-
-                    remoteConfig.addURI(uri)
-                    remoteConfig.addPushURI(uri)
-
-                    remoteConfig.update(storedConfig)
-
-                    storedConfig.save()
-                }.onFailure { e ->
-                    e.printStackTrace()
-                }
+                    readEnvironment()
+                }.build()
+            }.getOrElse { e ->
+                e.printStackTrace()
+                null
             }
         }
+        return repository
+    }
 
-        @JvmStatic
-        fun closeRepository() {
-            if (repository != null) repository!!.close()
-            repository = null
+    @JvmStatic
+    val isInitialized: Boolean
+        get() = repository != null
+
+    @JvmStatic
+    fun isGitRepo(): Boolean {
+        if (repository != null) {
+            return repository!!.objectDatabase.exists()
         }
+        return false
+    }
 
-        @JvmStatic
-        fun getRepositoryDirectory(): File {
-            return if (settings.getBoolean(PreferenceKeys.GIT_EXTERNAL, false)) {
-                val externalRepo = settings.getString(PreferenceKeys.GIT_EXTERNAL_REPO)
-                if (externalRepo != null)
-                    File(externalRepo)
-                else
-                    File(filesDir.toString(), "/store")
-            } else {
+    @JvmStatic
+    @Throws(Exception::class)
+    fun createRepository(localDir: File) {
+        localDir.delete()
+
+        Git.init().setDirectory(localDir).call()
+        getRepository(localDir)
+    }
+
+    // TODO add multiple remotes support for pull/push
+    @JvmStatic
+    fun addRemote(name: String, url: String, replace: Boolean = false) {
+        val storedConfig = repository!!.config
+        val remotes = storedConfig.getSubsections("remote")
+
+        if (!remotes.contains(name)) {
+            runCatching {
+                val uri = URIish(url)
+                val refSpec = RefSpec("+refs/head/*:refs/remotes/$name/*")
+
+                val remoteConfig = RemoteConfig(storedConfig, name)
+                remoteConfig.addFetchRefSpec(refSpec)
+                remoteConfig.addPushRefSpec(refSpec)
+                remoteConfig.addURI(uri)
+                remoteConfig.addPushURI(uri)
+
+                remoteConfig.update(storedConfig)
+
+                storedConfig.save()
+            }.onFailure { e ->
+                e.printStackTrace()
+            }
+        } else if (replace) {
+            runCatching {
+                val uri = URIish(url)
+
+                val remoteConfig = RemoteConfig(storedConfig, name)
+                // remove the first and eventually the only uri
+                if (remoteConfig.urIs.size > 0) {
+                    remoteConfig.removeURI(remoteConfig.urIs[0])
+                }
+                if (remoteConfig.pushURIs.size > 0) {
+                    remoteConfig.removePushURI(remoteConfig.pushURIs[0])
+                }
+
+                remoteConfig.addURI(uri)
+                remoteConfig.addPushURI(uri)
+
+                remoteConfig.update(storedConfig)
+
+                storedConfig.save()
+            }.onFailure { e ->
+                e.printStackTrace()
+            }
+        }
+    }
+
+    @JvmStatic
+    fun closeRepository() {
+        if (repository != null) repository!!.close()
+        repository = null
+    }
+
+    @JvmStatic
+    fun getRepositoryDirectory(): File {
+        return if (settings.getBoolean(PreferenceKeys.GIT_EXTERNAL, false)) {
+            val externalRepo = settings.getString(PreferenceKeys.GIT_EXTERNAL_REPO)
+            if (externalRepo != null)
+                File(externalRepo)
+            else
                 File(filesDir.toString(), "/store")
+        } else {
+            File(filesDir.toString(), "/store")
+        }
+    }
+
+    @JvmStatic
+    fun initialize(): Repository? {
+        val dir = getRepositoryDirectory()
+        // uninitialize the repo if the dir does not exist or is absolutely empty
+        settings.edit {
+            if (!dir.exists() || !dir.isDirectory || requireNotNull(dir.listFiles()).isEmpty()) {
+                putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)
+            } else {
+                putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true)
             }
         }
 
-        @JvmStatic
-        fun initialize(): Repository? {
-            val dir = getRepositoryDirectory()
-            // uninitialize the repo if the dir does not exist or is absolutely empty
-            settings.edit {
-                if (!dir.exists() || !dir.isDirectory || requireNotNull(dir.listFiles()).isEmpty()) {
-                    putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)
-                } else {
-                    putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true)
-                }
-            }
+        // create the repository static variable in PasswordRepository
+        return getRepository(File(dir.absolutePath + "/.git"))
+    }
 
-            // create the repository static variable in PasswordRepository
-            return getRepository(File(dir.absolutePath + "/.git"))
+    /**
+     * Gets the .gpg files in a directory
+     *
+     * @param path the directory path
+     * @return the list of gpg files in that directory
+     */
+    @JvmStatic
+    fun getFilesList(path: File?): ArrayList<File> {
+        if (path == null || !path.exists()) return ArrayList()
+
+        val directories = (path.listFiles(FileFilter { pathname -> pathname.isDirectory })
+            ?: emptyArray()).toList()
+        val files = (path.listFiles(FileFilter { pathname -> pathname.extension == "gpg" })
+            ?: emptyArray()).toList()
+
+        val items = ArrayList<File>()
+        items.addAll(directories)
+        items.addAll(files)
+
+        return items
+    }
+
+    /**
+     * Gets the passwords (PasswordItem) in a directory
+     *
+     * @param path the directory path
+     * @return a list of password items
+     */
+    @JvmStatic
+    fun getPasswords(path: File, rootDir: File, sortOrder: PasswordSortOrder): ArrayList<PasswordItem> {
+        // We need to recover the passwords then parse the files
+        val passList = getFilesList(path).also { it.sortBy { f -> f.name } }
+        val passwordList = ArrayList<PasswordItem>()
+        val showHidden = settings.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false)
+
+        if (passList.size == 0) return passwordList
+        if (!showHidden) {
+            passList.filter { !it.isHidden }.toCollection(passList.apply { clear() })
         }
-
-        /**
-         * Gets the .gpg files in a directory
-         *
-         * @param path the directory path
-         * @return the list of gpg files in that directory
-         */
-        @JvmStatic
-        fun getFilesList(path: File?): ArrayList<File> {
-            if (path == null || !path.exists()) return ArrayList()
-
-            val directories = (path.listFiles(FileFilter { pathname -> pathname.isDirectory })
-                ?: emptyArray()).toList()
-            val files = (path.listFiles(FileFilter { pathname -> pathname.extension == "gpg" })
-                ?: emptyArray()).toList()
-
-            val items = ArrayList<File>()
-            items.addAll(directories)
-            items.addAll(files)
-
-            return items
+        passList.forEach { file ->
+            passwordList.add(if (file.isFile) {
+                PasswordItem.newPassword(file.name, file, rootDir)
+            } else {
+                PasswordItem.newCategory(file.name, file, rootDir)
+            })
         }
-
-        /**
-         * Gets the passwords (PasswordItem) in a directory
-         *
-         * @param path the directory path
-         * @return a list of password items
-         */
-        @JvmStatic
-        fun getPasswords(path: File, rootDir: File, sortOrder: PasswordSortOrder): ArrayList<PasswordItem> {
-            // We need to recover the passwords then parse the files
-            val passList = getFilesList(path).also { it.sortBy { f -> f.name } }
-            val passwordList = ArrayList<PasswordItem>()
-            val showHidden = settings.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false)
-
-            if (passList.size == 0) return passwordList
-            if (!showHidden) {
-                passList.filter { !it.isHidden }.toCollection(passList.apply { clear() })
-            }
-            passList.forEach { file ->
-                passwordList.add(if (file.isFile) {
-                    PasswordItem.newPassword(file.name, file, rootDir)
-                } else {
-                    PasswordItem.newCategory(file.name, file, rootDir)
-                })
-            }
-            passwordList.sortWith(sortOrder.comparator)
-            return passwordList
-        }
+        passwordList.sortWith(sortOrder.comparator)
+        return passwordList
     }
 }

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PasswordSortOrder.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PasswordSortOrder.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.zeapo.pwdstore.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.zeapo.pwdstore.Application
+
+enum class PasswordSortOrder(val comparator: java.util.Comparator<PasswordItem>) {
+
+    FOLDER_FIRST(Comparator { p1: PasswordItem, p2: PasswordItem ->
+        (p1.type + p1.name)
+            .compareTo(p2.type + p2.name, ignoreCase = true)
+    }),
+
+    INDEPENDENT(Comparator { p1: PasswordItem, p2: PasswordItem ->
+        p1.name.compareTo(p2.name, ignoreCase = true)
+    }),
+
+    RECENTLY_USED(Comparator { p1: PasswordItem, p2: PasswordItem ->
+        val recentHistory = Application.instance.getSharedPreferences("recent_password_history", Context.MODE_PRIVATE)
+        val timeP1 = recentHistory.getString(p1.file.absolutePath.base64())
+        val timeP2 = recentHistory.getString(p2.file.absolutePath.base64())
+        when {
+            timeP1 != null && timeP2 != null -> timeP2.compareTo(timeP1)
+            timeP1 != null && timeP2 == null -> return@Comparator -1
+            timeP1 == null && timeP2 != null -> return@Comparator 1
+            else -> p1.name.compareTo(p2.name, ignoreCase = true)
+        }
+    }),
+
+    FILE_FIRST(Comparator { p1: PasswordItem, p2: PasswordItem ->
+        (p2.type + p1.name).compareTo(p1.type + p2.name, ignoreCase = true)
+    });
+
+    companion object {
+
+        @JvmStatic
+        fun getSortOrder(settings: SharedPreferences): PasswordSortOrder {
+            return valueOf(settings.getString(PreferenceKeys.SORT_ORDER) ?: FOLDER_FIRST.name)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,8 +329,8 @@
     <string name="connection_mode_openkeychain" translatable="false">OpenKeychain</string>
     <string name="git_server_config_save_success">Successfully saved configuration</string>
     <string name="git_server_config_save_error">The provided repository URL is not valid</string>
-    <string name="git_server_config_save_missing_username_https">Please specify the HTTPS username in the form https://username@example.com/username/…</string>
-    <string name="git_server_config_save_missing_username_ssh">Please specify the SSH username in the form username@example.com:username/…</string>
+    <string name="git_server_config_save_missing_username_https">Please specify the HTTPS username in the form https://username@example.com/…</string>
+    <string name="git_server_config_save_missing_username_ssh">Please specify the SSH username in the form username@example.com:…</string>
     <string name="git_server_config_save_auth_mode_mismatch">Valid authentication modes for %1$s: %2$s</string>
     <string name="git_operation_wrong_passphrase">Wrong passphrase</string>
     <string name="git_operation_wrong_password">Wrong password</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Removes unnecessary `lateinit` variables from `PasswordStore` and converts `PasswordRepository` into a proper singleton which it is used as anyways.

## :bulb: Motivation and Context
The confusing variable references in `PasswordStore` are a cognitive overhead when attempting to make sense of it, and `PasswordRepository`'s `open class` modifier is misleading when it is in reality a singleton.

## :green_heart: How did you test it?
App compiles and continues working as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
