### PR TITLE
Fix auth mode switching and expand URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 -  Add GPG key selection step to onboarding flow
 -  Allow configuring an app-wide HTTP(S) proxy
 -  Add option to automatically sync repository on app launch
+-  Add a quickfix for invalid HTTPS URLs that contain a custom port
 
 ## [1.12.1] - 2020-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 -  Some classes of errors would be swallowed by an unhelpful 'Invalid remote: origin' message
 -  Repositories created within APS would contain invalid `.gpg-id` files with no ability to fix them from the app
 -  Button labels were invisible in Autofill phishing warning screen
+-  Unsupported authentication modes would appear briefly in the server config screen
 
 ### Added
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitServerConfigActivity.kt
@@ -71,24 +71,15 @@ class GitServerConfigActivity : BaseGitActivity() {
             }
         }
 
-        binding.serverUrl.setText(GitSettings.url)
+        binding.serverUrl.setText(GitSettings.url.also {
+            if (it.isNullOrEmpty()) return@also
+            setAuthModes(it.startsWith("http://") || it.startsWith("https://"))
+        })
         binding.serverBranch.setText(GitSettings.branch)
 
         binding.serverUrl.doOnTextChanged { text, _, _, _ ->
             if (text.isNullOrEmpty()) return@doOnTextChanged
-            if (text.startsWith("http://") || text.startsWith("https://")) {
-                binding.authModeSshKey.isVisible = false
-                binding.authModeOpenKeychain.isVisible = false
-                binding.authModePassword.isVisible = true
-                if (binding.authModeGroup.checkedButtonId != binding.authModePassword.id)
-                    binding.authModeGroup.check(View.NO_ID)
-            } else {
-                binding.authModeSshKey.isVisible = true
-                binding.authModeOpenKeychain.isVisible = true
-                binding.authModePassword.isVisible = true
-                if (binding.authModeGroup.checkedButtonId == View.NO_ID)
-                    binding.authModeGroup.check(binding.authModeSshKey.id)
-            }
+            setAuthModes(text.startsWith("http://") || text.startsWith("https://"))
         }
 
         binding.saveButton.setOnClickListener {
@@ -168,6 +159,22 @@ class GitServerConfigActivity : BaseGitActivity() {
         }
     }
 
+    private fun setAuthModes(isHttps: Boolean) = with(binding) {
+        if (isHttps) {
+            authModeSshKey.isVisible = false
+            authModeOpenKeychain.isVisible = false
+            authModePassword.isVisible = true
+            if (authModeGroup.checkedButtonId != authModePassword.id)
+                authModeGroup.check(View.NO_ID)
+        } else {
+            authModeSshKey.isVisible = true
+            authModeOpenKeychain.isVisible = true
+            authModePassword.isVisible = true
+            if (authModeGroup.checkedButtonId == View.NO_ID)
+                authModeGroup.check(authModeSshKey.id)
+        }
+    }
+
     /**
      * Clones the repository, the directory exists, deletes it
      */
@@ -234,6 +241,7 @@ class GitServerConfigActivity : BaseGitActivity() {
     }
 
     companion object {
+
         fun createCloneIntent(context: Context): Intent {
             return Intent(context, GitServerConfigActivity::class.java).apply {
                 putExtra("cloning", true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,6 +407,8 @@
     <!-- SSH port validation -->
     <string name="ssh_scheme_needed_title">Potentially incorrect URL</string>
     <string name="ssh_scheme_needed_message">It appears that your URL contains a custom port, but does not specify the ssh:// scheme.\nThis can cause the port to be considered a part of your path. Press OK here to fix the URL.</string>
+    <string name="https_scheme_with_port_title">HTTPS URL with custom port</string>
+    <string name="https_scheme_with_port_message">It looks like you are using a HTTPS URL with a custom port. This is not supported, and will cause problems down the line. Press OK to remove the port from your URL.</string>
     <string name="sync_on_launch_title">Sync on launch</string>
     <string name="sync_on_launch_summary">Sync passwords when application is launched</string>
     <string name="syncing">Syncing…</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
- Ensure auth modes are correctly set when the server config activity first starts.
- Add a quickfix for HTTPS URLs defining a custom port

## :bulb: Motivation and Context
Currently the visibility of auth modes is only changed when the URL is modified, resulting in HTTPS users being shown SSH key and OpenKeychain authentication which is wrong.

The HTTPS URL quickfix is mostly a product of my buffoonery during testing and can be dropped entirely if not deemed useful.

## :green_heart: How did you test it?

Verified cloning an HTTPS repository then opening the server config screen only presented me with the checked password authentication mode.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
