### PR TITLE
Workaround AndroidX lifecycle requirements in OpenKeychain auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenKeychain authentication would fail with `LifecycleOwner com.zeapo.pwdstore.git.GitServerConfigActivity@f578da1 is attempting to register while current state is RESUMED. LifecycleOwners must call register before they are STARTED.`
+
 ### Added
 
 -  Add support for domain-level autofill in DuckDuckGo's F-Droid builds.

--- a/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/BaseGitActivity.kt
@@ -20,6 +20,7 @@ import com.zeapo.pwdstore.git.operation.PullOperation
 import com.zeapo.pwdstore.git.operation.PushOperation
 import com.zeapo.pwdstore.git.operation.ResetToRemoteOperation
 import com.zeapo.pwdstore.git.operation.SyncOperation
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import com.zeapo.pwdstore.utils.PreferenceKeys
 import com.zeapo.pwdstore.utils.getEncryptedGitPrefs
 import com.zeapo.pwdstore.utils.sharedPrefs
@@ -33,7 +34,7 @@ import net.schmizz.sshj.userauth.UserAuthException
  * Abstract [AppCompatActivity] that holds some information that is commonly shared across git-related
  * tasks and makes sense to be held here.
  */
-abstract class BaseGitActivity : AppCompatActivity() {
+abstract class BaseGitActivity : ContinuationContainerActivity() {
 
     /**
      * Enum of possible Git operations than can be run through [launchGitOperation].

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/BreakOutOfDetached.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/BreakOutOfDetached.kt
@@ -4,12 +4,12 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.zeapo.pwdstore.R
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import org.eclipse.jgit.api.RebaseCommand
 
-class BreakOutOfDetached(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
+class BreakOutOfDetached(callingActivity: ContinuationContainerActivity) : GitOperation(callingActivity) {
 
     override val commands = arrayOf(
         // abort the rebase

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/CloneOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/CloneOperation.kt
@@ -4,7 +4,7 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.GitCommand
 
@@ -14,7 +14,7 @@ import org.eclipse.jgit.api.GitCommand
  * @param uri URL to clone the repository from
  * @param callingActivity the calling activity
  */
-class CloneOperation(callingActivity: AppCompatActivity, uri: String) : GitOperation(callingActivity) {
+class CloneOperation(callingActivity: ContinuationContainerActivity, uri: String) : GitOperation(callingActivity) {
 
     override val commands: Array<GitCommand<out Any>> = arrayOf(
         Git.cloneRepository().setBranch(remoteBranch).setDirectory(repository.workTree).setURI(uri),

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/PullOperation.kt
@@ -4,10 +4,10 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import org.eclipse.jgit.api.GitCommand
 
-class PullOperation(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
+class PullOperation(callingActivity: ContinuationContainerActivity) : GitOperation(callingActivity) {
 
     /**
      * The story of why the pull operation is committing files goes like this: Once upon a time when

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/PushOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/PushOperation.kt
@@ -4,10 +4,10 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import org.eclipse.jgit.api.GitCommand
 
-class PushOperation(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
+class PushOperation(callingActivity: ContinuationContainerActivity) : GitOperation(callingActivity) {
 
     override val commands: Array<GitCommand<out Any>> = arrayOf(
         git.push().setPushAll().setRemote("origin"),

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/ResetToRemoteOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/ResetToRemoteOperation.kt
@@ -4,10 +4,10 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 import org.eclipse.jgit.api.ResetCommand
 
-class ResetToRemoteOperation(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
+class ResetToRemoteOperation(callingActivity: ContinuationContainerActivity) : GitOperation(callingActivity) {
 
     override val commands = arrayOf(
         // Stage all files

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/SyncOperation.kt
@@ -4,9 +4,9 @@
  */
 package com.zeapo.pwdstore.git.operation
 
-import androidx.appcompat.app.AppCompatActivity
+import com.zeapo.pwdstore.git.sshj.ContinuationContainerActivity
 
-class SyncOperation(callingActivity: AppCompatActivity) : GitOperation(callingActivity) {
+class SyncOperation(callingActivity: ContinuationContainerActivity) : GitOperation(callingActivity) {
 
     override val commands = arrayOf(
         // Stage all files

--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/ContinuationContainerActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/ContinuationContainerActivity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package com.zeapo.pwdstore.git.sshj
+
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.LayoutRes
+import androidx.appcompat.app.AppCompatActivity
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import net.schmizz.sshj.common.DisconnectReason
+import net.schmizz.sshj.userauth.UserAuthException
+
+/**
+ * Workaround for https://msfjarvis.dev/aps/issue/1164
+ */
+open class ContinuationContainerActivity : AppCompatActivity {
+
+    constructor() : super()
+    constructor(@LayoutRes layoutRes: Int) : super(layoutRes)
+
+    var stashedCont: Continuation<Intent>? = null
+
+    val continueAfterUserInteraction = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+        stashedCont?.let { cont ->
+            stashedCont = null
+            val data = result.data
+            if (data != null)
+                cont.resume(data)
+            else
+                cont.resumeWithException(UserAuthException(DisconnectReason.AUTH_CANCELLED_BY_USER))
+        }
+    }
+}

--- a/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjSessionFactory.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/sshj/SshjSessionFactory.kt
@@ -5,7 +5,6 @@
 package com.zeapo.pwdstore.git.sshj
 
 import android.util.Base64
-import androidx.fragment.app.FragmentActivity
 import com.github.ajalt.timberkt.d
 import com.github.ajalt.timberkt.w
 import com.github.michaelbull.result.getOrElse
@@ -40,10 +39,10 @@ import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.URIish
 import org.eclipse.jgit.util.FS
 
-sealed class SshAuthMethod(val activity: FragmentActivity) {
-    class Password(activity: FragmentActivity) : SshAuthMethod(activity)
-    class SshKey(activity: FragmentActivity) : SshAuthMethod(activity)
-    class OpenKeychain(activity: FragmentActivity) : SshAuthMethod(activity)
+sealed class SshAuthMethod(val activity: ContinuationContainerActivity) {
+    class Password(activity: ContinuationContainerActivity) : SshAuthMethod(activity)
+    class SshKey(activity: ContinuationContainerActivity) : SshAuthMethod(activity)
+    class OpenKeychain(activity: ContinuationContainerActivity) : SshAuthMethod(activity)
 }
 
 abstract class InteractivePasswordFinder : PasswordFinder {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Create a container activity to hold the nuts and bolts of our OpenKeychain authentication's `USER_INTERACTION_REQUIRED` stage and employ some sly workarounds to propagate its use.

## :bulb: Motivation and Context
Fixes #1164 

## :green_heart: How did you test it?
Verified I can authenticate using OpenKeychain

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [X] I reviewed submitted code
- [X] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
