### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"
@@ -21,7 +21,7 @@ jobs:
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
     - name: Build release app
-      uses: burrunan/gradle-cache-action@v1
+      uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       env:
         SNAPSHOT: "true"
       with:

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Draft a new release"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
         with:
           ref: 'release'
       - name: Extract version from milestone
@@ -32,7 +32,7 @@ jobs:
           git commit -am "Prepare release $RELEASE_VERSION"
 
       - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@24ed95dd0d9ada9dfec0d555129c3db5a9e93e2a
         with:
           source_branch: release-${{ env.RELEASE_VERSION }}
           destination_branch: release

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -15,26 +15,26 @@ jobs:
       - name: Extract version from milestone
         run: |
           VERSION="${{ github.event.milestone.title }}"
-          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create release branch
-        run: git checkout -b release-${{ env.RELEASE_VERSION }}
+          echo "RELEASE_VERSION=${VERSION/v/}" >> $GITHUB_ENV
 
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
         with:
-          version: v${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
 
       - name: Initialize git config and commit changes
         run: |
           git config user.name "GitHub Actions"
           git config user.email noreply@github.com
-          git commit -am "Prepare release $RELEASE_VERSION"
 
       - name: Create Pull Request
-        uses: repo-sync/pull-request@24ed95dd0d9ada9dfec0d555129c3db5a9e93e2a
+        uses: peter-evans/create-pull-request@c7f493a8000b8aeb17a1332e326ba76b57cb83eb
         with:
-          source_branch: release-${{ env.RELEASE_VERSION }}
-          destination_branch: release
-          pr_title: Release ${{ env.RELEASE_VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          author: GitHub Actions <noreply@github.com>
+          base: release
+          body: This is an automated pull request to bump the changelog for the v${{ env.RELEASE_VERSION }} release.
+          branch: release-${{ env.RELEASE_VERSION }}
+          commit-message: "CHANGELOG: bump for ${{ env.RELEASE_VERSION }}"
+          draft: true
+          title: Release v${{ env.RELEASE_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check if relevant files have changed
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9
       id: service-changed
       with:
         result-encoding: string
@@ -27,7 +27,7 @@ jobs:
 
     - name: Checkout repository
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}
@@ -35,13 +35,13 @@ jobs:
 
     - name: Run unit tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: burrunan/gradle-cache-action@v1
+      uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
         arguments: apiCheck testFreeDebug lintFreeDebug
 
     - name: Run instrumentation tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: reactivecircus/android-emulator-runner@v2.11.0
+      uses: reactivecircus/android-emulator-runner@07b0366e7b93d87f3d00b3e78d9033f04009b347
       with:
         api-level: ${{ matrix.api-level }}
         target: default
@@ -53,7 +53,7 @@ jobs:
 
     - name: (Fail-only) upload test report
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
           name: Test report
           path: app/build/reports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"
@@ -21,24 +21,24 @@ jobs:
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
     - name: Build release binaries
-      uses: burrunan/gradle-cache-action@v1
+      uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
         arguments: :app:assembleFreeRelease :app:assembleNonFreeRelease :app:bundleNonFreeRelease
 
     - name: Upload non-free release APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
         name: APS Non-Free Release APK
         path: app/build/outputs/apk/nonFree/release/app-nonFree-release.apk
 
     - name: Upload non-free release Bundle
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
         name: APS Non-Free Release Bundle
         path: app/build/outputs/bundle/nonFreeRelease/app-nonFree-release.aab
 
     - name: Upload free release APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
         name: APS Free Release APK
         path: app/build/outputs/apk/free/release/app-free-release.apk
@@ -53,36 +53,36 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
       - name: Get Non-Free Release APK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@f60857ee283b759efd0a9bf31b1b24a2d9c7e5cd
         with:
           name: APS Non-Free Release APK
           path: artifacts/nonFree
 
       - name: Get Non-Free Bundle
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@f60857ee283b759efd0a9bf31b1b24a2d9c7e5cd
         with:
           name: APS Non-Free Release Bundle
           path: artifacts/nonFree
 
       - name: Get Free Release APK
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@f60857ee283b759efd0a9bf31b1b24a2d9c7e5cd
         with:
           name: APS Free Release APK
           path: artifacts/free
 
       - name: Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@v1.1.0
+        uses: mindsers/changelog-reader-action@30552f0e948002519ff6b36ffbf889ef4da47246
         with:
           version: ${{ github.ref }}
           path: ./CHANGELOG.md
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@c38d3a140cc22e67e265c5d5b6b4888d1f02533f
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -97,7 +97,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
       - name: Upload Non-Free Release Apk
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e9f0662bdf9868f4aac644f0eedc2b56567fdba8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -107,7 +107,7 @@ jobs:
           asset_content_type: application/vnd.android.package-archive
 
       - name: Upload Non-Free Release Bundle
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e9f0662bdf9868f4aac644f0eedc2b56567fdba8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -117,7 +117,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Free Release Apk
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e9f0662bdf9868f4aac644f0eedc2b56567fdba8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
       - name: Initialize git config
         run: |
@@ -23,7 +23,7 @@ jobs:
         run: if [[ $(git diff --binary --stat) != '' ]]; then echo "UPDATED=true" >> $GITHUB_ENV; fi
 
       - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@24ed95dd0d9ada9dfec0d555129c3db5a9e93e2a
         if: env.UPDATED == 'true'
         with:
           source_branch: bot/update-psl

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -10,12 +10,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
-      - name: Initialize git config
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email noreply@github.com
-          git checkout -b bot/update-psl
-
       - name: Download new publicsuffix data
         run: curl -L https://github.com/mozilla-mobile/android-components/raw/master/components/lib/publicsuffixlist/src/main/assets/publicsuffixes -o autofill-parser/src/main/assets/publicsuffixes
 
@@ -23,13 +17,15 @@ jobs:
         run: if [[ $(git diff --binary --stat) != '' ]]; then echo "UPDATED=true" >> $GITHUB_ENV; fi
 
       - name: Create Pull Request
-        uses: repo-sync/pull-request@24ed95dd0d9ada9dfec0d555129c3db5a9e93e2a
+        uses: peter-evans/create-pull-request@c7f493a8000b8aeb17a1332e326ba76b57cb83eb
         if: env.UPDATED == 'true'
         with:
-          source_branch: bot/update-psl
-          destination_branch: develop
-          pr_title: "Update Public Suffix List data"
-          pr_body: "This is an automated pull request to update the publicsuffixes file to the latest copy from Mozilla"
           assignees: msfjarvis
-          pr_label: PSL
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          author: GitHub Actions <noreply@github.com>
+          base: develop
+          body: This is an automated pull request to update the publicsuffixes file to the latest copy from Mozilla
+          branch: bot/update-psl
+          commit-message: "autofill-parser: update publicsuffixes file"
+          labels: PSL
+          title: Update Public Suffix List data
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate_wrapper.yml
+++ b/.github/workflows/validate_wrapper.yml
@@ -12,5 +12,5 @@ jobs:
     name: "Wrapper validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1.0.3
+      - uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
+      - uses: gradle/wrapper-validation-action@2a9956c214b2b4b63544570479c926e7a121218e


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Pins all GitHub actions to exact commit hashes and replaces the pull request creation action with a more consistent and reliable one.

## :bulb: Motivation and Context
Tags can be force pushed to replace legitimate actions with malicious code which is a security risk. Using exact commit hashes makes updating slightly cumbersome in return for guaranteeing completely that a particular action will always have the code it did when the workflow was created.

In our neverending quest for a GitHub Action for pull requests, yet again we switch from `repo-sync/pull-request` to `peter-evans/create-pull-request` that appears to be working much better now that it won't silently update and cause breakages.

## :green_heart: How did you test it?
Release draft workflow: https://github.com/msfjarvis/Android-Password-Store/pull/7
Public suffix update: https://github.com/msfjarvis/Android-Password-Store/pull/6

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
