### PR TITLE
Fix extra content for multiple username fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Cancelling the Autofill "Generate password" action now correctly returns you to the original app.
+-   If multiple username fields exist in the password, we now ensure the later ones are not dropped from extra content.
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/model/PasswordEntry.kt
@@ -60,9 +60,11 @@ class PasswordEntry(content: String, private val totpFinder: TotpFinder = UriTot
     }
 
     val extraContentWithoutAuthData by lazy(LazyThreadSafetyMode.NONE) {
+        var foundUsername = false
         extraContent.splitToSequence("\n").filter { line ->
             return@filter when {
-                USERNAME_FIELDS.any { prefix -> line.startsWith(prefix, ignoreCase = true) } -> {
+                USERNAME_FIELDS.any { prefix -> line.startsWith(prefix, ignoreCase = true) } && !foundUsername -> {
+                    foundUsername = true
                     false
                 }
                 line.startsWith("otpauth://", ignoreCase = true) ||

--- a/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
+++ b/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
@@ -116,6 +116,17 @@ class PasswordEntryTest {
         assertFalse(entry.hasUsername())
     }
 
+    // https://msfjarvis.dev/aps/issue/1190
+    @Test fun extraContentWithUnknownFieldsInBetween() {
+        val entry = makeEntry("pass\nuser: user\nid: id\n$TOTP_URI")
+        assertTrue(entry.hasExtraContent())
+        assertTrue(entry.hasTotp())
+        assertTrue(entry.hasUsername())
+        assertEquals("pass", entry.password)
+        assertEquals("user", entry.username)
+        assertEquals("id: id", entry.extraContentWithoutAuthData)
+    }
+
     companion object {
 
         const val TOTP_URI = "otpauth://totp/ACME%20Co:john@example.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30"

--- a/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
+++ b/app/src/test/java/com/zeapo/pwdstore/model/PasswordEntryTest.kt
@@ -116,8 +116,8 @@ class PasswordEntryTest {
         assertFalse(entry.hasUsername())
     }
 
-    // https://msfjarvis.dev/aps/issue/1190
-    @Test fun extraContentWithUnknownFieldsInBetween() {
+    // https://github.com/android-password-store/Android-Password-Store/issues/1190
+    @Test fun extraContentWithMultipleUsernameFields() {
         val entry = makeEntry("pass\nuser: user\nid: id\n$TOTP_URI")
         assertTrue(entry.hasExtraContent())
         assertTrue(entry.hasTotp())


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Only drop the first username field from extra content because that's the one we pick to be username in the UI.

## :bulb: Motivation and Context
Fixes #1190

## :green_heart: How did you test it?
Added a unit test for the reporter's provided test case

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
