### PR TITLE
Fix Autofill dataset icon tint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 -   Cancelling the Autofill "Generate password" action now correctly returns you to the original app.
 -   If multiple username fields exist in the password, we now ensure the later ones are not dropped from extra content.
+-   Icons in Autofill suggestions are no longer black on almost black in dark mode.
 
 ### Changed
 

--- a/app/src/main/res/layout/oreo_autofill_dataset.xml
+++ b/app/src/main/res/layout/oreo_autofill_dataset.xml
@@ -4,7 +4,6 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -26,7 +25,8 @@
         android:adjustViewBounds="true"
         android:maxWidth="20dp"
         android:maxHeight="20dp"
-        app:tint="@color/secondary_color"
+        android:tint="@color/secondary_color"
+        tools:ignore="UseAppTint"
         tools:src="@mipmap/ic_launcher" />
 
     <LinearLayout


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
ImageViews in RemoteViews require tint to be specified with the android:
prefix, the lint thinks otherwise.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In dark mode, icons were barely discernible since [v1.13.0](https://github.com/android-password-store/Android-Password-Store/commit/6c1e41ba1050c92f4b615f7e857e0d085120a242).

## :green_heart: How did you test it?
Trigger Autofill inline suggestions disabled, observed that the icons are now again tinted in our secondary color.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
