### PR TITLE
Refactor build setup for Gradle configuration cache support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,18 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 import com.android.build.gradle.internal.api.BaseVariantOutputImpl
-import java.util.Properties
 
 plugins {
     id("com.android.application")
     kotlin("android")
     `aps-plugin`
-}
-
-val keystorePropertiesFile = rootProject.file("keystore.properties")
-
-fun isSnapshot(): Boolean {
-    return System.getenv("GITHUB_WORKFLOW") != null && System.getenv("SNAPSHOT") != null
 }
 
 android {
@@ -24,13 +17,6 @@ android {
                 (this as BaseVariantOutputImpl).outputFileName = "aps-${flavorName}_$versionName.apk"
             }
         }
-    }
-
-    adbOptions.installOptions("--user 0")
-
-    buildFeatures {
-        viewBinding = true
-        buildConfig = true
     }
 
     defaultConfig {
@@ -44,36 +30,6 @@ android {
         isAbortOnError = true
         isCheckReleaseBuilds = false
         disable("MissingTranslation", "PluralsCandidate", "ImpliedQuantity")
-    }
-
-    buildTypes {
-        named("release") {
-            isMinifyEnabled = true
-            setProguardFiles(listOf("proguard-android-optimize.txt", "proguard-rules.pro"))
-            buildConfigField("boolean", "ENABLE_DEBUG_FEATURES", if (isSnapshot()) "true" else "false")
-        }
-        named("debug") {
-            applicationIdSuffix = ".debug"
-            versionNameSuffix = "-debug"
-            isMinifyEnabled = false
-            buildConfigField("boolean", "ENABLE_DEBUG_FEATURES", "true")
-        }
-    }
-
-    if (keystorePropertiesFile.exists()) {
-        val keystoreProperties = Properties()
-        keystoreProperties.load(keystorePropertiesFile.inputStream())
-        signingConfigs {
-            register("release") {
-                keyAlias = keystoreProperties["keyAlias"] as String
-                keyPassword = keystoreProperties["keyPassword"] as String
-                storeFile = rootProject.file(keystoreProperties["storeFile"] as String)
-                storePassword = keystoreProperties["storePassword"] as String
-            }
-        }
-        listOf("release", "debug").map {
-            buildTypes.getByName(it).signingConfig = signingConfigs.getByName(it)
-        }
     }
 
     flavorDimensions("free")

--- a/buildSrc/src/main/java/PasswordStorePlugin.kt
+++ b/buildSrc/src/main/java/PasswordStorePlugin.kt
@@ -4,6 +4,7 @@
  */
 
 import com.android.build.gradle.TestedExtension
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.plugins.AppPlugin
 import com.android.build.gradle.internal.plugins.LibraryPlugin
 import org.gradle.api.Plugin
@@ -32,8 +33,12 @@ class PasswordStorePlugin : Plugin<Project> {
                         options.isDeprecation = true
                     }
                 }
-                is LibraryPlugin,
+                is LibraryPlugin -> {
+                    project.extensions.getByType<TestedExtension>().configureCommonAndroidOptions()
+                }
                 is AppPlugin -> {
+                    project.extensions.getByType<BaseAppModuleExtension>().configureAndroidApplicationOptions(project)
+                    project.extensions.getByType<BaseAppModuleExtension>().configureBuildSigning(project)
                     project.extensions.getByType<TestedExtension>().configureCommonAndroidOptions()
                 }
             }

--- a/buildSrc/src/main/java/SigningConfig.kt
+++ b/buildSrc/src/main/java/SigningConfig.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import java.util.Properties
+import org.gradle.api.Project
+
+private const val KEYSTORE_CONFIG_PATH = "keystore.properties"
+
+/**
+ * Configure signing for all build types.
+ */
+@Suppress("UnstableApiUsage")
+internal fun BaseAppModuleExtension.configureBuildSigning(project: Project) {
+    with(project) {
+        val keystoreConfigFile = rootProject.layout.projectDirectory.file(KEYSTORE_CONFIG_PATH)
+        if (!keystoreConfigFile.asFile.exists()) return
+        val contents = providers.fileContents(keystoreConfigFile).asText.forUseAtConfigurationTime()
+        val keystoreProperties = Properties()
+        keystoreProperties.load(contents.get().byteInputStream())
+        signingConfigs {
+            register("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = rootProject.file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+        val signingConfig = signingConfigs.getByName("release")
+        buildTypes.all { setSigningConfig(signingConfig) }
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Refactors our Gradle build configuration to move even more things into `buildSrc` and prepares for compatibility with [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) by replacing undocumented reads of environment variables and files with Gradle's new incubating APIs for the same. This also adds a build-time switch for minification, for when I need to debug an existing release build on my device but want to see the stacktrace.

## :bulb: Motivation and Context
I want to eventually move all our Gradle configuration to `buildSrc` so that new modules can be added without extra work.

## :green_heart: How did you test it?
Verified I can do release/debug builds as earlier and snapshot detection works.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
