### PR TITLE
App shortcut fixes

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -453,6 +453,8 @@ class PasswordStore : BaseGitActivity() {
         // Needs an action to be a shortcut intent
         authDecryptIntent.action = LaunchActivity.ACTION_DECRYPT_PASS
 
+        startActivity(decryptIntent)
+
         // Adds shortcut
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             val shortcutManager: ShortcutManager = getSystemService() ?: return
@@ -471,7 +473,6 @@ class PasswordStore : BaseGitActivity() {
                 shortcutManager.addDynamicShortcuts(listOf(shortcut))
             }
         }
-        startActivity(decryptIntent)
     }
 
     private fun validateState(): Boolean {

--- a/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordStore.kt
@@ -461,7 +461,7 @@ class PasswordStore : BaseGitActivity() {
             val shortcut = Builder(this, item.fullPathToParent)
                 .setShortLabel(item.toString())
                 .setLongLabel(item.fullPathToParent + item.toString())
-                .setIcon(Icon.createWithResource(this, R.mipmap.ic_launcher))
+                .setIcon(Icon.createWithResource(this, R.drawable.ic_lock_open_24px))
                 .setIntent(authDecryptIntent)
                 .build()
             val shortcuts = shortcutManager.dynamicShortcuts

--- a/app/src/main/res/drawable/ic_lock_open_24px.xml
+++ b/app/src/main/res/drawable/ic_lock_open_24px.xml
@@ -1,0 +1,14 @@
+<!--
+  ~ Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z" />
+</vector>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Ensure decryption goes through even if we fail to get a `ShortcutManager` instance, and provide app shortcuts a separate icon so they can actually render onto the screen.

## :bulb: Motivation and Context
Since we moved to an adaptive icon all launcher shortcuts have been rendered as a transparent icon because `AdaptiveIconDrawable` needs to be handled differently. To work around this, we finally use a [dedicated icon](https://material.io/resources/icons/?search=key&icon=lock_open&style=baseline) for the app shortcuts to ensure they can be differentiated properly.

## :green_heart: How did you test it?
Verified newly created app shortcuts had the new icon.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Actually resolve issue 1204, which I set out to do and failed at. This endeavour has been extremely demotivating.
