### PR TITLE
Automatically dismiss decryption screen after 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 -   Cancelling the Autofill "Generate password" action now correctly returns you to the original app.
 -   If multiple username fields exist in the password, we now ensure the later ones are not dropped from extra content.
 -   Icons in Autofill suggestions are no longer black on almost black in dark mode.
+-   Decrypt screen would stay in memory infinitely, allowing passwords to be seen without re-auth
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/crypto/DecryptActivity.kt
@@ -114,6 +114,18 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
     }
 
     /**
+     * Automatically finishes the activity 60 seconds after decryption succeeded to prevent
+     * information leaks from stale activities.
+     */
+    @OptIn(ExperimentalTime::class)
+    private fun startAutoDismissTimer() {
+        lifecycleScope.launch {
+            delay(60.seconds)
+            finish()
+        }
+    }
+
+    /**
      * Edit the current password and hide all the fields populated by encrypted data so that when
      * the result triggers they can be repopulated with new data.
      */
@@ -155,6 +167,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
             api?.executeApiAsync(data, inputStream, outputStream) { result ->
                 when (result?.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
                     OpenPgpApi.RESULT_CODE_SUCCESS -> {
+                        startAutoDismissTimer()
                         runCatching {
                             val showPassword = settings.getBoolean(PreferenceKeys.SHOW_PASSWORD, true)
                             val showExtraContent = settings.getBoolean(PreferenceKeys.SHOW_EXTRA_CONTENT, true)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Dismisses `DecryptActivity` 60 seconds after successful decryption to prevent a background instance being viewed without any authentication, providing auth bypass.

## :bulb: Motivation and Context
Fixes #1215

## :green_heart: How did you test it?
Verified activity gets finished from both foreground and background

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
