### PR TITLE
Update dependencies and fix openpgp-ktx proguard rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Catch-all rule for the project
-* @FabianHenneke @msfjarvis @Skrilltrax
+* @fmeum @msfjarvis @Skrilltrax

--- a/app/src/nonFree/res/layout/activity_oreo_autofill_sms.xml
+++ b/app/src/nonFree/res/layout/activity_oreo_autofill_sms.xml
@@ -36,7 +36,7 @@
 
     <ProgressBar
         android:id="@+id/progress"
-        style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
+        style="@style/Widget.MaterialComponents.CircularProgressIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="10dp"

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -25,9 +25,9 @@ internal fun Project.configureForRootProject() {
         delete(rootProject.buildDir)
     }
     tasks.withType<Wrapper> {
-        gradleVersion = "6.7.1"
+        gradleVersion = "6.8-rc-1"
         distributionType = Wrapper.DistributionType.ALL
-        distributionSha256Sum = "22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb"
+        distributionSha256Sum = "89714fb5db6bd66fa5a2302f58d26dc33ecd3db36b24a42d84ff6ba99551eeda"
     }
     configureBinaryCompatibilityValidator()
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,7 +9,7 @@ object Dependencies {
     object Kotlin {
         object Coroutines {
 
-            private const val version = "1.4.1"
+            private const val version = "1.4.2"
             const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
             const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
         }
@@ -24,14 +24,14 @@ object Dependencies {
         const val autofill = "androidx.autofill:autofill:1.1.0-rc01"
         const val appcompat = "androidx.appcompat:appcompat:1.3.0-alpha02"
         const val biometric = "androidx.biometric:biometric:1.1.0-rc01"
-        const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.0.4"
+        const val constraint_layout = "androidx.constraintlayout:constraintlayout:2.1.0-alpha1"
         const val core_ktx = "androidx.core:core-ktx:1.5.0-alpha05"
         const val documentfile = "androidx.documentfile:documentfile:1.0.1"
         const val fragment_ktx = "androidx.fragment:fragment-ktx:1.3.0-beta01"
         const val lifecycle_common = "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
         const val lifecycle_livedata_ktx = "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
         const val lifecycle_viewmodel_ktx = "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
-        const val material = "com.google.android.material:material:1.3.0-alpha03"
+        const val material = "com.google.android.material:material:1.3.0-alpha04"
         const val preference = "androidx.preference:preference:1.1.1"
         const val recycler_view = "androidx.recyclerview:recyclerview:1.2.0-alpha06"
         const val recycler_view_selection = "androidx.recyclerview:recyclerview-selection:1.1.0-rc03"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionSha256Sum=89714fb5db6bd66fa5a2302f58d26dc33ecd3db36b24a42d84ff6ba99551eeda
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/openpgp-ktx/build.gradle.kts
+++ b/openpgp-ktx/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
+        consumerProguardFiles("consumer-proguard-rules.pro")
     }
 
     buildFeatures.aidl = true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description
Updates dependencies and fixes a regression from #1223 that caused PGP operations to fail.

## :bulb: Motivation and Context
The Gradle update to 6.8-rc-1 was done because despite being F-Droid incompatible it is still a FOSS release, and allows us to benefit from crucial build speed improvements with `buildSrc` that we now extensively use within the project.

## :green_heart: How did you test it?
Verified APS doesn't fail to decrypt passwords on my :sparkles: new fancy Pixel 4a :sparkles:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
