### PR TITLE
GitCommandExecutor: make committer match author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 -   If multiple username fields exist in the password, we now ensure the later ones are not dropped from extra content.
 -   Icons in Autofill suggestions are no longer black on almost black in dark mode.
 -   Decrypt screen would stay in memory infinitely, allowing passwords to be seen without re-auth
+-   Git commits in the store would wrongly use the 'default' committer as opposed to the user's configured one
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/GitCommandExecutor.kt
@@ -53,9 +53,8 @@ class GitCommandExecutor(
                             withContext(Dispatchers.IO) {
                                 val name = GitSettings.authorName.ifEmpty { "root" }
                                 val email = GitSettings.authorEmail.ifEmpty { "localhost" }
-                                command
-                                    .setAuthor(PersonIdent(name, email))
-                                    .call()
+                                val identity = PersonIdent(name, email)
+                                command.setAuthor(identity).setCommitter(identity).call()
                             }
                         }
                     }
@@ -64,7 +63,7 @@ class GitCommandExecutor(
                             command.call()
                         }
                         val rr = result.rebaseResult
-                        if (rr.status === RebaseResult.Status.STOPPED) {
+                        if (rr.status == RebaseResult.Status.STOPPED) {
                             throw PullException.PullRebaseFailed
                         }
                     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Re-uses the identity fallback for author to also make the committer match.

## :bulb: Motivation and Context
I have a bunch of commits in my store that are authored by me but committed as `root`

```
Author:     Harsh Shandilya <me@msfjarvis.dev>
AuthorDate: Sun Nov 1 22:57:59 2020 +0530
Commit:     root <root@localhost>
CommitDate: Sun Nov 1 22:57:59 2020 +0530
```

## :green_heart: How did you test it?
Verified new passwords are now both authored and committed by my configured identity.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
