### PR TITLE
Set 10 second timeout on JGit transport commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   Icons in Autofill suggestions are no longer black on almost black in dark mode.
 -   Decrypt screen would stay in memory infinitely, allowing passwords to be seen without re-auth
 -   Git commits in the store would wrongly use the 'default' committer as opposed to the user's configured one
+-   Connection attempts now use a reasonable 10 second timeout as opposed to the default of 30 seconds
 
 ### Changed
 

--- a/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/git/operation/GitOperation.kt
@@ -108,6 +108,7 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
                 (transport as? SshTransport)?.sshSessionFactory = sshSessionFactory
                 credentialsProvider?.let { transport.credentialsProvider = it }
             }
+            command.setTimeout(CONNECT_TIMEOUT)
         }
     }
 
@@ -203,5 +204,13 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
         withContext(Dispatchers.IO) {
             sshSessionFactory?.close()
         }
+    }
+
+    companion object {
+
+        /**
+         * Timeout in seconds before [TransportCommand] will abort a stalled IO operation.
+         */
+        private const val CONNECT_TIMEOUT = 10
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Sets a reasonable 10 second timeout on JGit transport commands to ensure they don't appear "stuck" for a long time.

## :bulb: Motivation and Context
I've received complaints often and also personally observed that many types of connection issues cause JGit to just stall until the default timeout is reached which takes far too long.

## :green_heart: How did you test it?
Verified that enabling a VPN and then trying to pull a repository from my local computer over LAN caused the connection to timeout faster.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Add support for an additional fallback remote which can be used as a failover when the primary one is unavailable. For my case, the primary one will be my local computer over LAN, and the fallback would be a separately hosted Git repository available over the internet.
