### PR TITLE
Create issue template for RFCs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,7 @@
 name: Bug report
 about: Create a report to help us address issues you are facing with the app
 title: "[BUG]"
-labels: 'bug, triage: needed'
-assignees: ''
-
+labels: 'C-bug, S-awaiting-triage'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,9 +2,7 @@
 name: Feature request
 about: Suggest a new feature to be included in the app
 title: "[FEATURE]"
-labels: 'feature, triage: needed'
-assignees: 'msfjarvis'
-
+labels: 'C-feature, S-awaiting-triage'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,41 @@
+---
+name: RFC
+about: Proposal for any major/breaking changes that warrants discussion over design and other aspects. Users should not need to use this.
+title: "[RFC]"
+labels: 'C-rfc, S-waiting-for-comment'
+---
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal. This can include
+any other projects that have implemented similar changes, or any previous discussions that
+have happened around this within the scope of this project.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?


### PR DESCRIPTION
## :scroll: Description
Fixes the labels on the existing issue templates and adds a new one for RFCs.

## :bulb: Motivation and Context
Broken labels result in issues not being labelled for triage correctly, and
having an RFC template makes it slightly easier to build future proposals.
