### PR TITLE
Mark Chrome Canary as non-flaky and allowing save

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/settings/UserPreference.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/settings/UserPreference.kt
@@ -514,6 +514,7 @@ class UserPreference : AppCompatActivity() {
                                 BrowserAutofillSupportLevel.None -> getString(R.string.oreo_autofill_no_support)
                                 BrowserAutofillSupportLevel.FlakyFill -> getString(R.string.oreo_autofill_flaky_fill_support)
                                 BrowserAutofillSupportLevel.PasswordFill -> getString(R.string.oreo_autofill_password_fill_support)
+                                BrowserAutofillSupportLevel.PasswordFillAndSaveIfNoAccessibility -> getString(R.string.oreo_autofill_password_fill_and_conditional_save_support)
                                 BrowserAutofillSupportLevel.GeneralFill -> getString(R.string.oreo_autofill_general_fill_support)
                                 BrowserAutofillSupportLevel.GeneralFillAndSave -> getString(R.string.oreo_autofill_general_fill_and_save_support)
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,5 +398,6 @@
     <string name="port">Port</string>
     <string name="pref_proxy_settings">HTTP(S) proxy settings</string>
     <string name="invalid_proxy_url">Invalid URL</string>
+    <string name="oreo_autofill_password_fill_and_conditional_save_support">Fill and save passwords (saving requires that no accessibility services are enabled)</string>
 
 </resources>

--- a/autofill-parser/api/autofill-parser.api
+++ b/autofill-parser/api/autofill-parser.api
@@ -40,6 +40,7 @@ public final class com/github/androidpasswordstore/autofillparser/BrowserAutofil
 	public static final field GeneralFillAndSave Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
 	public static final field None Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
 	public static final field PasswordFill Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
+	public static final field PasswordFillAndSaveIfNoAccessibility Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
 	public static fun valueOf (Ljava/lang/String;)Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
 	public static fun values ()[Lcom/github/androidpasswordstore/autofillparser/BrowserAutofillSupportLevel;
 }

--- a/autofill-parser/gradle.properties
+++ b/autofill-parser/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.github.androidpasswordstore
-VERSION_NAME=1.0.0
+VERSION_NAME=1.1.0-SNAPSHOT
 POM_ARTIFACT_ID=autofill-parser
 POM_ARTIFACT_DESCRIPTION=Android library for low-level parsing of Autofill structures
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Mark Chrome Canary as a non-flaky Autofill browser and add save support for it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The fixes made to Chrome Canary as listed in #926 should make fill flows reliable as well as allow unmasked passwords to be saved.

## :green_heart: How did you test it?
Went through many Autofill flows and no longer noticed unreliability. Save needs a bit more testing as it may lead to false-positives.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Wait for 89 to reach Beta.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
