### PR TITLE
Strip down README to feature new docs and Discussions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [pull_request_target]
 
 name: Check pull request
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,8 @@
 
 [![GitHub workflow](https://github.com/android-password-store/Android-Password-Store/workflows/Deploy%20snapshot%20builds/badge.svg)](https://github.com/android-password-store/Android-Password-Store/actions)
 [![Backers on Open Collective](https://opencollective.com/Android-Password-Store/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/Android-Password-Store/sponsors/badge.svg)](#sponsors)
-[![Join the chat at https://gitter.im/android-password-store/public](https://badges.gitter.im/android-password-store/public.svg)](https://gitter.im/android-password-store/public?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This application tries to be 100% compatible with [pass](http://www.passwordstore.org/)
-
-You can install the application from:
-
-* [F-Droid](https://f-droid.org/packages/dev.msfjarvis.aps/)
-* [Play Store](https://play.google.com/store/apps/details?id=dev.msfjarvis.aps)
-* [Snapshot builds](https://dl.msfjarvis.dev/APS/)
-
-Pull requests are more than welcome (see [TODO](https://github.com/android-password-store/Android-Password-Store/projects/1#column-228844)).
+## Download
 
 <a href="https://play.google.com/store/apps/details?id=dev.msfjarvis.aps">
   <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" 
@@ -25,37 +16,28 @@ Pull requests are more than welcome (see [TODO](https://github.com/android-passw
        height="80" />
 </a>
 
-## Build types
+## Documentation
 
-We generate release binaries under two separate configurations titled `free` and `nonFree`. The distinction was created following the merge of [#900](https://msfjarvis.dev/aps/pr/900), that introduced a dependency on closed source GMS libraries. Since F-Droid is a FOSS-only app store, we created the `free` flavor where we do not ship the GMS dependency and thus the feature to fill SMS OTPs is unavailable.
+We're in the process of rewriting our documentation from scratch, and the work-in-progress state can be seen [here](https://android-password-store.github.io/docs). See the [wiki](https://github.com/android-password-store/Android-Password-Store/wiki/) for the old documentation.
 
-## Features
+## Contributing
 
-* Clone an existing pass repository (ssh-key and user/pass support)
-* List the passwords
-* Handle the directories as categories
-* Decrypt the password files (first line is the password, the rest is extra data)
-* Add a new password to the current category (or no category if added at the root)
-* Pull and Push changes to the remote repository
-* Ability to change remote repository info
+Want to contribute? See if you can [find an issue](https://github.com/android-password-store/Android-Password-Store/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) you wanna close, then send a PR!
 
-## How-To
+Interested in helping to translate Password Store? Contribute [here](https://crowdin.com/project/android-password-store)!
 
-See the [wiki](https://github.com/android-password-store/Android-Password-Store/wiki/First-time-setup) for FAQs and other thorough documentation.
+Wanna test early access builds to find bugs and offer feedback? Read the [release channels](https://android-password-store.github.io/docs/users/release-channels) documentation to get access!
 
 ## Community
 
 Ways to get in touch:
 
-* [Github issues](https://github.com/android-password-store/Android-Password-Store/issues), use it if you have a bug report, you do not understand how something works or you want to submit a feature request.
-
-## Contributing Translations
-
-Interested in helping to translate Password Store? Contribute [here](https://crowdin.com/project/android-password-store)!
+* [Github issues](https://github.com/android-password-store/Android-Password-Store/issues): Use it if you have a bug report, or you want to submit a feature request.
+* [GitHub Discussions](https://github.com/android-password-store/Android-Password-Store/discussions): Use it if you do not understand something, or want to discuss a feature request in more detail with all community members before pitching it to maintainers.
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. Want to contribute? See if you can [find an issue](https://github.com/android-password-store/Android-Password-Store/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) you wanna close, then send a PR!
+This project exists thanks to all the people who contribute.
 
 [![Opencollective](https://opencollective.com/Android-Password-Store/contributors.svg?width=890&button=false)](https://github.com/android-password-store/Android-Password-Store/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Want to contribute? See if you can [find an issue](https://github.com/android-pa
 
 Interested in helping to translate Password Store? Contribute [here](https://crowdin.com/project/android-password-store)!
 
-Wanna test early access builds to find bugs and offer feedback? Read the [release channels](https://android-password-store.github.io/docs/users/release-channels) documentation to get access!
+Wanna test development builds to find bugs and offer feedback? Read the [release channels](https://android-password-store.github.io/docs/users/release-channels) documentation to get access!
 
 ## Community
 


### PR DESCRIPTION
## :scroll: Description

Heavily strips down the README to drop unnecessary entries, and to feature the work-in-progress documentation as well as our new discussions forum on GitHub Discussions.

Gitter did not end up working for us because we tend to stick to GitHub for all APS related things and having to monitor an extra platform just added load that none of us really bore that well.
