### PR TITLE
github: checkout PR head when running checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,8 @@ jobs:
     - name: Checkout repository
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Ensure the pull request head is checked out before running a workflow.

## :bulb: Motivation and Context
In #1243 I switched the PR checks workflow to `pull_request_target` which executes the workflow in the context of the base repository. That's the good part. The stupid part is that the default `HEAD` that gets checked out is now the main branch rather than the PR, which is absolutely pointless because that means the code in the PR never gets tested.

## :green_heart: How did you test it?
:shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
