### PR TITLE
Transform broken repo error message to be more helpful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   On Android 11, Autofill will use the new [inline autofill](https://developer.android.com/guide/topics/text/ime-autofill#configure-provider) UI that integrates Autofill results into your keyboard app.
 -   Invalid `.gpg-id` files can now be fixed automatically by deleting them and then trying to create a new password.
+-   Suggest users to re-clone repository when it is deemed to be broken
 
 ### Fixed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
@@ -112,6 +112,8 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
         return if (err.message?.contains("cannot open additional channels") == true) {
             GitSettings.useMultiplexing = false
             SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")
+        } else if (err.message?.contains("int org.eclipse.jgit.lib.AnyObjectId.w1") == true) {
+            IllegalStateException("Your local repository appears to be an incomplete Git clone, please delete and re-clone from settings")
         } else if (err is TransportException && err.disconnectReason == DisconnectReason.HOST_KEY_NOT_VERIFIABLE) {
             SSHException(DisconnectReason.HOST_KEY_NOT_VERIFIABLE,
                 "WARNING: The remote host key has changed. If this is expected, please go to Git server settings and clear the saved host key."

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
@@ -109,17 +109,22 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
      */
     private fun transformGitError(throwable: Throwable): Throwable {
         val err = rootCauseException(throwable)
-        return if (err.message?.contains("cannot open additional channels") == true) {
-            GitSettings.useMultiplexing = false
-            SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")
-        } else if (err.message?.contains("int org.eclipse.jgit.lib.AnyObjectId.w1") == true) {
-            IllegalStateException("Your local repository appears to be an incomplete Git clone, please delete and re-clone from settings")
-        } else if (err is TransportException && err.disconnectReason == DisconnectReason.HOST_KEY_NOT_VERIFIABLE) {
-            SSHException(DisconnectReason.HOST_KEY_NOT_VERIFIABLE,
-                "WARNING: The remote host key has changed. If this is expected, please go to Git server settings and clear the saved host key."
-            )
-        } else {
-            err
+        return when {
+            err.message?.contains("cannot open additional channels") == true -> {
+                GitSettings.useMultiplexing = false
+                SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")
+            }
+            err.message?.contains("int org.eclipse.jgit.lib.AnyObjectId.w1") == true -> {
+                IllegalStateException("Your local repository appears to be an incomplete Git clone, please delete and re-clone from settings")
+            }
+            err is TransportException && err.disconnectReason == DisconnectReason.HOST_KEY_NOT_VERIFIABLE -> {
+                SSHException(DisconnectReason.HOST_KEY_NOT_VERIFIABLE,
+                    "WARNING: The remote host key has changed. If this is expected, please go to Git server settings and clear the saved host key."
+                )
+            }
+            else -> {
+                err
+            }
         }
     }
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
@@ -72,19 +72,7 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
             GitOp.BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(this)
             GitOp.RESET -> ResetToRemoteOperation(this)
         }
-        return op.executeAfterAuthentication(GitSettings.authMode).mapError { throwable ->
-            val err = rootCauseException(throwable)
-            if (err.message?.contains("cannot open additional channels") == true) {
-                GitSettings.useMultiplexing = false
-                SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")
-            } else if (err is TransportException && err.disconnectReason == DisconnectReason.HOST_KEY_NOT_VERIFIABLE) {
-                SSHException(DisconnectReason.HOST_KEY_NOT_VERIFIABLE,
-                    "WARNING: The remote host key has changed. If this is expected, please go to Git server settings and clear the saved host key."
-                )
-            } else {
-                err
-            }
-        }
+        return op.executeAfterAuthentication(GitSettings.authMode).mapError(::transformGitError)
     }
 
     fun finishOnSuccessHandler(@Suppress("UNUSED_PARAMETER") nothing: Unit) {
@@ -112,6 +100,24 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
             }
         } else {
             onPromptDone()
+        }
+    }
+
+    /**
+     * Takes the result of [launchGitOperation] and applies any necessary transformations
+     * on the [throwable] returned from it
+     */
+    private fun transformGitError(throwable: Throwable): Throwable {
+        val err = rootCauseException(throwable)
+        return if (err.message?.contains("cannot open additional channels") == true) {
+            GitSettings.useMultiplexing = false
+            SSHException(DisconnectReason.TOO_MANY_CONNECTIONS, "The server does not support multiple Git operations per SSH session. Please try again, a slower fallback mode will be used.")
+        } else if (err is TransportException && err.disconnectReason == DisconnectReason.HOST_KEY_NOT_VERIFIABLE) {
+            SSHException(DisconnectReason.HOST_KEY_NOT_VERIFIABLE,
+                "WARNING: The remote host key has changed. If this is expected, please go to Git server settings and clear the saved host key."
+            )
+        } else {
+            err
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Slightly refactors error handling and adds a more helpful error message when attempting to run a Git operation on a broken repository.

## :bulb: Motivation and Context
People time and again manage to break things :shrug:

## :green_heart: How did you test it?
It's rather hard to be able to reliably replicate a broken repository so I'm just hoping it works :tm:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [ ] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Maybe start a backport PR for some of our fixes and release a v1.13.2?
