### PR TITLE
Refactor GitCommandExecutor

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/util/git/GitCommandExecutor.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/GitCommandExecutor.kt
@@ -5,17 +5,12 @@
 
 package dev.msfjarvis.aps.util.git
 
-import android.widget.Toast
-import androidx.fragment.app.FragmentActivity
-import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.runCatching
-import com.google.android.material.snackbar.Snackbar
-import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.util.git.GitException.PullException
 import dev.msfjarvis.aps.util.git.GitException.PushException
-import dev.msfjarvis.aps.util.settings.GitSettings
 import dev.msfjarvis.aps.util.git.operation.GitOperation
-import dev.msfjarvis.aps.util.extensions.snackbar
+import dev.msfjarvis.aps.util.settings.GitSettings
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.runCatching
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.eclipse.jgit.api.CommitCommand
@@ -27,15 +22,10 @@ import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.transport.RemoteRefUpdate
 
 class GitCommandExecutor(
-    private val activity: FragmentActivity,
     private val operation: GitOperation,
 ) {
 
-    suspend fun execute(): Result<Unit, Throwable> {
-        val snackbar = activity.snackbar(
-            message = activity.resources.getString(R.string.git_operation_running),
-            length = Snackbar.LENGTH_INDEFINITE,
-        )
+    suspend fun execute(): Result<GitResult, Throwable> {
         // Count the number of uncommitted files
         var nbChanges = 0
         return runCatching {
@@ -89,13 +79,7 @@ class GitCommandExecutor(
                                         }
                                     }
                                     RemoteRefUpdate.Status.UP_TO_DATE -> {
-                                        withContext(Dispatchers.Main) {
-                                            Toast.makeText(
-                                                activity.applicationContext,
-                                                activity.applicationContext.getString(R.string.git_push_up_to_date),
-                                                Toast.LENGTH_SHORT
-                                            ).show()
-                                        }
+                                        return@runCatching GitResult.AlreadyUpToDate
                                     }
                                     else -> {
                                     }
@@ -110,8 +94,7 @@ class GitCommandExecutor(
                     }
                 }
             }
-        }.also {
-            snackbar.dismiss()
+            GitResult.OK
         }
     }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/GitResult.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/GitResult.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2014-2020 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package dev.msfjarvis.aps.util.git
+
+/**
+ * Result of a Git operation executed by [GitCommandExecutor]
+ */
+sealed class GitResult {
+
+    /**
+     * All good!
+     */
+    object OK : GitResult()
+
+    /**
+     * Push operation succeeded and HEAD is already in sync with remote.
+     */
+    object AlreadyUpToDate : GitResult()
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Introduces a `GitResult` class to wrap results from `GitCommandExecutor` and extract UI
functionality from `GitCommandExecutor`.

## :bulb: Motivation and Context
`GitOperation` handles all the other UI tasks for Git so it made sense to move the last
ones out from `GitCommandExecutor`.

## :green_heart: How did you test it?
Verified I still get the 'Already up-to-date' toast when pushing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
