### PR TITLE
Switch back to pull_request to mitigate security issue

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-on: [pull_request_target]
+on: [pull_request]
 
 name: Check pull request
 jobs:
@@ -9,8 +9,8 @@ jobs:
         api-level: [23, 29]
     steps:
 
-    - name: Auto-cancel redundant workflow run
-      uses: technote-space/auto-cancel-redundant-workflow@f9dfa1c127a520e4d71b92892850f861fb861206
+    #- name: Auto-cancel redundant workflow run
+    #  uses: technote-space/auto-cancel-redundant-workflow@f9dfa1c127a520e4d71b92892850f861fb861206
 
     - name: Check if relevant files have changed
       uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9
@@ -31,8 +31,8 @@ jobs:
     - name: Checkout repository
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      with:
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      #with:
+      #  ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Falls back to the `pull_request` trigger for PR checks

## :bulb: Motivation and Context
According to advisory GHSL-2020-367 the changes I made to support pull_request_target make this repository vulnerable to attacks from any malicious forker

## :green_heart: How did you test it?
:shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Use the newly added `workflow_run` trigger to reinstate the functionality being removed right now.
