### PR TITLE
Mark unfocused single password fields as fillable

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategy.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategy.kt
@@ -187,6 +187,26 @@ internal val autofillStrategy = strategy {
         }
     }
 
+    // Fallback rule for the case of a login form with a password field and other fields that are
+    // not recognized by any other rule. If one of the other fields is focused and we return no
+    // response, the system will not invoke the service again if focus later changes to the password
+    // field. Hence, we must mark it as fillable now.
+    // This rule can apply in single origin mode since even though the password field may not be
+    // focused at the time the rule runs, the fill suggestion will only show if it ever receives
+    // focus.
+    rule(applyInSingleOriginMode = true) {
+        currentPassword {
+            takeSingle { hasAutocompleteHintCurrentPassword }
+        }
+    }
+
+    // See above.
+    rule(applyInSingleOriginMode = true) {
+        genericPassword {
+            takeSingle { true }
+        }
+    }
+
     // Match any focused password field with optional username field on manual request.
     rule(applyInSingleOriginMode = true, applyOnManualRequestOnly = true) {
         genericPassword {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Unfocused single password fields in forms with no other recognized
fields must be marked as fillable or the Autofill service will no
longer be invoked on that form.

This is compatible with the restrictions of single-origin mode as
filling only takes place after the password field has gained focus and
the user has tapped the fill UI.

For an example website where fill UI is not shown without this commit,
open https://amazon.lbb.de and tab the user name field ("Benutzername")
first before focusing the password field.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Browsed the web, happened upon a page with broken Autofill triggers, got worried that there might be yet another Chrome Autofill issue, was very relieved when I found it to be a bug in my own code.

## :green_heart: How did you test it?
Password field now triggers Autofill even after tapping the username field first.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Add `"benutzername"`as a keyword for username fields, which would have hidden this bug (but is useful anyway).

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
