### PR TITLE
Show less obvious Autofill actions first

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
@@ -134,15 +134,15 @@ class Api30AutofillResponseBuilder(form: FillableForm) {
                     addDataset(it)
                 }
             }
-            makeSearchDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
-                datasetCount++
-                addDataset(it)
-            }
             makeGenerateDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
                 datasetCount++
                 addDataset(it)
             }
             makeFillOtpFromSmsDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
+                datasetCount++
+                addDataset(it)
+            }
+            makeSearchDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
                 datasetCount++
                 addDataset(it)
             }

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
@@ -137,15 +137,15 @@ class AutofillResponseBuilder(form: FillableForm) {
                     addDataset(it)
                 }
             }
-            makeSearchDataset(context)?.let {
-                datasetCount++
-                addDataset(it)
-            }
             makeGenerateDataset(context)?.let {
                 datasetCount++
                 addDataset(it)
             }
             makeFillOtpFromSmsDataset(context)?.let {
+                datasetCount++
+                addDataset(it)
+            }
+            makeSearchDataset(context)?.let {
                 datasetCount++
                 addDataset(it)
             }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Show Generate and Fill SMS OTP Autofill actions before the more uninteresting (and expected) Search action.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generate and Fill SMS OTP can go off-screen and are thus not very discoverable.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
