### PR TITLE
Disallow overwriting passwords when editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 -   Connection attempts now use a reasonable 10 second timeout as opposed to the default of 30 seconds
 -   A change to the remote host key for a server would prevent the user from being able to connect to it
 -   Pressing the back button in the navigation bar and the one in the toolbar behaved differently
+-   Editing a password allowed accidentally overwriting an existing one
 
 ### Changed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
@@ -398,7 +398,10 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                             runCatching {
                                 val file = File(path)
                                 // If we're not editing, this file should not already exist!
-                                if (!editing && file.exists()) {
+                                // Additionally, if we were editing and the incoming and outgoing
+                                // filenames differ, it means we renamed. Ensure that the target
+                                // doesn't already exist to prevent an accidental overwrite.
+                                if ((!editing || editing && suggestedName != file.nameWithoutExtension) && file.exists()) {
                                     snackbar(message = getString(R.string.password_creation_duplicate_error))
                                     return@executeApiAsync
                                 }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
@@ -401,7 +401,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
                                 // Additionally, if we were editing and the incoming and outgoing
                                 // filenames differ, it means we renamed. Ensure that the target
                                 // doesn't already exist to prevent an accidental overwrite.
-                                if ((!editing || editing && suggestedName != file.nameWithoutExtension) && file.exists()) {
+                                if ((!editing || (editing && suggestedName != file.nameWithoutExtension)) && file.exists()) {
                                     snackbar(message = getString(R.string.password_creation_duplicate_error))
                                     return@executeApiAsync
                                 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Expands the file existence checks when saving to prevent accidentally overwriting other password files.

## :bulb: Motivation and Context
Fixes #1285

## :green_heart: How did you test it?
Tried renaming to an existing password when editing and confirmed that it didn't go through.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Split out the creation and editing screens to prevent these bugs.
