### PR TITLE
Mark Chrome Beta as reliably fillable and saveable

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -146,6 +146,7 @@ private val BROWSER_SAVE_FLAG = mapOf(
 
 @RequiresApi(Build.VERSION_CODES.O)
 private val BROWSER_SAVE_FLAG_IF_NO_ACCESSIBILITY = mapOf(
+    "com.chrome.beta" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.canary" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.dev" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
 )
@@ -181,7 +182,6 @@ internal fun getBrowserAutofillSupportInfoIfTrusted(
 
 private val FLAKY_BROWSERS = listOf(
     "com.android.chrome",
-    "com.chrome.beta",
     "org.bromite.bromite",
     "org.ungoogled.chromium.stable",
     "com.kiwibrowser.browser",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Chrome Beta triggers Autofill reliably now and is also able to save passwords when no Accessibility service is enabled.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://chromereleases.googleblog.com/2021/01/chrome-beta-for-android-update_28.html


## :green_heart: How did you test it?
Filling and saving worked well.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
