### PR TITLE
Fix app shortcuts not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 -   A change to the remote host key for a server would prevent the user from being able to connect to it
 -   Pressing the back button in the navigation bar and the one in the toolbar behaved differently
 -   Editing a password allowed accidentally overwriting an existing one
+-   App shortcuts would never update once the first 4 were set
 
 ### Changed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -20,6 +20,7 @@ import android.view.MenuItem.OnActionExpandListener
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 import androidx.core.content.edit
@@ -452,21 +453,26 @@ class PasswordStore : BaseGitActivity() {
 
         // Adds shortcut
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            val shortcutManager: ShortcutManager = getSystemService() ?: return
-            val shortcut = Builder(this, item.fullPathToParent)
-                .setShortLabel(item.toString())
-                .setLongLabel(item.fullPathToParent + item.toString())
-                .setIcon(Icon.createWithResource(this, R.drawable.ic_lock_open_24px))
-                .setIntent(authDecryptIntent)
-                .build()
-            val shortcuts = shortcutManager.dynamicShortcuts
-            if (shortcuts.size >= shortcutManager.maxShortcutCountPerActivity && shortcuts.size > 0) {
-                shortcuts.removeAt(shortcuts.size - 1)
-                shortcuts.add(0, shortcut)
-                shortcutManager.dynamicShortcuts = shortcuts
-            } else {
-                shortcutManager.addDynamicShortcuts(listOf(shortcut))
-            }
+            addShortcut(item, authDecryptIntent)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N_MR1)
+    private fun addShortcut(item: PasswordItem, intent: Intent) {
+        val shortcutManager: ShortcutManager = getSystemService() ?: return
+        val shortcut = Builder(this, item.fullPathToParent)
+            .setShortLabel(item.toString())
+            .setLongLabel(item.fullPathToParent + item.toString())
+            .setIcon(Icon.createWithResource(this, R.drawable.ic_lock_open_24px))
+            .setIntent(intent)
+            .build()
+        val shortcuts = shortcutManager.dynamicShortcuts
+        if (shortcuts.size >= shortcutManager.maxShortcutCountPerActivity && shortcuts.size > 0) {
+            shortcuts.removeAt(shortcuts.size - 1)
+            shortcuts.add(0, shortcut)
+            shortcutManager.dynamicShortcuts = shortcuts
+        } else {
+            shortcutManager.addDynamicShortcuts(listOf(shortcut))
         }
     }
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -468,7 +468,7 @@ class PasswordStore : BaseGitActivity() {
             .build()
         val shortcuts = shortcutManager.dynamicShortcuts
         if (shortcuts.size >= MAX_SHORTCUT_COUNT && shortcuts.size > 0) {
-            shortcuts.removeAt(shortcuts.size - 1)
+            shortcuts.removeLast()
             shortcuts.add(0, shortcut)
             shortcutManager.dynamicShortcuts = shortcuts
         } else {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -467,7 +467,7 @@ class PasswordStore : BaseGitActivity() {
             .setIntent(intent)
             .build()
         val shortcuts = shortcutManager.dynamicShortcuts
-        if (shortcuts.size >= shortcutManager.maxShortcutCountPerActivity && shortcuts.size > 0) {
+        if (shortcuts.size >= MAX_SHORTCUT_COUNT && shortcuts.size > 0) {
             shortcuts.removeAt(shortcuts.size - 1)
             shortcuts.add(0, shortcut)
             shortcutManager.dynamicShortcuts = shortcuts
@@ -683,6 +683,10 @@ class PasswordStore : BaseGitActivity() {
 
     companion object {
 
+        // The max shortcut count from the system is set to 15 for some godforsaken reason, which
+        // makes zero sense and is why our update logic just never worked. Capping it at 4 which is
+        // what most launchers seem to have agreed upon is the only reasonable solution.
+        private const val MAX_SHORTCUT_COUNT = 4
         const val REQUEST_ARG_PATH = "PATH"
         private fun isPrintable(c: Char): Boolean {
             val block = UnicodeBlock.of(c)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -467,13 +467,18 @@ class PasswordStore : BaseGitActivity() {
             .setIntent(intent)
             .build()
         val shortcuts = shortcutManager.dynamicShortcuts
-        if (shortcuts.size >= MAX_SHORTCUT_COUNT && shortcuts.size > 0) {
+        // If we're above or equal to the maximum shortcuts allowed, drop the last item.
+        if (shortcuts.size >= MAX_SHORTCUT_COUNT) {
             shortcuts.removeLast()
-            shortcuts.add(0, shortcut)
-            shortcutManager.dynamicShortcuts = shortcuts
-        } else {
-            shortcutManager.addDynamicShortcuts(listOf(shortcut))
         }
+        // Reverse the list so we can append our new shortcut at the 'end'.
+        shortcuts.reverse()
+        shortcuts.add(shortcut)
+        // Reverse it again, so the previous items are now in the correct order and our new item
+        // is at the front like it's supposed to.
+        shortcuts.reverse()
+        // Write back the new shortcuts.
+        shortcutManager.dynamicShortcuts = shortcuts
     }
 
     private fun validateState(): Boolean {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Splits out shortcut logic into its own method and reimplements it in a clearer fashion.

## :bulb: Motivation and Context

Fixes #1204

## :green_heart: How did you test it?
Verified with logging and visually that clicking on passwords builds up shortcuts until the maximum size and then starts dropping them from the end and adding to the beginning.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
