### PR TITLE
Rework clear clipboard feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 -   Pressing the back button in the navigation bar and the one in the toolbar behaved differently
 -   Editing a password allowed accidentally overwriting an existing one
 -   App shortcuts would never update once the first 4 were set
+-   Clipboard history now attempts to flush through 35 times rather than 20 to combat increased clipboard history item count in Samsung devices
 
 ### Changed
 

--- a/app/src/androidTest/java/dev/msfjarvis/aps/util/settings/MigrationsTest.kt
+++ b/app/src/androidTest/java/dev/msfjarvis/aps/util/settings/MigrationsTest.kt
@@ -13,6 +13,7 @@ import dev.msfjarvis.aps.Application
 import dev.msfjarvis.aps.util.extensions.getString
 import dev.msfjarvis.aps.util.extensions.sharedPrefs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -103,5 +104,17 @@ class MigrationsTest {
         runMigrations(context)
         assertEquals(false, context.sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_FOLDERS, false))
         assertEquals(true, context.sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false))
+    }
+
+    @Test
+    fun verifyClearClipboardHistoryMigration() {
+        val context = Application.instance.applicationContext
+        context.sharedPrefs.edit {
+            clear()
+            putBoolean(PreferenceKeys.CLEAR_CLIPBOARD_20X, true)
+        }
+        runMigrations(context)
+        assertEquals(true, context.sharedPrefs.getBoolean(PreferenceKeys.CLEAR_CLIPBOARD_HISTORY, false))
+        assertFalse(context.sharedPrefs.contains(PreferenceKeys.CLEAR_CLIPBOARD_20X))
     }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/settings/MiscSettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/settings/MiscSettings.kt
@@ -60,7 +60,7 @@ class MiscSettings(activity: FragmentActivity) : SettingsProvider {
                     true
                 }
             }
-            checkBox(PreferenceKeys.CLEAR_CLIPBOARD_20X) {
+            checkBox(PreferenceKeys.CLEAR_CLIPBOARD_HISTORY) {
                 defaultValue = false
                 titleRes = R.string.pref_clear_clipboard_title
                 summaryRes = R.string.pref_clear_clipboard_summary

--- a/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
@@ -80,7 +80,7 @@ class ClipboardService : Service() {
     }
 
     private fun clearClipboard() {
-        val deepClear = sharedPrefs.getBoolean(PreferenceKeys.CLEAR_CLIPBOARD_20X, false)
+        val deepClear = sharedPrefs.getBoolean(PreferenceKeys.CLEAR_CLIPBOARD_HISTORY, false)
         val clipboard = clipboard
 
         if (clipboard != null) {

--- a/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
@@ -90,7 +90,7 @@ class ClipboardService : Service() {
                 clipboard.setPrimaryClip(clip)
                 if (deepClear) {
                     withContext(Dispatchers.IO) {
-                        repeat(20) {
+                        repeat(CLIPBOARD_CLEAR_COUNT) {
                             val count = (it * 500).toString()
                             clipboard.setPrimaryClip(ClipData.newPlainText(count, count))
                         }
@@ -179,5 +179,8 @@ class ClipboardService : Service() {
         const val EXTRA_NOTIFICATION_TIME = "EXTRA_NOTIFICATION_TIME"
         private const val ACTION_CLEAR = "ACTION_CLEAR_CLIPBOARD"
         private const val CHANNEL_ID = "NotificationService"
+        // Newest Samsung phones now feature a history of up to 30 items. To err on the side of caution,
+        // push 35 fake ones.
+        private const val CLIPBOARD_CLEAR_COUNT = 35
     }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/util/settings/Migrations.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/settings/Migrations.kt
@@ -24,6 +24,7 @@ fun runMigrations(context: Context) {
     migrateToGitUrlBasedConfig(sharedPrefs)
     migrateToHideAll(sharedPrefs)
     migrateToSshKey(context, sharedPrefs)
+    migrateToClipboardHistory(sharedPrefs)
 }
 
 private fun migrateToGitUrlBasedConfig(sharedPrefs: SharedPreferences) {
@@ -109,6 +110,18 @@ private fun migrateToSshKey(context: Context, sharedPrefs: SharedPreferences) {
         SshKey.useLegacyKey(isGeneratedKey)
         sharedPrefs.edit {
             remove(PreferenceKeys.USE_GENERATED_KEY)
+        }
+    }
+}
+
+private fun migrateToClipboardHistory(sharedPrefs: SharedPreferences) {
+    if (sharedPrefs.contains(PreferenceKeys.CLEAR_CLIPBOARD_20X)) {
+        sharedPrefs.edit {
+            putBoolean(
+                PreferenceKeys.CLEAR_CLIPBOARD_HISTORY,
+                sharedPrefs.getBoolean(PreferenceKeys.CLEAR_CLIPBOARD_20X, false)
+            )
+            remove(PreferenceKeys.CLEAR_CLIPBOARD_20X)
         }
     }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/settings/PreferenceKeys.kt
@@ -11,7 +11,12 @@ object PreferenceKeys {
     const val APP_VERSION = "app_version"
     const val AUTOFILL_ENABLE = "autofill_enable"
     const val BIOMETRIC_AUTH = "biometric_auth"
+    @Deprecated(
+        message = "Use CLEAR_CLIPBOARD_HISTORY instead",
+        replaceWith = ReplaceWith("PreferenceKeys.CLEAR_CLIPBOARD_HISTORY"),
+    )
     const val CLEAR_CLIPBOARD_20X = "clear_clipboard_20x"
+    const val CLEAR_CLIPBOARD_HISTORY = "clear_clipboard_history"
     const val CLEAR_SAVED_PASS = "clear_saved_pass"
     const val COPY_ON_DECRYPT = "copy_on_decrypt"
     const val ENABLE_DEBUG_LOGGING = "enable_debug_logging"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -117,8 +117,6 @@
     <string name="pref_category_autofill_title">Automatisch ausfüllen</string>
     <string name="pref_autofill_enable_title">Autofill aktivieren</string>
     <string name="pref_category_misc_title">Verschiedenes</string>
-    <string name="pref_clear_clipboard_title">Lösche die Zwischenablage 20-mal</string>
-    <string name="pref_clear_clipboard_summary">Speichert Nonsense 20-mal anstatt 1-mal in der Zwischenablage. Nützlich bspw. auf Samsung-Geräten, die den Verlauf der Zwischenablage speichern.</string>
     <string name="pref_git_delete_repo_summary">Lösche das lokale (versteckte) Repository</string>
     <string name="pref_external_repository_title">Externes Repository</string>
     <string name="pref_external_repository_summary">Nutze ein externes Repository</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -119,8 +119,6 @@
     <string name="pref_category_autofill_title">Saisie automatique</string>
     <string name="pref_autofill_enable_title">Saisie automatique</string>
     <string name="pref_category_misc_title">Divers</string>
-    <string name="pref_clear_clipboard_title">Effacer le presse-papier 20 fois</string>
-    <string name="pref_clear_clipboard_summary">Enregistre des informations absurdes dans le presse-papier 20 fois à la place d\'une seule. Utile sur les téléphones Samsung qui disposent d\'un historique du presse-papier.</string>
     <string name="pref_git_delete_repo_summary">Supprime le dépot local (caché)</string>
     <string name="pref_external_repository_title">Dépôt externe</string>
     <string name="pref_external_repository_summary">Utilise un dépôt externe pour les mots de passe</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -121,8 +121,6 @@
     <string name="pref_category_autofill_title">Completado automático</string>
     <string name="pref_autofill_enable_title">Activar completado automático</string>
     <string name="pref_category_misc_title">Varios</string>
-    <string name="pref_clear_clipboard_title">Baleirar portapapeis 20 veces</string>
-    <string name="pref_clear_clipboard_summary">Gardar números consecutivos no portapapeis 20 veces. Resulta útil nos móbiles Samsung que gardan historial no portapapeis.</string>
     <string name="pref_git_delete_repo_summary">Elimina repositorio local (oculto).</string>
     <string name="pref_external_repository_title">Repositorio externo</string>
     <string name="pref_external_repository_summary">Usar un repositorio externo de contrasinais</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -121,8 +121,6 @@
     <string name="pref_category_autofill_title">Auto-compilazione</string>
     <string name="pref_autofill_enable_title">Abilita Auto-Compilazione</string>
     <string name="pref_category_misc_title">Varie</string>
-    <string name="pref_clear_clipboard_title">Cancella 20 volte gli appunti</string>
-    <string name="pref_clear_clipboard_summary">Archivia i numeri consecutivi negli appunti per 20 volte. Utile sui telefoni Samsung che presentano la cronologia degli appunti.</string>
     <string name="pref_git_delete_repo_summary">Elimina repository locale (nascosta)</string>
     <string name="pref_external_repository_title">Repository Esterna</string>
     <string name="pref_external_repository_summary">Usa una repository di password esterna</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -121,8 +121,6 @@
     <string name="pref_category_autofill_title">Preenchimento Automático</string>
     <string name="pref_autofill_enable_title">Ativar preenchimento automático</string>
     <string name="pref_category_misc_title">Outros</string>
-    <string name="pref_clear_clipboard_title">Limpar área de transferência 20 vezes</string>
-    <string name="pref_clear_clipboard_summary">Armazene números consecutivos na área de transferência 20 vezes. Útil em telefones Samsung que apresentam o histórico da área de transferência.</string>
     <string name="pref_git_delete_repo_summary">Exclui o repositório local (oculto)</string>
     <string name="pref_external_repository_title">Repositório externo</string>
     <string name="pref_external_repository_summary">Use um repositório de senha externo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -125,8 +125,6 @@
     <string name="pref_category_autofill_title">Автозаполнение</string>
     <string name="pref_autofill_enable_title">Включить автозаполнение</string>
     <string name="pref_category_misc_title">Другое</string>
-    <string name="pref_clear_clipboard_title">Очистить буфер 20 раз</string>
-    <string name="pref_clear_clipboard_summary">Вставлять чепуху в буфер обмена 20 раз вместо одного. Полезно на некоторых моделях телефонов с запоминанием истории буфера обмена</string>
     <string name="pref_git_delete_repo_summary">Удалить локальный (скрытый) репозиторий</string>
     <string name="pref_external_repository_title">Внешний репозиторий</string>
     <string name="pref_external_repository_summary">Использовать внешний репозиторий</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,8 +138,8 @@
     <string name="pref_category_autofill_title">Autofill</string>
     <string name="pref_autofill_enable_title">Enable Autofill</string>
     <string name="pref_category_misc_title">Misc</string>
-    <string name="pref_clear_clipboard_title">Clear clipboard 20 times</string>
-    <string name="pref_clear_clipboard_summary">Store consecutive numbers in the clipboard 20 times. Useful on Samsung phones that feature clipboard history.</string>
+    <string name="pref_clear_clipboard_title">Workaround clipboard history feature</string>
+    <string name="pref_clear_clipboard_summary">Enable to flood clipboard history on devices that include such a feature with consecutive numbers, flushing out any passwords</string>
     <string name="pref_git_delete_repo_summary">Deletes local (hidden) repository</string>
     <string name="pref_external_repository_title">External repository</string>
     <string name="pref_external_repository_summary">Use an external password repository</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Renames the `clear_clipboard_20x` preference to `clear_clipboard_history` for future-proofing, adds a migration and accompanying test, increases the number of times the clearing occurs from 20 to 35 and rewords the preference string to better communicate what the feature does without locking in an exact number (in the interest of future-proofing localisation work).

## :bulb: Motivation and Context
I received an email report about the limit being changed from the 20 from years ago to 30 on current generation Samsung Galaxy devices which prevented the feature from actually working.

## :green_heart: How did you test it?
Verified that my clipboard was cleared 35 times (based on the final number in my clipboard and stepping through the clipboard history in Gboard).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
Maybe expose the number as a user setting?
