### PR TITLE
Add tests for GPG identifier parsing

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/util/crypto/GpgIdentifier.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/crypto/GpgIdentifier.kt
@@ -1,0 +1,38 @@
+package dev.msfjarvis.aps.util.crypto
+
+import me.msfjarvis.openpgpktx.util.OpenPgpUtils
+
+sealed class GpgIdentifier {
+    data class KeyId(val id: Long) : GpgIdentifier()
+    data class UserId(val email: String) : GpgIdentifier()
+
+    companion object {
+        @OptIn(ExperimentalUnsignedTypes::class)
+        fun fromString(identifier: String): GpgIdentifier? {
+            if (identifier.isEmpty()) return null
+            // Match long key IDs:
+            // FF22334455667788 or 0xFF22334455667788
+            val maybeLongKeyId = identifier.removePrefix("0x").takeIf {
+                it.matches("[a-fA-F0-9]{16}".toRegex())
+            }
+            if (maybeLongKeyId != null) {
+                val keyId = maybeLongKeyId.toULong(16)
+                return KeyId(keyId.toLong())
+            }
+
+            // Match fingerprints:
+            // FF223344556677889900112233445566778899 or 0xFF223344556677889900112233445566778899
+            val maybeFingerprint = identifier.removePrefix("0x").takeIf {
+                it.matches("[a-fA-F0-9]{40}".toRegex())
+            }
+            if (maybeFingerprint != null) {
+                // Truncating to the long key ID is not a security issue since OpenKeychain only accepts
+                // non-ambiguous key IDs.
+                val keyId = maybeFingerprint.takeLast(16).toULong(16)
+                return KeyId(keyId.toLong())
+            }
+
+            return OpenPgpUtils.splitUserId(identifier).email?.let { UserId(it) }
+        }
+    }
+}

--- a/app/src/test/java/dev/msfjarvis/aps/util/crypto/GpgIdentifierTest.kt
+++ b/app/src/test/java/dev/msfjarvis/aps/util/crypto/GpgIdentifierTest.kt
@@ -1,0 +1,38 @@
+package dev.msfjarvis.aps.util.crypto
+
+import kotlin.test.Ignore
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.Test
+
+class GpgIdentifierTest {
+
+    @Test
+    fun `parses hexadecimal key id without leading 0x`() {
+        val identifier = GpgIdentifier.fromString("79E8208280490C77")
+        assertNotNull(identifier)
+        assertTrue { identifier is GpgIdentifier.KeyId }
+    }
+
+    @Test
+    fun `parses hexadecimal key id`() {
+        val identifier = GpgIdentifier.fromString("0x79E8208280490C77")
+        assertNotNull(identifier)
+        assertTrue { identifier is GpgIdentifier.KeyId }
+    }
+
+    @Test
+    fun `parses email as user id`() {
+        val identifier = GpgIdentifier.fromString("aps@msfjarvis.dev")
+        assertNotNull(identifier)
+        assertTrue { identifier is GpgIdentifier.UserId }
+    }
+
+    @Test
+    @Ignore("OpenKeychain can't yet handle these so we don't either")
+    fun `parses non-email user id`() {
+        val identifier = GpgIdentifier.fromString("john.doe")
+        assertNotNull(identifier)
+        assertTrue { identifier is GpgIdentifier.UserId }
+    }
+}

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
@@ -6,7 +6,6 @@ package me.msfjarvis.openpgpktx.util
 
 import android.content.Context
 import android.content.Intent
-import android.text.TextUtils
 import java.io.Serializable
 import java.util.Locale
 import java.util.regex.Pattern
@@ -64,7 +63,7 @@ public object OpenPgpUtils {
      * See SplitUserIdTest for examples.
      */
     public fun splitUserId(userId: String): UserId {
-        if (!TextUtils.isEmpty(userId)) {
+        if (userId.isNotEmpty()) {
             val matcher = USER_ID_PATTERN.matcher(userId)
             if (matcher.matches()) {
                 var name = if (matcher.group(1).isEmpty()) null else matcher.group(1)
@@ -95,15 +94,15 @@ public object OpenPgpUtils {
      */
     public fun createUserId(userId: UserId): String? {
         val userIdBuilder = StringBuilder()
-        if (!TextUtils.isEmpty(userId.name)) {
+        if (!userId.name.isNullOrEmpty()) {
             userIdBuilder.append(userId.name)
         }
-        if (!TextUtils.isEmpty(userId.comment)) {
+        if (!userId.comment.isNullOrEmpty()) {
             userIdBuilder.append(" (")
             userIdBuilder.append(userId.comment)
             userIdBuilder.append(")")
         }
-        if (!TextUtils.isEmpty(userId.email)) {
+        if (!userId.email.isNullOrEmpty()) {
             userIdBuilder.append(" <")
             userIdBuilder.append(userId.email)
             userIdBuilder.append(">")


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Splits out GpgIdentifier parsing into its own class and adds a couple tests to assert its behavior.

## :bulb: Motivation and Context
Makes it easier to test cases for bugs like https://github.com/open-keychain/open-keychain/issues/2588.

## :green_heart: How did you test it?
Added unit tests pass

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
The tests are not nearly as exhaustive as they should be, so that needs to be addressed before merging this.
I'm pushing the branch to the main repo so everyone can add tests.
