### PR TITLE
Enable Kotlin's JVM IR backend

### DIFF
--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -64,6 +64,7 @@ internal fun Project.configureForAllProjects() {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
             freeCompilerArgs = freeCompilerArgs + additionalCompilerArgs
             languageVersion = "1.4"
+            useIR = true
         }
     }
     tasks.withType<Test> {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Turns on the new IR-backed Kotlin compiler for the JVM

## :bulb: Motivation and Context
JetBrains recommends projects on 1.4.30 use the IR backend to find and report bugs before it becomes the default, so we're doing our part.


## :green_heart: How did you test it?
App builds and runs as before.