### PR TITLE
Mark Chrome as reliably fillable and saveable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+-   Autofill now works much more reliably in Chrome 89 and later, including support for saving passwords if no accessibility service is enabled.
 -   Pressing the back button in the navigation bar and the one in the toolbar behaved differently
 -   Editing a password allowed accidentally overwriting an existing one
 -   App shortcuts would never update once the first 4 were set

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -146,6 +146,7 @@ private val BROWSER_SAVE_FLAG = mapOf(
 
 @RequiresApi(Build.VERSION_CODES.O)
 private val BROWSER_SAVE_FLAG_IF_NO_ACCESSIBILITY = mapOf(
+    "com.android.chrome" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.beta" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.canary" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.dev" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
@@ -181,7 +182,6 @@ internal fun getBrowserAutofillSupportInfoIfTrusted(
 }
 
 private val FLAKY_BROWSERS = listOf(
-    "com.android.chrome",
     "org.bromite.bromite",
     "org.ungoogled.chromium.stable",
     "com.kiwibrowser.browser",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Mark stable Chrome (89) as reliably fillable and saveable for Autofill.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #926.

## :green_heart: How did you test it?
Filling and saving just works. Finally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Should we mention the improved support (including save support) in the changelog, even though nothing really changed on our end?

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
