### PR TITLE
Pin sshauthentication-api to v5.7.1 and fix autofill-parser build warnings

### DIFF
--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
@@ -23,6 +23,7 @@ private const val BITMASK = 0xff.toByte()
  * https://github.com/square/okhttp/blob/1977136/okhttp/src/main/kotlin/okhttp3/internal/publicsuffix/PublicSuffixDatabase.kt
  */
 @Suppress("ComplexMethod", "NestedBlockDepth")
+@OptIn(ExperimentalUnsignedTypes::class)
 internal fun ByteArray.binarySearch(labels: List<ByteArray>, labelIndex: Int): String? {
   var low = 0
   var high = size
@@ -55,7 +56,7 @@ internal fun ByteArray.binarySearch(labels: List<ByteArray>, labelIndex: Int): S
       // Compare the bytes. Note that the file stores UTF-8 encoded bytes, so we must compare
       // the
       // unsigned bytes.
-      @Suppress("EXPERIMENTAL_API_USAGE") compareResult = (byte0.toUByte() - byte1.toUByte()).toInt()
+      compareResult = (byte0.toUByte() - byte1.toUByte()).toInt()
       if (compareResult != 0) {
         break
       }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -70,7 +70,7 @@ object Dependencies {
     const val modern_android_prefs = "de.maxr1998:modernandroidpreferences:2.0"
     const val plumber = "com.squareup.leakcanary:plumber-android:2.6"
     const val sshj = "com.hierynomus:sshj:0.31.0"
-    const val ssh_auth = "com.github.open-keychain.open-keychain:sshauthentication-api:-SNAPSHOT"
+    const val ssh_auth = "com.github.open-keychain.open-keychain:sshauthentication-api:v5.7.1"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val timberkt = "com.github.ajalt:timberkt:1.5.1"
     const val whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.0"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [x] Dependency updates

## :scroll: Description
Pins sshauthentication-api to v5.7 and properly opts into ExperimentalUnsignedTypes in autofill-parser to silence a slew of build warnings.


## :bulb: Motivation and Context
Using the `-SNAPSHOT` version makes the build indeterministic since it is a moving qualifier.

## :green_heart: How did you test it?
Verified `gradle :app:iNFR` passes locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
