### PR TITLE
Don't hardcode TOTP period

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -190,7 +190,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
               if (entry.hasTotp()) {
                 launch(Dispatchers.IO) {
                   // Calculate the actual remaining time for the first pass
-                  // then return to the standard 30 second affair.
+                  // then return to the standard rotation.
                   val remainingTime = entry.totpPeriod - (System.currentTimeMillis() % entry.totpPeriod)
                   withContext(Dispatchers.Main) {
                     val code = entry.calculateTotpCode() ?: "Error"
@@ -200,7 +200,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
                   repeat(Int.MAX_VALUE) {
                     val code = entry.calculateTotpCode() ?: "Error"
                     withContext(Dispatchers.Main) { adapter.updateOTPCode(code) }
-                    delay(30.seconds)
+                    delay(entry.totpPeriod.seconds)
                   }
                 }
               }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Removes the hardcoded 30 second delay in TOTP calculation and makes it use the actual TOTP period instead.

## :bulb: Motivation and Context

While 30 is the most used period, any periods other than 30 would output incorrect and outdated codes otherwise.
