### PR TITLE
Adding support for Git's simple protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 -   Allow doing a merge instead of a rebase when pulling or syncing
 -   Add support for manually providing TOTP parameters
 -   Parse extra content as individual fields
+-   Support for the [Git protocol](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_git_protocol)
 
 ### Fixed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
@@ -76,14 +76,14 @@ class GitServerConfigActivity : BaseGitActivity() {
     binding.serverUrl.setText(
       GitSettings.url.also {
         if (it.isNullOrEmpty()) return@also
-        setAuthModes(it.startsWith("http://") || it.startsWith("https://"))
+        setAuthModes(it)
       }
     )
     binding.serverBranch.setText(GitSettings.branch)
 
     binding.serverUrl.doOnTextChanged { text, _, _, _ ->
       if (text.isNullOrEmpty()) return@doOnTextChanged
-      setAuthModes(text.startsWith("http://") || text.startsWith("https://"))
+      setAuthModes(text)
     }
 
     binding.clearHostKeyButton.isVisible = GitSettings.hasSavedHostKey()
@@ -106,7 +106,7 @@ class GitServerConfigActivity : BaseGitActivity() {
             .build()
             .show(supportFragmentManager, "SSH_SCHEME_WARNING")
           return@setOnClickListener
-        } else if (!newUrl.startsWith("ssh://")) {
+        } else if (!newUrl.startsWith("ssh://") && !newUrl.startsWith("git://")) {
           BasicBottomSheet.Builder(this)
             .setTitleRes(R.string.ssh_scheme_needed_title)
             .setMessageRes(R.string.ssh_scheme_needed_message)
@@ -177,9 +177,14 @@ class GitServerConfigActivity : BaseGitActivity() {
     }
   }
 
-  private fun setAuthModes(isHttps: Boolean) =
+  private fun setAuthModes(url: CharSequence) =
     with(binding) {
-      if (isHttps) {
+      if (url.startsWith("git://")) {
+        authModeSshKey.isVisible = false
+        authModeOpenKeychain.isVisible = false
+        authModePassword.isVisible = false
+        if (authModeGroup.checkedChipId != View.NO_ID) authModeGroup.check(View.NO_ID)
+      } else if (url.startsWith("http://") || url.startsWith("https://")) {
         authModeSshKey.isVisible = false
         authModeOpenKeychain.isVisible = false
         authModePassword.isVisible = true

--- a/app/src/main/java/dev/msfjarvis/aps/util/settings/GitSettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/settings/GitSettings.kt
@@ -17,6 +17,7 @@ import java.io.File
 import org.eclipse.jgit.transport.URIish
 
 enum class Protocol(val pref: String) {
+  Git("git://"),
   Ssh("ssh://"),
   Https("https://"),
   ;
@@ -152,6 +153,7 @@ object GitSettings {
       when (parsedUrl.scheme) {
         in listOf("http", "https") -> Protocol.Https
         in listOf("ssh", null) -> Protocol.Ssh
+        in listOf("git", null) -> Protocol.Git
         else -> return UpdateConnectionSettingsResult.FailedToParseUrl
       }
     if (newAuthMode != AuthMode.None && parsedUrl.user.isNullOrBlank())
@@ -159,12 +161,16 @@ object GitSettings {
 
     val validHttpsAuth = listOf(AuthMode.None, AuthMode.Password)
     val validSshAuth = listOf(AuthMode.OpenKeychain, AuthMode.Password, AuthMode.SshKey)
+    val validGitAuth = listOf(AuthMode.None)
     when {
       newProtocol == Protocol.Https && newAuthMode !in validHttpsAuth -> {
         return UpdateConnectionSettingsResult.AuthModeMismatch(newProtocol, validHttpsAuth)
       }
       newProtocol == Protocol.Ssh && newAuthMode !in validSshAuth -> {
         return UpdateConnectionSettingsResult.AuthModeMismatch(newProtocol, validSshAuth)
+      }
+      newProtocol == Protocol.Git && newAuthMode !in validGitAuth -> {
+        return UpdateConnectionSettingsResult.AuthModeMismatch(newProtocol, validGitAuth)
       }
     }
 

--- a/app/src/main/java/dev/msfjarvis/aps/util/settings/Migrations.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/settings/Migrations.kt
@@ -65,6 +65,7 @@ private fun migrateToGitUrlBasedConfig(sharedPrefs: SharedPreferences) {
           }
         runCatching { if (URI(url).rawAuthority != null) url else null }.get()
       }
+      Protocol.Git -> null
     }
 
   sharedPrefs.edit {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Git offers a simple TCP server for repositories using [`git-daemon`](https://git-scm.com/docs/git-daemon). This adds support for it.

## :bulb: Motivation and Context
Tried to clone a repository from my local network and found out it wasn't supported.

## :green_heart: How did you test it?
On my phone with the daemon on the LAN as originally wanted.

## :pencil: Checklist
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable