### PR TITLE
Actively discourage use of git protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 -   Accessibility autofill has been removed completely due to being buggy, insecure and lacking in features. Upgrade to Android 8 or preferably later to gain access to our advanced Autofill implementation.
 -   The settings UI has been completely re-done to dramatically improve discoverability and navigation for users
+-   Using the `git://` protocol in the server URL now presents an explicit discouragement rather than a generic error
 
 ## [1.13.4] - 2021-03-20
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
@@ -116,6 +116,15 @@ class GitServerConfigActivity : BaseGitActivity() {
           return@setOnClickListener
         }
       }
+      if (newUrl.startsWith("git://")) {
+        BasicBottomSheet.Builder(this)
+          .setTitleRes(R.string.git_scheme_disallowed_title)
+          .setMessageRes(R.string.git_scheme_disallowed_message)
+          .setPositiveButtonClickListener {}
+          .build()
+          .show(supportFragmentManager, "SSH_SCHEME_WARNING")
+        return@setOnClickListener
+      }
       when (val updateResult =
           GitSettings.updateConnectionSettingsIfValid(
             newAuthMode = newAuthMode,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,6 +389,8 @@
   <string name="ssh_scheme_needed_message">It appears that your URL contains a custom port, but does not specify the ssh:// scheme.\nThis can cause the port to be considered a part of your path. Press OK here to fix the URL.</string>
   <string name="https_scheme_with_port_title">HTTPS URL with custom port</string>
   <string name="https_scheme_with_port_message">It looks like you are using a HTTPS URL with a custom port. This is not supported, and will cause problems down the line. Press OK to remove the port from your URL.</string>
+  <string name="git_scheme_disallowed_title">Using the git:// protocol is discouraged</string>
+  <string name="git_scheme_disallowed_message">The git protocol provided by git-daemon performs no transport encryption and is unsuitable for secure operations.</string>
 
   <!-- Proxy configuration activity -->
   <string name="proxy_hostname">Proxy hostname</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds an explicit prompt discouraging the use of the `git://` protocol.

## :bulb: Motivation and Context
﻿
Closes #1367

## :green_heart: How did you test it?

Verified using a `git://`-based URL now correctly shows the prompt from the screenshot below.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :camera_flash: Screenshots / GIFs

![Screenshot of the error prompt](https://i.imgur.com/c5vbqds.jpg)
