### PR TITLE
Mark non-native Autofill browsers as unsupported on Oreo

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -48,7 +48,6 @@ import androidx.annotation.RequiresApi
    check whether it correctly distinguishes web origins even if iframes are present on the page.
    You can use https://fabianhenneke.github.io/Android-Password-Store/ as a test form.
 */
-
 /*
  * **Security assumption**: Browsers on this list correctly report the web origin of the top-level
  * window as part of their AssistStructure.
@@ -208,7 +207,14 @@ private fun getBrowserAutofillSupportLevel(context: Context, appPackage: String)
     browserInfo.multiOriginMethod == BrowserMultiOriginMethod.None -> BrowserAutofillSupportLevel.PasswordFill
     browserInfo.saveFlags == null -> BrowserAutofillSupportLevel.GeneralFill
     else -> BrowserAutofillSupportLevel.GeneralFillAndSave
+  }.takeUnless { supportLevel ->
+    // On Android Oreo, only browsers with native Autofill support can be used with Password Store
+    // (compatibility mode is only available on Android Pie and higher). Since all known browsers
+    // with native Autofill support offer full save support as well, we reuse the list of those
+    // browsers here.
+    supportLevel != BrowserAutofillSupportLevel.GeneralFillAndSave && Build.VERSION.SDK_INT < Build.VERSION_CODES.P
   }
+    ?: BrowserAutofillSupportLevel.None
 }
 
 @RequiresApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Android Oreo lacks the Autofill compatibility mode for browsers, which
means that browsers without explicit Android support will not trigger
Autofill events on web sites.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1369.

## :green_heart: How did you test it?
About to try this in an emulator.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
