### PR TITLE
Fix licence declarations for libraries

### DIFF
--- a/autofill-parser/build.gradle.kts
+++ b/autofill-parser/build.gradle.kts
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 
 plugins {

--- a/autofill-parser/gradle.properties
+++ b/autofill-parser/gradle.properties
@@ -1,6 +1,6 @@
 #
 # Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
-# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 #
 
 VERSION_NAME=1.1.0-SNAPSHOT

--- a/autofill-parser/src/main/AndroidManifest.xml
+++ b/autofill-parser/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
-  ~ SPDX-License-Identifier: GPL-3.0-only
+  ~ SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
   -->
 
 <manifest package="com.github.androidpasswordstore.autofillparser"></manifest>

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillHelper.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillHelper.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategy.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategy.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategyDsl.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillStrategyDsl.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
  */
 package com.github.androidpasswordstore.autofillparser
 

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
@@ -1,11 +1,7 @@
 /*
- * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
- */
-
-/*
  * SPDX-License-Identifier: (LGPL-3.0-only WITH LGPL-3.0-linking-exception) OR MPL-2.0
  */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
@@ -1,11 +1,7 @@
 /*
- * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
- */
-
-/*
  * SPDX-License-Identifier: (LGPL-3.0-only WITH LGPL-3.0-linking-exception) OR MPL-2.0
  */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoader.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoader.kt
@@ -1,11 +1,7 @@
 /*
- * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
- */
-
-/*
  * SPDX-License-Identifier: (LGPL-3.0-only WITH LGPL-3.0-linking-exception) OR MPL-2.0
  */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
@@ -1,11 +1,7 @@
 /*
- * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
- */
-
-/*
  * SPDX-License-Identifier: (LGPL-3.0-only WITH LGPL-3.0-linking-exception) OR MPL-2.0
  */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/openpgp-ktx/CHANGELOG.md
+++ b/openpgp-ktx/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+### [Unreleased]
+
+### [3.0.0] - 2021-04-10
+- Relicence under Apache 2.0
+
+### [2.2.0] - 2020-11-04
+- Update dependencies
+- Enable tracking of public API changes
+
+### [2.1.0] - 2020-08-16
+- Target Android 11
+- Update to Kotlin 1.4
+- Update library dependencies
+
+### [2.0.0] - 2020-04-29
+- **BREAKING**: Remove `IOpenPgpCallback` and replace it with a lambda reference.
+
+### [1.2.0] - 2020-01-25
+- Fix unmarshalling of `OpenPgpError`
+
+### [1.1.0] - 2019-12-26
+- Update library dependencies
+- Embed proguard rules in library
+
+### [1.0.0] - 2019-11-29
+- Update library dependencies
+- Make logtags unique across classes to aid debugging
+- **BREAKING**: Make parameters in OnBound interface non-null
+- **BREAKING**: `OpenPgpApi#executeApiAsync` is now a `suspend` function and only works with a [coroutines](https://github.com/kotlin/kotlinx.coroutines) caller
+- Don't generate `BuildConfig` in the library
+
+### [0.1.0] - 2019-11-08
+- Initial release
+
+[Unreleased]: https://github.com/android-password-store/Android-Password-Store/commits/develop/openpgp-ktx
+[3.0.0]: https://github.com/android-password-store/Android-Password-Store/releases/openpgp-ktx-v3.0.0
+[2.2.0]: https://github.com/android-password-store/openpgp-ktx/releases/2.2.0
+[2.1.0]: https://github.com/android-password-store/openpgp-ktx/releases/2.1.0
+[2.0.0]: https://github.com/android-password-store/openpgp-ktx/releases/2.0.0
+[1.2.0]: https://github.com/android-password-store/openpgp-ktx/releases/1.2.0
+[1.1.0]: https://github.com/android-password-store/openpgp-ktx/releases/1.1.0
+[1.0.0]: https://github.com/android-password-store/openpgp-ktx/releases/1.0.0
+[0.1.0]: https://github.com/android-password-store/openpgp-ktx/releases/0.1.0

--- a/openpgp-ktx/build.gradle.kts
+++ b/openpgp-ktx/build.gradle.kts
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 plugins {

--- a/openpgp-ktx/gradle.properties
+++ b/openpgp-ktx/gradle.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-VERSION_NAME=2.2.0
+VERSION_NAME=3.0.0
 POM_ARTIFACT_ID=openpgp-ktx
 POM_NAME=openpgp-ktx
 POM_DESCRIPTION=Reimplementation of OpenKeychain's integration library in Kotlin

--- a/openpgp-ktx/gradle.properties
+++ b/openpgp-ktx/gradle.properties
@@ -1,6 +1,6 @@
 #
 # Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
-# SPDX-License-Identifier: GPL-3.0-only
+# SPDX-License-Identifier: Apache-2.0
 #
 
 VERSION_NAME=2.2.0
@@ -14,8 +14,8 @@ POM_SCM_URL=https://github.com/Android-Password-Store/android-password-store
 POM_SCM_CONNECTION=scm:git:https://github.com/Android-Password-Store/android-password-store.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:Android-Password-Store/android-password-store
 
-POM_LICENCE_NAME=LGPL-3.0-only WITH LGPL-3.0-linking-exception
-POM_LICENCE_URL=https://www.gnu.org/licenses/lgpl-3.0.txt
+POM_LICENCE_NAME=Apache-2.0
+POM_LICENCE_URL=https://opensource.org/licenses/Apache-2.0
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=android-password-store

--- a/openpgp-ktx/src/main/AndroidManifest.xml
+++ b/openpgp-ktx/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <!--
   ~ Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
-  ~ SPDX-License-Identifier: GPL-3.0-only
+  ~ SPDX-License-Identifier: Apache-2.0
   -->
 
 <manifest package="me.msfjarvis.openpgpktx" />

--- a/openpgp-ktx/src/main/aidl/org/openintents/openpgp/IOpenPgpService2.aidl
+++ b/openpgp-ktx/src/main/aidl/org/openintents/openpgp/IOpenPgpService2.aidl
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2019 The Android Password Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-Only
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.openintents.openpgp;
 

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 package me.msfjarvis.openpgpktx
 

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 @file:Suppress("Unused")
 

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 package me.msfjarvis.openpgpktx.util
 

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 package me.msfjarvis.openpgpktx.util
 

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 package me.msfjarvis.openpgpktx.util
 

--- a/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpDecryptionResult.kt
+++ b/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpDecryptionResult.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 @file:JvmName("OpenPgpDecryptionResult")
 

--- a/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpError.kt
+++ b/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpError.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 @file:JvmName("OpenPgpError")
 

--- a/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpMetadata.kt
+++ b/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpMetadata.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 @file:JvmName("OpenPgpMetadata")
 

--- a/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpSignatureResult.kt
+++ b/openpgp-ktx/src/main/java/org/openintents/openpgp/OpenPgpSignatureResult.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
- * SPDX-License-Identifier: GPL-3.0-only
+ * SPDX-License-Identifier: Apache-2.0
  */
 @file:JvmName("OpenPgpSignatureResult")
 


### PR DESCRIPTION
## :scroll: Description

Restores the correct LGPL-3.0 + MPL-2.0 licence headers to `autofill-parser` and relicences `openpgp-ktx` under the Apache-2.0 licence used by the upstream `openpgp-api` project, since we are a derivative work of it and thus cannot licence it under a more restrictive licence.

Once this is merged we'll be releasing a new major version of `openpgp-ktx` with the new licence.

## :bulb: Motivation and Context

Licences are hard :shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
