### PR TITLE
Fix library deployment workflow

### DIFF
--- a/.github/workflows/deploy_library_releases.yml
+++ b/.github/workflows/deploy_library_releases.yml
@@ -35,8 +35,7 @@ jobs:
         SONATYPE_NEXUS_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
         SONATYPE_NEXUS_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.NEXUS_PUBLISH_GPG_KEY }}
-        ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_ID }}
-        ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_PASSWORD }}
 
     - name: Close and release repository
       uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6

--- a/.github/workflows/deploy_library_releases.yml
+++ b/.github/workflows/deploy_library_releases.yml
@@ -27,32 +27,21 @@ jobs:
           echo '::set-output name=PROJECT::autofill-parser'
         fi
 
-    - name: Setup secrets
-      run: |
-        # Using --batch doesn't prompt for a password for importing, which works
-        # out for us since we supply it to the Gradle plugin directly.
-        echo "${NEXUS_PUBLISH_GPG_KEY}" | base64 --decode | gpg --batch --import
-
-        # Set environment variables
-        echo "SONATYPE_NEXUS_USERNAME=${NEXUS_PUBLISH_USERNAME}" >> $GITHUB_ENV
-        echo "SONATYPE_NEXUS_PASSWORD=${NEXUS_PUBLISH_PASSWORD}" >> $GITHUB_ENV
-        # The ORG_GRADLE_PROJECT_ prefixed properties are equivalent to ./gradlew -Pproperty.name=value
-        echo "ORG_GRADLE_PROJECT_signing.keyId=${NEXUS_PUBLISH_GPG_KEY_ID}" >> $GITHUB_ENV
-        echo "ORG_GRADLE_PROJECT_signing.password=${NEXUS_PUBLISH_GPG_KEY_PASSWORD}" >> $GITHUB_ENV
-        echo "ORG_GRADLE_PROJECT_signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg" >> $GITHUB_ENV
-      env:
-        NEXUS_PUBLISH_GPG_KEY: ${{ secrets.NEXUS_PUBLISH_GPG_KEY }}
-        NEXUS_PUBLISH_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
-        NEXUS_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
-        NEXUS_PUBLISH_GPG_KEY_ID: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_ID }}
-        NEXUS_PUBLISH_GPG_KEY_PASSWORD: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_PASSWORD }}
-
     - name: Upload binaries
       uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
         arguments: :${{ steps.task-select.outputs.PROJECT }}:uploadArchives
+      env:
+        SONATYPE_NEXUS_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
+        SONATYPE_NEXUS_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.NEXUS_PUBLISH_GPG_KEY }}
+        ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_ID }}
+        ORG_GRADLE_PROJECT_signingKeyPassword: ${{ secrets.NEXUS_PUBLISH_GPG_KEY_PASSWORD }}
 
     - name: Close and release repository
       uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
         arguments: closeAndReleaseRepository
+      env:
+        SONATYPE_NEXUS_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
+        SONATYPE_NEXUS_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}

--- a/buildSrc/src/main/java/PasswordStorePlugin.kt
+++ b/buildSrc/src/main/java/PasswordStorePlugin.kt
@@ -16,6 +16,8 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.SigningExtension
+import org.gradle.plugins.signing.SigningPlugin
 
 class PasswordStorePlugin : Plugin<Project> {
 
@@ -44,6 +46,9 @@ class PasswordStorePlugin : Plugin<Project> {
         }
         is KtfmtPlugin -> {
           project.extensions.getByType<KtfmtExtension>().configureKtfmt()
+        }
+        is SigningPlugin -> {
+          project.extensions.getByType<SigningExtension>().configureBuildSigning()
         }
       }
     }

--- a/buildSrc/src/main/java/SigningConfig.kt
+++ b/buildSrc/src/main/java/SigningConfig.kt
@@ -6,6 +6,8 @@
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import java.util.Properties
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.plugins.signing.SigningExtension
 
 private const val KEYSTORE_CONFIG_PATH = "keystore.properties"
 
@@ -29,4 +31,10 @@ internal fun BaseAppModuleExtension.configureBuildSigning(project: Project) {
     val signingConfig = signingConfigs.getByName("release")
     buildTypes.all { setSigningConfig(signingConfig) }
   }
+}
+
+internal fun SigningExtension.configureBuildSigning() {
+  val signingKey: String? by project
+  val signingPassword: String? by project
+  useInMemoryPgpKeys(signingKey, signingPassword)
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Refactors how environment variables are provided to the workflow steps and improves the signing setup within our Gradle build to eliminate the GPG CLI entirely.

## :bulb: Motivation and Context

While making the openpgp-ktx release I discovered our library deployment workflow doesn't work at all :sweat_smile:

It took a while to suss out the exact cause, and some more to find a more robust way of making this work, but I'm confident in the new setup.

## :green_heart: How did you test it?

Replicated the GHA environment variables and confirmed that builds published to a local repository were all signed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Test this with an `autofill-parser` release?
