### PR TITLE
Fix IDE resolution for buildSrc and update binary-compatibility-validator

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,8 +12,6 @@ repositories {
   google()
   gradlePluginPortal()
   mavenCentral()
-  // For binary compatibility validator.
-  maven { url = uri("https://kotlin.bintray.com/kotlinx") }
 }
 
 ktfmt {
@@ -40,7 +38,7 @@ gradlePlugin {
 
 dependencies {
   implementation("com.android.tools.build:gradle:4.1.3")
-  implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.2.4")
+  implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0")
   implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.30")
   implementation("de.undercouch:gradle-download-task:4.1.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,12 +39,12 @@ gradlePlugin {
 }
 
 dependencies {
-  implementation(libs.androidGradlePlugin)
-  implementation(libs.binaryCompatibilityValidator)
-  implementation(libs.dokkaPlugin)
-  implementation(libs.downloadTaskPlugin)
-  implementation(libs.kotlinGradlePlugin)
-  implementation(libs.ktfmtGradlePlugin)
-  implementation(libs.mavenPublishPlugin)
-  implementation(libs.semver4j)
+  implementation("com.android.tools.build:gradle:4.1.3")
+  implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.2.4")
+  implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.30")
+  implementation("de.undercouch:gradle-download-task:4.1.1")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
+  implementation("com.ncorti.ktfmt.gradle:plugin:0.5.0")
+  implementation("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
+  implementation("com.vdurmont:semver4j:3.1.0")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,3 +1,6 @@
+/**
+ * IDEs don't support this very well for buildSrc, so we use the regular dependency format
+ * until that changes.
 dependencyResolutionManagement {
   versionCatalogs {
     create("libs") {
@@ -5,3 +8,4 @@ dependencyResolutionManagement {
     }
   }
 }
+*/

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -36,7 +36,7 @@ internal fun Project.configureForAllProjects() {
   repositories {
     google()
     mavenCentral()
-    jcenter() {
+    jcenter {
       content {
         // https://github.com/zhanghai/AndroidFastScroll/issues/35
         includeModule("me.zhanghai.android.fastscroll", "library")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ lifecycle = "2.4.0-alpha01"
 [libraries]
 # buildSrc dependencies
 androidGradlePlugin = "com.android.tools.build:gradle:4.1.3"
-binaryCompatibilityValidator = "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.4"
+binaryCompatibilityValidator = "org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0"
 dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
 downloadTaskPlugin = "de.undercouch:gradle-download-task:4.1.1"
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Replaces the newly introduced Gradle version catalog in `buildSrc` back to regular dependency references, and updates the binary-compatibility-validator plugin while at it.

## :bulb: Motivation and Context

IDEs seem to offer demonstrably poor support for custom version catalogs, causing most code in `buildSrc` to be highlighted with errors and making development a rather hard task.

## :green_heart: How did you test it?

Verified IDEs offer completion and reference navigation for our dependencies once more.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
