### PR TITLE
Remove hand-rolled CoroutineScope and fix inverted conditions

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivity.kt
@@ -40,10 +40,7 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.msfjarvis.openpgpktx.util.OpenPgpApi
@@ -53,7 +50,7 @@ import org.openintents.openpgp.OpenPgpError
 
 @RequiresApi(Build.VERSION_CODES.O)
 @AndroidEntryPoint
-class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
+class AutofillDecryptActivity : AppCompatActivity() {
 
   companion object {
 
@@ -101,9 +98,6 @@ class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
   private var continueAfterUserInteraction: Continuation<Intent>? = null
   private lateinit var directoryStructure: DirectoryStructure
 
-  override val coroutineContext
-    get() = Dispatchers.IO + SupervisorJob()
-
   override fun onStart() {
     super.onStart()
     val filePath =
@@ -124,7 +118,7 @@ class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
     val action = if (isSearchAction) AutofillAction.Search else AutofillAction.Match
     directoryStructure = AutofillPreferences.directoryStructure(this)
     d { action.toString() }
-    launch {
+    lifecycleScope.launch {
       val credentials = decryptCredential(File(filePath))
       if (credentials == null) {
         setResult(RESULT_CANCELED)
@@ -141,7 +135,6 @@ class AutofillDecryptActivity : AppCompatActivity(), CoroutineScope {
 
   override fun onDestroy() {
     super.onDestroy()
-    coroutineContext.cancelChildren()
   }
 
   private suspend fun executeOpenPgpApi(data: Intent, input: InputStream, output: OutputStream): Intent? {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -91,7 +91,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
     passwordEntry?.let { entry ->
       if (menu != null) {
         menu.findItem(R.id.edit_password).isVisible = true
-        if (entry.password.isNullOrBlank()) {
+        if (!entry.password.isNullOrBlank()) {
           menu.findItem(R.id.share_password_as_plaintext).isVisible = true
           menu.findItem(R.id.copy_password).isVisible = true
         }
@@ -189,7 +189,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
               passwordEntry = entry
               invalidateOptionsMenu()
 
-              if (entry.password.isNullOrBlank()) {
+              if (!entry.password.isNullOrBlank()) {
                 items.add(FieldItem.createPasswordField(entry.password!!))
               }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Removes the manually implemented `CoroutineScope` with `lifecycleScope` and fixes a couple inverted conditions in `DecryptActivity`.

## :bulb: Motivation and Context

Manually implementing `CoroutineScope` is generally discouraged and even more pointless when a superior solution exists in `lifecycleScope`. The flipped conditions in `DecryptActivity` would cause the app to only show a password field when the password is blank.

## :green_heart: How did you test it?

Verified passwords show up in `DecryptActivity` when they should and decryption through Autofill works as intended.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with ktfmt (`./gradlew ktfmtFormat`)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
