### PR TITLE
Use correct time to find TOTP secret

### DIFF
--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -14,6 +14,7 @@ import dev.msfjarvis.aps.util.totp.Otp
 import dev.msfjarvis.aps.util.totp.TotpFinder
 import kotlin.collections.set
 import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -83,10 +84,10 @@ constructor(
       scope.launch {
         updateTotp(clock.millis())
         val remainingTime = totpPeriod - (System.currentTimeMillis() % totpPeriod)
-        delay(remainingTime)
+        delay(remainingTime.seconds)
         repeat(Int.MAX_VALUE) {
           updateTotp(clock.millis())
-          delay(totpPeriod * 1_000)
+          delay(totpPeriod.seconds)
         }
       }
     }

--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -86,7 +86,7 @@ constructor(
         delay(remainingTime)
         repeat(Int.MAX_VALUE) {
           updateTotp(clock.millis())
-          delay(totpPeriod)
+          delay(totpPeriod * 1_000)
         }
       }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Time received from TotpFinder is in seconds so convert it to milliseconds before using it.

## :bulb: Motivation and Context


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
