### PR TITLE
Add scripts to boot an emulator and use them in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,20 +43,32 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
+    - name: Boot emulator in background
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: |
+        ./scripts/setup_environment.sh
+        ./scripts/boot_emulator.sh &
+      env:
+        ANDROID_API_LEVEL: ${{ matrix.api-level }}
+
     - name: Run unit tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
         arguments: apiCheck testFreeDebug lintFreeDebug ktfmtCheck
 
+    - name: Wait for emulator bootup
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: |
+        until [ "$(adb shell getprop sys.boot_completed)" == "1" ]
+          do sleep 5
+        done
+
     - name: Run instrumentation tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: reactivecircus/android-emulator-runner@08b092e904025fada32a01b711af1e7ff7b7a4a3
+      uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
       with:
-        api-level: ${{ matrix.api-level }}
-        target: default
-        script: |
-          ./gradlew :app:connectedFreeDebugAndroidTest
+        arguments: :app:connectedFreeDebugAndroidTest
 
     - name: (Fail-only) upload test report
       if: failure()

--- a/scripts/boot_emulator.sh
+++ b/scripts/boot_emulator.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Creates and boots an emulator that exactly matches the one in our CI. It is recommended
+# to use this as the target device for screenshot tests.
+
+set -euo pipefail
+
+[ -n "${ANDROID_SDK_ROOT:-}" ] || {
+  echo "ANDROID_SDK_ROOT must be set to use this script"
+  exit
+  1
+}
+[ -n "${ANDROID_API_LEVEL:-}" ] || { echo "ANDROID_API_LEVEL not defined; defaulting to 30"; }
+[ -n "${ANDROID_SYSTEM_IMAGE_TYPE:-}" ] || { echo "ANDROID_SYSTEM_IMAGE_TYPE not defined; defaulting to 'google_apis' "; }
+
+API_LEVEL="${ANDROID_API_LEVEL:-30}"
+SYSTEM_IMAGE_TYPE="${ANDROID_SYSTEM_IMAGE_TYPE:-google_apis}"
+
+echo no | "${ANDROID_SDK_ROOT}"/cmdline-tools/latest/bin/avdmanager create avd \
+  --force \
+  -n "Pixel_XL_API_${API_LEVEL}" \
+  --abi "${SYSTEM_IMAGE_TYPE}/x86" \
+  --package "system-images;android-${API_LEVEL};${SYSTEM_IMAGE_TYPE};x86" \
+  --device 'pixel_xl'
+
+"${ANDROID_SDK_ROOT}"/emulator/emulator \
+  -avd "Pixel_XL_API_${API_LEVEL}" \
+  -no-window \
+  -gpu swiftshader_indirect \
+  -no-snapshot \
+  -noaudio \
+  -no-boot-anim

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Installs the latest command line tools and sets up the necessary packages for an Android emulator
+# for API level $ANDROID_API_LEVEL, or API 30 if unspecified.
+
+set -euo pipefail
+
+CMDLINE_TOOLS_URL_MAC="https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip"
+CMDLINE_TOOLS_URL_LINUX="https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip"
+
+[ -n "${ANDROID_SDK_ROOT:-}" ] || {
+  echo "ANDROID_SDK_ROOT must be set to use this script"
+  exit
+  1
+}
+
+if [ "$(uname)" == "Linux" ]; then
+  wget "${CMDLINE_TOOLS_URL_LINUX}" -O /tmp/tools.zip -o /dev/null
+elif [ "$(uname)" == "Darwin" ]; then
+  wget "${CMDLINE_TOOLS_URL_MAC}" -O /tmp/tools.zip -o /dev/null
+else
+  echo "This script only works on Linux and Mac"
+  exit 1
+fi
+
+[ -n "${ANDROID_API_LEVEL:-}" ] || { echo "ANDROID_API_LEVEL not defined; defaulting to 30"; }
+[ -n "${ANDROID_SYSTEM_IMAGE_TYPE:-}" ] || { echo "ANDROID_SYSTEM_IMAGE_TYPE not defined; defaulting to 'google_apis' "; }
+
+API_LEVEL="${ANDROID_API_LEVEL:-30}"
+SYSTEM_IMAGE_TYPE="${ANDROID_SYSTEM_IMAGE_TYPE:-google_apis}"
+
+unzip -qo /tmp/tools.zip -d "${ANDROID_SDK_ROOT}/latest"
+mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools"
+if [ -d "${ANDROID_SDK_ROOT}/cmdline-tools" ]; then
+  rm -rf "${ANDROID_SDK_ROOT}/cmdline-tools"
+fi
+mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools"
+mv -v "${ANDROID_SDK_ROOT}/latest/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest"
+
+export PATH="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${PATH}"
+
+sdkmanager --install 'build-tools;30.0.3' platform-tools "platforms;android-${API_LEVEL}"
+sdkmanager --install emulator
+sdkmanager --install "system-images;android-${API_LEVEL};${SYSTEM_IMAGE_TYPE};x86"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Add a set of scripts that boot a clean, deterministic emulator each time and use them for our CI. In the near future when our UI starts migrating to Jetpack Compose, the consistency will be extremely useful for screenshot testing.

## :bulb: Motivation and Context

Being able to run the emulator within our environment will allow us to re-use our build cache accumulated during unit testing and slightly speed things up. It also moves emulator bootup to the background, so that we don't have to waste time waiting for it.

## :green_heart: How did you test it?

This PR?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
