### PR TITLE
Migrate some tests to Robolectric

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,5 +100,6 @@ dependencies {
 
   androidTestImplementation(libs.bundles.testDependencies)
   androidTestImplementation(libs.bundles.androidTestDependencies)
+  testImplementation(libs.testing.robolectric)
   testImplementation(libs.bundles.testDependencies)
 }

--- a/app/src/test/java/dev/msfjarvis/aps/util/totp/UriTotpFinderTest.kt
+++ b/app/src/test/java/dev/msfjarvis/aps/util/totp/UriTotpFinderTest.kt
@@ -7,7 +7,12 @@ package dev.msfjarvis.aps.util.totp
 
 import kotlin.test.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [23])
 class UriTotpFinderTest {
 
   private val totpFinder = UriTotpFinder()

--- a/app/src/test/java/dev/msfjarvis/aps/util/viewmodel/StrictDomainRegexTest.kt
+++ b/app/src/test/java/dev/msfjarvis/aps/util/viewmodel/StrictDomainRegexTest.kt
@@ -8,10 +8,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 private infix fun String.matchedForDomain(domain: String) =
   SearchableRepositoryViewModel.generateStrictDomainRegex(domain)?.containsMatchIn(this) == true
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [23])
 class StrictDomainRegexTest {
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ thirdparty-nonfree-googlePlayAuthApiPhone = "com.google.android.gms:play-service
 # Testing dependencies
 testing-junit = "junit:junit:4.13.2"
 testing-kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+testing-robolectric = "org.robolectric:robolectric:4.5.1"
 androidx-testing-rules = { module = "androidx.test:rules", version.ref="androidx_test" }
 androidx-testing-runner = { module = "androidx.test:runner", version.ref="androidx_test" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Migrate tests with low coupling to Robolectric.

## :bulb: Motivation and Context

This cuts down on emulator needs for us and allows for things to be run faster in development.

## :green_heart: How did you test it?

`./gradlew :app:testNonFreeDebug`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Improving how we construct and use `GitSettings` across our codebase so that the migrations test can also be moved to Robolectric
