### PR TITLE
Enable StrictMode in debug logging builds

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/Application.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/Application.kt
@@ -5,6 +5,9 @@
 package dev.msfjarvis.aps
 
 import android.content.SharedPreferences
+import android.os.StrictMode
+import android.os.StrictMode.ThreadPolicy
+import android.os.StrictMode.VmPolicy
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
@@ -31,6 +34,8 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
     instance = this
     if (BuildConfig.ENABLE_DEBUG_FEATURES || prefs.getBoolean(PreferenceKeys.ENABLE_DEBUG_LOGGING, false)) {
       plant(DebugTree())
+      StrictMode.setVmPolicy(VmPolicy.Builder().detectAll().penaltyLog().build())
+      StrictMode.setThreadPolicy(ThreadPolicy.Builder().detectAll().penaltyLog().build())
     }
     prefs.registerOnSharedPreferenceChangeListener(this)
     setNightMode()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Enables [StrictMode](https://developer.android.com/reference/android/os/StrictMode) in builds with debugging features enabled with the logging penalty that prints stacktraces of all violations to the logcat stream.


## :bulb: Motivation and Context

`StrictMode` catches potential errors such as main thread File I/O that can manifest in user-facing issues like ANRs.

## :green_heart: How did you test it?

Enabled debug logging on a release build and verified StrictMode violations are logged.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Start fixing the problems reported by `StrictMode`
