### PR TITLE
Do not ASCII armor files when encrypting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   Accessibility autofill has been removed completely due to being buggy, insecure and lacking in features. Upgrade to Android 8 or preferably later to gain access to our advanced Autofill implementation.
 -   The settings UI has been completely re-done to dramatically improve discoverability and navigation for users
 -   Using the `git://` protocol in the server URL now presents an explicit discouragement rather than a generic error
+-   Encrypted data is no longer ASCII armored, bringing it in line with `pass`
 
 ## [1.13.4] - 2021-03-20
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivity.kt
@@ -366,7 +366,7 @@ class PasswordCreationActivity : BasePgpActivity(), OpenPgpServiceConnection.OnB
         encryptionIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, userIds)
       }
 
-      encryptionIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true)
+      encryptionIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, false)
 
       val content = "$editPass\n$editExtra"
       val inputStream = ByteArrayInputStream(content.toByteArray())


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Disables the extra field that forces passwords to be ASCII armored.

## :bulb: Motivation and Context

﻿The pass CLI as of v1.7.3 does not do that either, and it increases the git diff for no real benefit.

## :green_heart: How did you test it?

Verified passwords edited by APS are no longer converted from binary to ASCII text.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
