### PR TITLE
Refactor openpgp-ktx to leverage coroutines

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -165,55 +165,54 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
     val inputStream = File(fullPath).inputStream()
     val outputStream = ByteArrayOutputStream()
 
-    lifecycleScope.launch(Dispatchers.IO) {
-      api?.executeApiAsync(data, inputStream, outputStream) { result ->
-        when (result?.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
-          OpenPgpApi.RESULT_CODE_SUCCESS -> {
-            startAutoDismissTimer()
-            runCatching {
-              val showPassword = settings.getBoolean(PreferenceKeys.SHOW_PASSWORD, true)
-              val entry = passwordEntryFactory.create(lifecycleScope, outputStream.toByteArray())
-              val items = arrayListOf<FieldItem>()
-              val adapter = FieldItemAdapter(emptyList(), showPassword) { text -> copyTextToClipboard(text) }
+    lifecycleScope.launch(Dispatchers.Main) {
+      val result = withContext(Dispatchers.IO) { checkNotNull(api).executeApi(data, inputStream, outputStream) }
+      when (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
+        OpenPgpApi.RESULT_CODE_SUCCESS -> {
+          startAutoDismissTimer()
+          runCatching {
+            val showPassword = settings.getBoolean(PreferenceKeys.SHOW_PASSWORD, true)
+            val entry = passwordEntryFactory.create(lifecycleScope, outputStream.toByteArray())
+            val items = arrayListOf<FieldItem>()
+            val adapter = FieldItemAdapter(emptyList(), showPassword) { text -> copyTextToClipboard(text) }
 
-              if (settings.getBoolean(PreferenceKeys.COPY_ON_DECRYPT, false)) {
-                copyPasswordToClipboard(entry.password)
-              }
-
-              passwordEntry = entry
-              invalidateOptionsMenu()
-
-              if (!entry.password.isNullOrBlank()) {
-                items.add(FieldItem.createPasswordField(entry.password!!))
-              }
-
-              if (entry.hasTotp()) {
-                launch(Dispatchers.IO) {
-                  withContext(Dispatchers.Main) {
-                    val code = entry.totp.value
-                    items.add(FieldItem.createOtpField(code))
-                  }
-                  entry.totp.collect { code -> withContext(Dispatchers.Main) { adapter.updateOTPCode(code) } }
-                }
-              }
-
-              if (!entry.username.isNullOrBlank()) {
-                items.add(FieldItem.createUsernameField(entry.username!!))
-              }
-
-              entry.extraContent.forEach { (key, value) -> items.add(FieldItem(key, value, FieldItem.ActionType.COPY)) }
-
-              binding.recyclerView.adapter = adapter
-              adapter.updateItems(items)
+            if (settings.getBoolean(PreferenceKeys.COPY_ON_DECRYPT, false)) {
+              copyPasswordToClipboard(entry.password)
             }
-              .onFailure { e -> e(e) }
+
+            passwordEntry = entry
+            invalidateOptionsMenu()
+
+            if (!entry.password.isNullOrBlank()) {
+              items.add(FieldItem.createPasswordField(entry.password!!))
+            }
+
+            if (entry.hasTotp()) {
+              launch(Dispatchers.IO) {
+                withContext(Dispatchers.Main) {
+                  val code = entry.totp.value
+                  items.add(FieldItem.createOtpField(code))
+                }
+                entry.totp.collect { code -> withContext(Dispatchers.Main) { adapter.updateOTPCode(code) } }
+              }
+            }
+
+            if (!entry.username.isNullOrBlank()) {
+              items.add(FieldItem.createUsernameField(entry.username!!))
+            }
+
+            entry.extraContent.forEach { (key, value) -> items.add(FieldItem(key, value, FieldItem.ActionType.COPY)) }
+
+            binding.recyclerView.adapter = adapter
+            adapter.updateItems(items)
           }
-          OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED -> {
-            val sender = getUserInteractionRequestIntent(result)
-            userInteractionRequiredResult.launch(IntentSenderRequest.Builder(sender).build())
-          }
-          OpenPgpApi.RESULT_CODE_ERROR -> handleError(result)
+            .onFailure { e -> e(e) }
         }
+        OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED -> {
+          val sender = getUserInteractionRequestIntent(result)
+          userInteractionRequiredResult.launch(IntentSenderRequest.Builder(sender).build())
+        }
+        OpenPgpApi.RESULT_CODE_ERROR -> handleError(result)
       }
     }
   }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -189,8 +189,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
 
             if (entry.hasTotp()) {
               launch {
-                val code = entry.totp.value
-                items.add(FieldItem.createOtpField(code))
+                items.add(FieldItem.createOtpField(entry.totp.value))
                 entry.totp.collect { code -> withContext(Dispatchers.Main) { adapter.updateOTPCode(code) } }
               }
             }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -188,11 +188,9 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
             }
 
             if (entry.hasTotp()) {
-              launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                  val code = entry.totp.value
-                  items.add(FieldItem.createOtpField(code))
-                }
+              launch {
+                val code = entry.totp.value
+                items.add(FieldItem.createOtpField(code))
                 entry.totp.collect { code -> withContext(Dispatchers.Main) { adapter.updateOTPCode(code) } }
               }
             }

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 - The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
 
+- The synchronous and callback based APIs in `OpenPgpApi` have been removed in favor of a singular coroutines-based entrypoint.
+
 ### Fixed
 
 - Fix build warning from undeclared unsigned type use.

--- a/openpgp-ktx/api/openpgp-ktx.api
+++ b/openpgp-ktx/api/openpgp-ktx.api
@@ -88,8 +88,7 @@ public final class me/msfjarvis/openpgpktx/util/OpenPgpApi {
 	public static final field RESULT_SIGNATURE_MICALG Ljava/lang/String;
 	public static final field SERVICE_INTENT_2 Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;Lorg/openintents/openpgp/IOpenPgpService2;)V
-	public final fun executeApi (Landroid/content/Intent;Ljava/io/InputStream;Ljava/io/OutputStream;)Landroid/content/Intent;
-	public final fun executeApiAsync (Landroid/content/Intent;Ljava/io/InputStream;Ljava/io/OutputStream;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun executeApi (Landroid/content/Intent;Ljava/io/InputStream;Ljava/io/OutputStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class me/msfjarvis/openpgpktx/util/OpenPgpApi$Companion {

--- a/openpgp-ktx/gradle.properties
+++ b/openpgp-ktx/gradle.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-VERSION_NAME=3.0.0
+VERSION_NAME=4.0.0-SNAPSHOT
 POM_ARTIFACT_ID=openpgp-ktx
 POM_NAME=openpgp-ktx
 POM_DESCRIPTION=Reimplementation of OpenKeychain's integration library in Kotlin


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Rewrites the guts of `OpenPgpApi` to make more operations `suspend` and deprecates both the synchronous as well as the callback-based APIs in favor of a single coroutines based implementation.

## :bulb: Motivation and Context

The callback style API made for a rather awkward calling convention that made little sense in a coroutines enabled world.

## :green_heart: How did you test it?

Verified encryption and decryption activities still work as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
