### PR TITLE
Sync localisations from Crowdin

### DIFF
--- a/.github/workflows/sync_crowdin.yml
+++ b/.github/workflows/sync_crowdin.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * 6'
 
 jobs:
-  update-publicsuffix-data:
+  sync-crowdin:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -314,8 +314,15 @@
   <string name="select_repo_type_text">Wählen Sie aus, ob sie ein lokales Repository, oder ein remote Repository anlegen möchten.</string>
   <string name="clone_remote_repo">Remote Repository klonen</string>
   <string name="create_local_repo">Lokales Repository anlegen</string>
+  <string name="select_gpg_key_title">Wähle\nGPG Key</string>
+  <string name="gpg_key_select">Schlüssel auswählen</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">Möglicherweise inkorrekte URL</string>
   <string name="ssh_scheme_needed_message">Es sieht so aus, als ob Sie einen benutzerdefinierten Port in Ihrer URL angegeben haben, aber nicht in dem ssh://-Schema.\nDas kann dazu führen, dass Ihr Port als Teil des Pfades betrachtet wird. Drücken Sie hier auf OK um die URL zu korrigieren.</string>
   <!-- Proxy configuration activity -->
+  <string name="port">Port</string>
+  <string name="otp_import_qr_code">QR-Code scannen</string>
+  <string name="otp_import_manual_entry">Manuell eingeben</string>
+  <string name="otp_import_manual_hint_secret">Schlüssel</string>
+  <string name="gpg_key_select_mandatory">Die Auswahl eines GPG-Schlüssels ist notwendig, um fortzufahren</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -354,6 +354,8 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="ssh_scheme_needed_message">Semella que o teu URL contén un porto personalizado, pero non indica o esquema ssh://.\nEsto pode facer que o porto sexa considerado parte do enderezo. Preme aquí en OK para arranxalo URL.</string>
   <string name="https_scheme_with_port_title">URL HTTPS con porto personalizado</string>
   <string name="https_scheme_with_port_message">Semella que estar a usar un URL HTTPS cun porto personalizado. Esta función non está soportada, e causará problemas futuros. Preme OK para eliminar o porto do URL.</string>
+  <string name="git_scheme_disallowed_title">Non se recomenda utilizar o protocolo git://</string>
+  <string name="git_scheme_disallowed_message">O protocolo git proporcionado polo git-daemon non realiza o transporte cifrado e non é válido para operacións seguras.</string>
   <!-- Proxy configuration activity -->
   <string name="proxy_hostname">Servidor proxy</string>
   <string name="port">Porto</string>
@@ -366,4 +368,5 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="otp_import_manual_entry">Escribir manualmente</string>
   <string name="otp_import_manual_hint_secret">Segredo</string>
   <string name="otp_import_manual_hint_account">Conta</string>
+  <string name="gpg_key_select_mandatory">É preciso elexir unha chave GPG para continuar</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -353,6 +353,8 @@
   <string name="ssh_scheme_needed_message">Parece que sua URL contém uma porta personalizada, mas não especifica o esquema ssh://\nIsto pode fazer com que a porta seja considerada uma parte do seu caminho. Pressione OK aqui para corrigir o URL.</string>
   <string name="https_scheme_with_port_title">URL HTTPS com porta personalizada</string>
   <string name="https_scheme_with_port_message">Parece que você está usando uma URL HTTPS com uma porta personalizada. Isto não é suportado e causará problemas na linha. Pressione OK para remover a porta da URL.</string>
+  <string name="git_scheme_disallowed_title">Usa o protocolo git:// não é recomendado</string>
+  <string name="git_scheme_disallowed_message">O protocolo git fornecido pelo git-daemon não produz qualquer encriptação de transporte e não é adequado para operações seguras.</string>
   <!-- Proxy configuration activity -->
   <string name="proxy_hostname">Nome do Host de proxy</string>
   <string name="port">Porta</string>
@@ -361,4 +363,9 @@
   <string name="oreo_autofill_password_fill_and_conditional_save_support">Preencha e salve as senhas (salvamento requer que nenhum serviço de acessibilidade esteja ativado)</string>
   <string name="clear_saved_host_key">Limpar chave de host salva</string>
   <string name="clear_saved_host_key_success">Chave de host limpa com sucesso!</string>
+  <string name="otp_import_qr_code">Escanear QR code</string>
+  <string name="otp_import_manual_entry">Inserir manualmente</string>
+  <string name="otp_import_manual_hint_secret">Segredo</string>
+  <string name="otp_import_manual_hint_account">Conta</string>
+  <string name="gpg_key_select_mandatory">A seleção de uma chave GPG é necessária para prosseguir</string>
 </resources>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -45,5 +45,6 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")
   implementation("com.ncorti.ktfmt.gradle:plugin:0.5.0")
   implementation("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
+  implementation("com.squareup.okhttp3:okhttp:4.9.0")
   implementation("com.vdurmont:semver4j:3.1.0")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ hiltGradlePlugin = { module = "com.google.dagger:hilt-android-gradle-plugin", ve
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktfmtGradlePlugin = "com.ncorti.ktfmt.gradle:plugin:0.5.0"
 mavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.13.0"
+okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
 semver4j = "com.vdurmont:semver4j:3.1.0"
 
 # Kotlin dependencies


### PR DESCRIPTION
## :scroll: Description

Syncs strings and fixes the workflow name for the Crowdin sync that has been annoying me for a while D:

Also finally adds a `buildOnApi` task that will set off a build on Crowdin automatically before syncing strings. This will eliminate the manual build and/or sync that I've had to be doing.
