### PR TITLE
Accept emails without TLDs during GpgIdentifier parsing

### DIFF
--- a/app/src/test/java/dev/msfjarvis/aps/util/crypto/GpgIdentifierTest.kt
+++ b/app/src/test/java/dev/msfjarvis/aps/util/crypto/GpgIdentifierTest.kt
@@ -5,7 +5,6 @@
 
 package dev.msfjarvis.aps.util.crypto
 
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -28,15 +27,14 @@ class GpgIdentifierTest {
 
   @Test
   fun `parses email as user id`() {
-    val identifier = GpgIdentifier.fromString("aps@msfjarvis.dev")
+    val identifier = GpgIdentifier.fromString("john.doe@example.org")
     assertNotNull(identifier)
     assertTrue { identifier is GpgIdentifier.UserId }
   }
 
   @Test
-  @Ignore("OpenKeychain can't yet handle these so we don't either")
-  fun `parses non-email user id`() {
-    val identifier = GpgIdentifier.fromString("john.doe")
+  fun `parses user@host without TLD`() {
+    val identifier = GpgIdentifier.fromString("john.doe@example")
     assertNotNull(identifier)
     assertTrue { identifier is GpgIdentifier.UserId }
   }

--- a/openpgp-ktx/CHANGELOG.md
+++ b/openpgp-ktx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### [Unreleased]
 
 - The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
+- Accept emails without a TLD
 
 ### [3.0.0] - 2021-04-10
 - Relicence under Apache 2.0

--- a/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
+++ b/openpgp-ktx/src/main/java/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
@@ -20,7 +20,7 @@ public object OpenPgpUtils {
       Pattern.DOTALL
     )
   private val USER_ID_PATTERN = Pattern.compile("^(.*?)(?: \\((.*)\\))?(?: <(.*)>)?$")
-  private val EMAIL_PATTERN = Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*\\.[^<>\"]*)\"?>?$")
+  private val EMAIL_PATTERN = Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*[.]?[^<>\"]*)\"?>?$")
   public const val PARSE_RESULT_NO_PGP: Int = -1
   public const val PARSE_RESULT_MESSAGE: Int = 0
   public const val PARSE_RESULT_SIGNED_MESSAGE: Int = 1


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Accept emails without TLDs and update tests to cover the case.

## :bulb: Motivation and Context

Fixes https://github.com/open-keychain/open-keychain/issues/2579

It appears the issue was only with the regex in `OpenPgpUtils`, and OpenKeychain itself
is totally chill with an email that's not really valid. You can see proof
of that during the key creation itself, where OpenKeychain warns that a valid email is
helpful for compatibility with other clients but doesn't block creation of said key.

## :green_heart: How did you test it?

- Created a new GPG key in OpenKeychain with the email `john.doe@example`
- Created a password store on my PC with the same email (`pass init john.doe@example`)
- Imported the store in APS and the onboarding process correctly accepted it
- Created a new password in APS
- Was able to correctly decrypt it both in the app as well as a Linux desktop

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code with the IDE's reformat action (Ctrl + Shift + L/Cmd + Shift + L)
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
