### PR TITLE
Fix incorrect changelog entries

### DIFF
--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -12,8 +12,6 @@ All notable changes to this project will be documented in this file.
 
 - The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
 
-- The synchronous and callback based APIs in `OpenPgpApi` have been removed in favor of a singular coroutines-based entrypoint.
-
 ### Fixed
 
 - Fix build warning from undeclared unsigned type use.

--- a/openpgp-ktx/CHANGELOG.md
+++ b/openpgp-ktx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### [Unreleased]
 
 - The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
+- The synchronous and callback based APIs in `OpenPgpApi` have been removed in favor of a singular coroutines-based entrypoint.
 - Accept emails without a TLD
 
 ### [3.0.0] - 2021-04-10


### PR DESCRIPTION
The changelog entry added in #1398 was supposed to go in openpgp-ktx, but was accidentally added to autofill-parser instead.