### PR TITLE
Upgrade Kotlin and AndroidX dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@
 plugins {
   `binary-compatibility-validator`
   `aps-plugin`
+  // Fix for leak in Kotlin Gradle Plugin: https://youtrack.jetbrains.com/issue/KT-46368
   id("dev.zacsweers.kgp-150-leak-patcher") version "1.0.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@
 plugins {
   `binary-compatibility-validator`
   `aps-plugin`
+  id("dev.zacsweers.kgp-150-leak-patcher") version "1.0.1"
 }
 
 allprojects { apply(plugin = "com.ncorti.ktfmt.gradle") }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
   google()
   gradlePluginPortal()
   mavenCentral()
+  // Dokka's transitive kotlinx-html dependency is only published to their Space repo
+  // https://github.com/Kotlin/dokka/releases/tag/v1.4.32
   maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {
     name = "KotlinX HTML Maven"
     content {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,16 @@ repositories {
   google()
   gradlePluginPortal()
   mavenCentral()
+  maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {
+    name = "KotlinX HTML Maven"
+    content {
+      includeModule("org.jetbrains.kotlinx", "kotlinx-html")
+      includeModule("org.jetbrains.kotlinx", "kotlinx-html-assembly")
+      includeModule("org.jetbrains.kotlinx", "kotlinx-html-common")
+      includeModule("org.jetbrains.kotlinx", "kotlinx-html-js")
+      includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+    }
+  }
 }
 
 ktfmt {
@@ -37,9 +47,9 @@ gradlePlugin {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:4.1.3")
+  implementation("com.android.tools.build:gradle:4.2.0")
   implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0")
-  implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.30")
+  implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.32")
   implementation("de.undercouch:gradle-download-task:4.1.1")
   implementation("com.google.dagger:hilt-android-gradle-plugin:2.35.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 # Centralized versions for dependencies that share versions
 [versions]
-androidx_test = "1.4.0-alpha05"
+androidx_test = "1.4.0-alpha06"
 coroutines = "1.5.0-RC"
 hilt = "2.35.1"
 kotlin = "1.5.0"
@@ -8,9 +8,9 @@ lifecycle = "2.4.0-alpha01"
 
 [libraries]
 # buildSrc dependencies
-androidGradlePlugin = "com.android.tools.build:gradle:4.1.3"
+androidGradlePlugin = "com.android.tools.build:gradle:4.2.0"
 binaryCompatibilityValidator = "org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0"
-dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
+dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
 downloadTaskPlugin = "de.undercouch:gradle-download-task:4.1.1"
 hiltGradlePlugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -29,7 +29,7 @@ androidx-annotation = "androidx.annotation:annotation:1.1.0"
 androidx-autofill = "androidx.autofill:autofill:1.2.0-alpha01"
 androidx-appcompat = "androidx.appcompat:appcompat:1.3.0-rc01"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
-androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0-beta01"
+androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0-beta02"
 androidx-coreKtx = "androidx.core:core-ktx:1.6.0-alpha02"
 androidx-documentfile = "androidx.documentfile:documentfile:1.0.1"
 androidx-fragmentKtx = "androidx.fragment:fragment-ktx:1.3.3"
@@ -63,10 +63,10 @@ thirdparty-fastscroll = "me.zhanghai.android.fastscroll:library:1.1.5"
 thirdparty-jgit = "org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r"
 thirdparty-kotlinResult = "com.michael-bull.kotlin-result:kotlin-result:1.1.11"
 thirdparty-leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
-thirdparty-modernAndroidPrefs = "de.maxr1998:modernandroidpreferences:2.0"
+thirdparty-modernAndroidPrefs = "de.maxr1998:modernandroidpreferences:2.1.0"
 thirdparty-plumber = "com.squareup.leakcanary:plumber-android:2.7"
 thirdparty-sshj = "com.hierynomus:sshj:0.31.0"
-thirdparty-sshauth = "com.github.open-keychain.open-keychain:sshauthentication-api:v5.7.1"
+thirdparty-sshauth = "com.github.open-keychain.open-keychain:sshauthentication-api:5.7.5"
 thirdparty-timber = "com.jakewharton.timber:timber:4.7.1"
 thirdparty-timberkt = "com.github.ajalt:timberkt:1.5.1"
 thirdparty-whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.0"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

Performs the following dependency upgrades

- AGP: 4.1.3 -> 4.2.0
- Dokka: 1.4.30 -> 1.4.32
- AndroidX Test: 1.4.0-alpha05 -> 1.4.0-alpha06
- ConstraintLayout: 2.1.0-beta01 -> 2.1.0-beta02
- ModernAndroidPreferences: 2.0 -> 2.1.0
- sshauthentication-api: 5.7.1 -> 5.7.5
