### PR TITLE
Show current copy timeout in settings

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/settings/PasswordSettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/settings/PasswordSettings.kt
@@ -44,7 +44,8 @@ class PasswordSettings(private val activity: FragmentActivity) : SettingsProvide
       sharedPrefs.edit { putString(PreferenceKeys.PREF_KEY_CUSTOM_DICT, uri.toString()) }
 
       val inputStream = activity.contentResolver.openInputStream(uri)
-      val customDictFile = File(activity.filesDir.toString(), XkpwdDictionary.XKPWD_CUSTOM_DICT_FILE).outputStream()
+      val customDictFile =
+        File(activity.filesDir.toString(), XkpwdDictionary.XKPWD_CUSTOM_DICT_FILE).outputStream()
       inputStream?.copyTo(customDictFile, 1024)
       inputStream?.close()
       customDictFile.close()
@@ -100,7 +101,10 @@ class PasswordSettings(private val activity: FragmentActivity) : SettingsProvide
       addPreferenceItem(customDictPathPref)
       editText(PreferenceKeys.GENERAL_SHOW_TIME) {
         titleRes = R.string.pref_clipboard_timeout_title
-        summaryProvider = { activity.getString(R.string.pref_clipboard_timeout_summary) }
+        summaryProvider =
+          { timeout ->
+            activity.getString(R.string.pref_clipboard_timeout_summary, timeout ?: "45")
+          }
         textInputType = InputType.TYPE_CLASS_NUMBER
       }
       checkBox(PreferenceKeys.SHOW_PASSWORD) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Show copy timeout.

## :bulb: Motivation and Context
45 > %1s

## :green_heart: How did you test it?
:eyes: 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
