### PR TITLE
Upgrade Gradle and `androidx.annotation`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 dependencies {
   kapt(libs.dagger.hilt.compiler)
-  compileOnly(libs.androidx.annotation)
+  implementation(libs.androidx.annotation)
   coreLibraryDesugaring(libs.android.desugarJdkLibs)
   implementation(projects.autofillParser)
   implementation(projects.formatCommon)

--- a/autofill-parser/build.gradle.kts
+++ b/autofill-parser/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-  compileOnly(libs.androidx.annotation)
+  implementation(libs.androidx.annotation)
   implementation(libs.androidx.autofill)
   implementation(libs.kotlin.coroutines.android)
   implementation(libs.kotlin.coroutines.core)

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -21,9 +21,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  */
 internal fun Project.configureForRootProject() {
   tasks.withType<Wrapper> {
-    gradleVersion = "7.0"
+    gradleVersion = "7.0.1"
     distributionType = Wrapper.DistributionType.ALL
-    distributionSha256Sum = "81003f83b0056d20eedf48cddd4f52a9813163d4ba185bcf8abd34b8eeea4cbd"
+    distributionSha256Sum = "ca42877db3519b667cd531c414be517b294b0467059d401e7133f0e55b9bf265"
   }
   configureBinaryCompatibilityValidator()
 }

--- a/format-common/build.gradle.kts
+++ b/format-common/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-  compileOnly(libs.androidx.annotation)
+  implementation(libs.androidx.annotation)
   implementation(libs.dagger.hilt.core)
   implementation(libs.thirdparty.commons.codec)
   implementation(libs.thirdparty.kotlinResult)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 
 # AndroidX dependencies
 androidx-activityKtx = "androidx.activity:activity-ktx:1.3.0-alpha07"
-androidx-annotation = "androidx.annotation:annotation:1.1.0"
+androidx-annotation = "androidx.annotation:annotation:1.2.0"
 androidx-autofill = "androidx.autofill:autofill:1.2.0-alpha01"
 androidx-appcompat = "androidx.appcompat:appcompat:1.3.0-rc01"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=81003f83b0056d20eedf48cddd4f52a9813163d4ba185bcf8abd34b8eeea4cbd
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionSha256Sum=ca42877db3519b667cd531c414be517b294b0467059d401e7133f0e55b9bf265
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

Switches to Gradle 7.0.1 that ships important caching fixes and works around a dependency resolution quirk to bump androidx.annotation to 1.2.0

## :green_heart: How did you test it?

Builds succeed as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
