### PR TITLE
Offload some main thread disk reads to background thread

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/adapters/PasswordItemRecyclerAdapter.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/adapters/PasswordItemRecyclerAdapter.kt
@@ -17,12 +17,16 @@ import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.data.password.PasswordItem
 import dev.msfjarvis.aps.util.viewmodel.SearchableRepositoryAdapter
 import dev.msfjarvis.aps.util.viewmodel.stableId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-open class PasswordItemRecyclerAdapter :
+open class PasswordItemRecyclerAdapter(coroutineScope: CoroutineScope) :
   SearchableRepositoryAdapter<PasswordItemRecyclerAdapter.PasswordItemViewHolder>(
     R.layout.password_row_layout,
     ::PasswordItemViewHolder,
-    PasswordItemViewHolder::bind
+    coroutineScope,
+    PasswordItemViewHolder::bind,
   ) {
 
   fun makeSelectable(recyclerView: RecyclerView) {
@@ -48,7 +52,7 @@ open class PasswordItemRecyclerAdapter :
     private val folderIndicator: AppCompatImageView = itemView.findViewById(R.id.folder_indicator)
     lateinit var itemDetails: ItemDetailsLookup.ItemDetails<String>
 
-    fun bind(item: PasswordItem) {
+    suspend fun bind(item: PasswordItem) {
       val parentPath = item.fullPathToParent.replace("(^/)|(/$)".toRegex(), "")
       val source =
         if (parentPath.isNotEmpty()) {
@@ -62,7 +66,9 @@ open class PasswordItemRecyclerAdapter :
       if (item.type == PasswordItem.TYPE_CATEGORY) {
         folderIndicator.visibility = View.VISIBLE
         val count =
-          item.file.listFiles { path -> path.isDirectory || path.extension == "gpg" }?.size ?: 0
+          withContext(Dispatchers.IO) {
+            item.file.listFiles { path -> path.isDirectory || path.extension == "gpg" }?.size ?: 0
+          }
         childCount.visibility = if (count > 0) View.VISIBLE else View.GONE
         childCount.text = "$count"
       } else {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
@@ -22,6 +22,7 @@ import androidx.core.text.buildSpannedString
 import androidx.core.text.underline
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.ajalt.timberkt.e
 import com.github.androidpasswordstore.autofillparser.FormOrigin
@@ -132,8 +133,11 @@ class AutofillFilterView : AppCompatActivity() {
     with(binding) {
       rvPassword.apply {
         adapter =
-          SearchableRepositoryAdapter(R.layout.oreo_autofill_filter_row, ::PasswordViewHolder) {
-            item ->
+          SearchableRepositoryAdapter(
+              R.layout.oreo_autofill_filter_row,
+              ::PasswordViewHolder,
+              lifecycleScope,
+            ) { item ->
             val file = item.file.relativeTo(item.rootDir)
             val pathToIdentifier = directoryStructure.getPathToIdentifierFor(file)
             val identifier = directoryStructure.getIdentifierFor(file)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/folderselect/SelectFolderFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/folderselect/SelectFolderFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
@@ -36,7 +37,7 @@ class SelectFolderFragment : Fragment(R.layout.password_recycler_view) {
     super.onViewCreated(view, savedInstanceState)
     binding.fab.hide()
     recyclerAdapter =
-      PasswordItemRecyclerAdapter().onItemClicked { _, item ->
+      PasswordItemRecyclerAdapter(lifecycleScope).onItemClicked { _, item ->
         listener.onFragmentInteraction(item)
       }
     binding.passRecycler.apply {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordFragment.kt
@@ -133,7 +133,7 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     }
 
     recyclerAdapter =
-      PasswordItemRecyclerAdapter()
+      PasswordItemRecyclerAdapter(lifecycleScope)
         .onItemClicked { _, item -> listener.onFragmentInteraction(item) }
         .onSelectionChanged { selection ->
           // In order to not interfere with drag selection, we disable the


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Refactors `PasswordItemRecyclerAdapter` to run FS operations on `Dispatchers.IO`.

## :bulb: Motivation and Context

Since enable StrictMode in #1391 I have observed that the two major violations of main thread FS access were `PasswordItemRecyclerAdapter` and `PasswordRepository`. The latter needs to be removed completely in the future, so this PR addresses the issues in just the adapter.

## :green_heart: How did you test it?

Verified I no longer log StrictMode violations for `PasswordItemRecyclerAdapter` on app launch.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Refactor out uses of PasswordRepository and move the actually useful parts to an `@Inject`-able class with a more defined state and clear cut responsibilities.
