### PR TITLE
Tweak git server config screen UI and remove unused resources

### DIFF
--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -91,21 +91,18 @@
 
       <com.google.android.material.chip.Chip
         android:id="@+id/auth_mode_ssh_key"
-        style="@style/AppTheme.Chip.Choice"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/connection_mode_ssh_key" />
 
       <com.google.android.material.chip.Chip
         android:id="@+id/auth_mode_password"
-        style="@style/AppTheme.Chip.Choice"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/connection_mode_basic_authentication" />
 
       <com.google.android.material.chip.Chip
         android:id="@+id/auth_mode_open_keychain"
-        style="@style/AppTheme.Chip.Choice"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/connection_mode_openkeychain" />

--- a/app/src/main/res/layout/activity_git_clone.xml
+++ b/app/src/main/res/layout/activity_git_clone.xml
@@ -17,27 +17,15 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.appcompat.widget.AppCompatTextView
-      android:id="@+id/server_label"
-      style="@style/TextAppearance.MaterialComponents.Headline5"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_margin="8dp"
-      android:text="@string/server_name"
-      android:textSize="24sp"
-      android:textStyle="bold"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
     <com.google.android.material.textfield.TextInputLayout
       android:id="@+id/label_server_url"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:layout_margin="8dp"
+      android:layout_marginTop="8dp"
       android:hint="@string/server_url"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/server_label">
+      app:layout_constraintTop_toTopOf="parent">
 
       <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/server_url"
@@ -53,7 +41,7 @@
       android:id="@+id/label_server_branch"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:layout_margin="8dp"
+      android:layout_marginTop="8dp"
       android:hint="@string/server_branch"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
@@ -73,7 +61,6 @@
       style="@style/TextAppearance.MaterialComponents.Headline6"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_margin="8dp"
       android:layout_marginTop="16dp"
       android:layout_marginBottom="16dp"
       android:text="@string/connection_mode"
@@ -84,7 +71,6 @@
       android:id="@+id/auth_mode_group"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_margin="8dp"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@id/label_auth_mode"
       app:singleSelection="true">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -41,7 +41,6 @@
   <string name="clipboard_password_toast_text">Passwort ist in der Zwischenablage, du hast %d Sekunden, um es einzufügen.</string>
   <string name="clipboard_password_no_clear_toast_text">Passwort wurde in die Zwischenablage kopiert</string>
   <string name="clipboard_copied_text">In die Zwischenablage kopiert</string>
-  <string name="clipboard_otp_copied_text">OTP-Code in die Zwischenablage kopiert</string>
   <string name="file_toast_text">Bitte setze einen Pfad</string>
   <string name="path_toast_text">Bitte setze einen Pfad</string>
   <string name="empty_toast_text">Du kannst kein leeres Passwort setzen oder leere Extra-Angaben</string>
@@ -61,7 +60,6 @@
   <string name="location_hidden">Versteckt (bevorzugt)</string>
   <string name="external_repository_dialog_title">Wählen Sie, wo die Passwörter gespeichert werden sollen</string>
   <string name="external_repository_dialog_text">Sie müssen ein Verzeichnis auswählen, in dem Ihre Passwörter gespeichert werden sollen. Wenn Sie Ihre Passwörter innerhalb des versteckten Speichers der Anwendung speichern möchten, brechen Sie diesen Dialog ab und deaktivieren Sie die Option \"Externe Repository\".</string>
-  <string name="server_name">Server</string>
   <string name="server_url">Repository-URL</string>
   <string name="server_branch">Branch</string>
   <string name="connection_mode">Authentifizierungsmethode</string>
@@ -81,13 +79,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Suche</string>
   <string name="password">Passwort:</string>
-  <string name="otp">OTP:</string>
-  <string name="extra_content">Weiterer Inhalt:</string>
   <string name="username">Benutzername:</string>
   <string name="edit_password">Passwort bearbeiten</string>
   <string name="copy_password">Passwort kopieren</string>
   <string name="share_as_plaintext">Als Klartext teilen</string>
-  <string name="last_changed">Zuletzt geändert %s</string>
   <!-- Preferences -->
   <string name="pref_edit_git_server_settings">Git-Server Einstellungen</string>
   <string name="pref_edit_git_config">Lokale Git Konfiguration &amp; Dienstprogramme</string>
@@ -185,8 +180,6 @@
   <string name="git_log">Commit-Log anzeigen</string>
   <string name="show_password_pref_title">Zeige das Password</string>
   <string name="show_password_pref_summary">Soll das entschlüsselte Passwort sichtbar sein? Dies deaktiviert nicht das Kopieren.</string>
-  <string name="show_extra_content_pref_title">Zeige weiteren Inhalt</string>
-  <string name="show_extra_content_pref_summary">Soll weiterer Inhalt sichtbar sein?</string>
   <string name="pwd_generate_button">Generieren</string>
   <string name="refresh_list">Aktualisieren</string>
   <string name="send_plaintext_password_to">Passwort unverschlüsselt senden an…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -45,7 +45,6 @@
   <string name="clipboard_password_toast_text">Mot de passe copié dans le presse papier, vous avez %d secondes pour coller celui-ci.</string>
   <string name="clipboard_password_no_clear_toast_text">Mot de passe copié dans le presse-papiers</string>
   <string name="clipboard_copied_text">Copié dans le presse-papiers</string>
-  <string name="clipboard_otp_copied_text">Code OTP copié dans le presse-papiers</string>
   <string name="file_toast_text">Veuillez fournir un nom de fichier</string>
   <string name="path_toast_text">Veuillez fournir un chemin d\'accès au fichier</string>
   <string name="empty_toast_text">Vous ne pouvez pas utiliser un mot de passe vide ou des données supplémentaires vide</string>
@@ -65,7 +64,6 @@
   <string name="location_hidden">Caché (Recommandé)</string>
   <string name="external_repository_dialog_title">Choisissez où sauvegarder les mots de passe</string>
   <string name="external_repository_dialog_text">Vous devez sélectionner un répertoire où sauvegarder vos mots de passe. Si vous souhaitez sauvegarder vos mots de passe dans la mémoire cachée de l\'application, annulez cette boîte de dialogue et désactivez l\'option \"Répertoire externe\".</string>
-  <string name="server_name">Serveur</string>
   <string name="server_url">URL du dépôt</string>
   <string name="server_branch">Branche</string>
   <string name="connection_mode">Méthode d\'authentification</string>
@@ -85,13 +83,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Chercher</string>
   <string name="password">Mot de passe</string>
-  <string name="otp">OTP</string>
-  <string name="extra_content">Contenu supplémentaire</string>
   <string name="username">Nom d\'utilisateur</string>
   <string name="edit_password">Éditer le mot de passe</string>
   <string name="copy_password">Copier le mot de passe</string>
   <string name="share_as_plaintext">Partager en clair</string>
-  <string name="last_changed">Dernière modification le %s</string>
   <!-- Preferences -->
   <string name="pref_category_repository_title">Dépôt</string>
   <string name="pref_edit_git_server_settings">Modifier les paramètres du serveur Git</string>
@@ -195,8 +190,6 @@
   <string name="git_log">Afficher l\'historique des commits</string>
   <string name="show_password_pref_title">Montrer le mot de passe</string>
   <string name="show_password_pref_summary">Contrôle la visibilité des mots de passe une fois déchifrées, ceci n\'empêche pas de copier le mot de passe</string>
-  <string name="show_extra_content_pref_title">Afficher le contenu supplémentaire</string>
-  <string name="show_extra_content_pref_summary">Controller la visibilité du contenu supplémentaire une fois déchiffré</string>
   <string name="pwd_generate_button">Générer</string>
   <string name="refresh_list">Rafraichir la liste</string>
   <string name="send_plaintext_password_to">Envoyer le mot de passe en clair via…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -45,7 +45,6 @@
   <string name="clipboard_password_toast_text">Contrasinal copiado ao portapapeis, tes %d segundos para pegala nalgures.</string>
   <string name="clipboard_password_no_clear_toast_text">Contrasinal copiado ao portapapeis</string>
   <string name="clipboard_copied_text">Copiada ó portapapeis</string>
-  <string name="clipboard_otp_copied_text">Código OTP copiado ó portapapeis</string>
   <string name="file_toast_text">Debes proporcionar un nome de ficheiro</string>
   <string name="path_toast_text">Por favor indica a ruta ao ficheiro</string>
   <string name="empty_toast_text">Non podes deixar baleiro o contrasinal ou o contido extra</string>
@@ -65,7 +64,6 @@
   <string name="location_hidden">Agochado (preferible)</string>
   <string name="external_repository_dialog_title">Escolle onde gardar os contrasinais</string>
   <string name="external_repository_dialog_text">Tes que escoller un directorio para gardar os contrasinais. Se queres gardalos dentro do directorio oculto da aplicación, cancela este diálogo e desactiva a opción \"Repositorio Externo\".</string>
-  <string name="server_name">Servidor</string>
   <string name="server_url">URL do servidor</string>
   <string name="server_branch">Póla</string>
   <string name="connection_mode">Modo de autenticación</string>
@@ -85,13 +83,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Buscar</string>
   <string name="password">Contrasinal</string>
-  <string name="otp">OTP</string>
-  <string name="extra_content">Contido extra:</string>
   <string name="username">Nome de usuaria</string>
   <string name="edit_password">Editar contrasinal</string>
   <string name="copy_password">Copiar contrasinal</string>
   <string name="share_as_plaintext">Compartir como texto plano</string>
-  <string name="last_changed">Último cambio %s</string>
   <!-- Preferences -->
   <string name="pref_category_repository_title">Repositorio</string>
   <string name="pref_edit_git_server_settings">Editar axustes do servidor git</string>
@@ -195,8 +190,6 @@
   <string name="git_log">Mostrar rexistro dos cambios</string>
   <string name="show_password_pref_title">Mostrar contrasinal</string>
   <string name="show_password_pref_summary">Controlar a visibilidade do contrasinal unha vez descifrado, esto non desactiva o copiado do contrasinal</string>
-  <string name="show_extra_content_pref_title">Mostrar contido extra</string>
-  <string name="show_extra_content_pref_summary">Controla a visibilidade do contido extra unha vez descifrado</string>
   <string name="pwd_generate_button">Crear</string>
   <string name="refresh_list">Actualizar lista</string>
   <string name="send_plaintext_password_to">Enviar contrasinal como texto plano usando...</string>

--- a/app/src/main/res/values-hdpi/dimens.xml
+++ b/app/src/main/res/values-hdpi/dimens.xml
@@ -4,7 +4,6 @@
   -->
 
 <resources>
-  <dimen name="toggle_group_text_size">12sp</dimen>
   <dimen name="onboarding_icon_margin_top">50dp</dimen>
   <dimen name="onboarding_button_margin_top">70dp</dimen>
   <dimen name="onboarding_desc_margin_top">48dp</dimen>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -45,7 +45,6 @@
   <string name="clipboard_password_toast_text">Password copiata negli appunti, hai %d secondi per incollarla da qualche parte.</string>
   <string name="clipboard_password_no_clear_toast_text">Password copiata negli appunti</string>
   <string name="clipboard_copied_text">Copiato negli appunti</string>
-  <string name="clipboard_otp_copied_text">Codice OTP copiato negli appunti</string>
   <string name="file_toast_text">Sei pregato di fornire il nome di un file</string>
   <string name="path_toast_text">Sei pregato di fornire il percorso di un file</string>
   <string name="empty_toast_text">Non puoi usare una password vuota o dei contenuti extra vuoti</string>
@@ -65,7 +64,6 @@
   <string name="location_hidden">Nascosto (Preferito)</string>
   <string name="external_repository_dialog_title">Scegli dove memorizzare le password</string>
   <string name="external_repository_dialog_text">Devi selezionare una directory in cui memorizzare le tue password. Se vuoi memorizzare le tue password entro l\'archiviazione nascosta dell\'applicazione, annulla questa finestra di dialogo e disabilita l\'opzione \"Repository Esterna\".</string>
-  <string name="server_name">Server</string>
   <string name="server_url">URL della repository</string>
   <string name="server_branch">Ramo</string>
   <string name="connection_mode">Modalità di Autenticazione</string>
@@ -85,13 +83,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Cerca</string>
   <string name="password">Password</string>
-  <string name="otp">OTP</string>
-  <string name="extra_content">Contenuto extra:</string>
   <string name="username">Nome Utente</string>
   <string name="edit_password">Modifica password</string>
   <string name="copy_password">Copia password</string>
   <string name="share_as_plaintext">Condividi come testo semplice</string>
-  <string name="last_changed">Ultima modifica %s</string>
   <!-- Preferences -->
   <string name="pref_edit_git_server_settings">Modifica impostazioni del server di Git</string>
   <string name="pref_edit_git_config">Configurazione &amp; utilità della configurazione di Git</string>
@@ -189,8 +184,6 @@
   <string name="git_log">Mostra registro di conferma</string>
   <string name="show_password_pref_title">Mostra la password</string>
   <string name="show_password_pref_summary">Controlla la visibilità delle password una volta decrittografate. Questo non disabilita la copia negli appunti.</string>
-  <string name="show_extra_content_pref_title">Mostra contenuti extra</string>
-  <string name="show_extra_content_pref_summary">Controlla la visibilità del contenuto extra una volta decrittografato.</string>
   <string name="pwd_generate_button">Genera</string>
   <string name="refresh_list">Aggiorna elenco</string>
   <string name="send_plaintext_password_to">Invia password come testo semplice usando…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,7 +45,6 @@
   <string name="clipboard_password_toast_text">Senha copiada para área de transferência, você tem %d segundos para colá-la em algum lugar.</string>
   <string name="clipboard_password_no_clear_toast_text">Senha copiada para área de transferência</string>
   <string name="clipboard_copied_text">Copiado para a área de transferência</string>
-  <string name="clipboard_otp_copied_text">Código OTP copiado para a área de transferência</string>
   <string name="file_toast_text">Por favor, informe um nome de arquivo</string>
   <string name="path_toast_text">Por favor, forneça o caminho do arquivo</string>
   <string name="empty_toast_text">Você não pode usar uma senha vazia ou conteúdo extra vazio</string>
@@ -65,7 +64,6 @@
   <string name="location_hidden">Oculto (preferencial)</string>
   <string name="external_repository_dialog_title">Escolha onde armazenar as senhas</string>
   <string name="external_repository_dialog_text">Você deve selecionar um diretório onde armazenar suas senhas. Se você deseja armazenar suas senhas dentro do armazenamento oculto do aplicativo, cancele esta caixa de diálogo e desative a opção \"Repositório Externo\".</string>
-  <string name="server_name">Servidor</string>
   <string name="server_url">URL do repositório</string>
   <string name="server_branch">Branch</string>
   <string name="connection_mode">Modo de autenticação</string>
@@ -85,13 +83,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Pesquisar</string>
   <string name="password">Senha:</string>
-  <string name="otp">OTP:</string>
-  <string name="extra_content">Conteúdo extra:</string>
   <string name="username">Usuário:</string>
   <string name="edit_password">Editar senha</string>
   <string name="copy_password">Copiar senha</string>
   <string name="share_as_plaintext">Compartilhar como texto</string>
-  <string name="last_changed">Última alteração %s</string>
   <!-- Preferences -->
   <string name="pref_category_repository_title">Repositório</string>
   <string name="pref_edit_git_server_settings">Editar configurações do servidor Git</string>
@@ -195,8 +190,6 @@
   <string name="git_log">Mostrar log de commit</string>
   <string name="show_password_pref_title">Mostrar a senha</string>
   <string name="show_password_pref_summary">Controle a visibilidade das senhas quando descriptografadas. Isso não desativa a cópia para a área de transferência.</string>
-  <string name="show_extra_content_pref_title">Exibir conteúdo extra</string>
-  <string name="show_extra_content_pref_summary">Controlar a visibilidade do conteúdo extra uma vez descriptografado.</string>
   <string name="pwd_generate_button">Gerar</string>
   <string name="refresh_list">Atualizar lista</string>
   <string name="send_plaintext_password_to">Enviar senha como texto simples usando…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -49,7 +49,6 @@
   <string name="clipboard_password_toast_text">Пароль скопирован в буфер обмена, у вас есть %d секунд чтобы вставить его.</string>
   <string name="clipboard_password_no_clear_toast_text">Пароль скопирован в буфер обмена</string>
   <string name="clipboard_copied_text">Скопировано в буфер обмена</string>
-  <string name="clipboard_otp_copied_text">OTP код скопирован в буфер обмена</string>
   <string name="file_toast_text">Пожалуйста, укажите имя файла</string>
   <string name="path_toast_text">Пожалуйста, задайте путь к файлу</string>
   <string name="empty_toast_text">Вы не можете использовать пустой пароль или пустое поле информации</string>
@@ -69,7 +68,6 @@
   <string name="location_hidden">Скрытый (Предпочтительно)</string>
   <string name="external_repository_dialog_title">Выберете где хранить пароли</string>
   <string name="external_repository_dialog_text">Вы должны выбрать директорию где хранить пароли. Если вы хотите хранить пароли в скрытом хранилище приложения, тогда отмените этот диалог и отключите настройку \"Внешний репозиторий\".</string>
-  <string name="server_name">Сервер</string>
   <string name="server_url">URL репозитория</string>
   <string name="server_branch">Ветка</string>
   <string name="connection_mode">Тип авторизации</string>
@@ -89,13 +87,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Поиск</string>
   <string name="password">Пароль:</string>
-  <string name="otp">OTP:</string>
-  <string name="extra_content">Дополнительная информация:</string>
   <string name="username">Имя пользователя:</string>
   <string name="edit_password">Редактировать пароль</string>
   <string name="copy_password">Скопировать пароль</string>
   <string name="share_as_plaintext">Поделиться в открытом виде</string>
-  <string name="last_changed">Последние изменение %s</string>
   <!-- Preferences -->
   <string name="pref_category_repository_title">Репозиторий</string>
   <string name="pref_edit_git_server_settings">Изменить настройки сервера Git</string>
@@ -194,8 +189,6 @@
   <string name="git_log">Показать журнал изменений</string>
   <string name="show_password_pref_title">Показывать пароли</string>
   <string name="show_password_pref_summary">Видимость расшифрованных паролей, не влияет на копирование в буфер.</string>
-  <string name="show_extra_content_pref_title">Показать дополнительную информацию</string>
-  <string name="show_extra_content_pref_summary">Видимость поля дополнительной информации после расшифрования</string>
   <string name="pwd_generate_button">Сгенерировать</string>
   <string name="refresh_list">Обновить список</string>
   <string name="send_plaintext_password_to">Поделиться паролем в открытом виде с помощью</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,7 +10,6 @@
   <dimen name="fab_compat_margin">16dp</dimen>
   <dimen name="normal_margin">8dp</dimen>
   <dimen name="bottom_sheet_item_height">56dp</dimen>
-  <dimen name="toggle_group_text_size">14sp</dimen>
   <dimen name="onboarding_icon_margin_top">100dp</dimen>
   <dimen name="onboarding_button_margin_top">140dp</dimen>
   <dimen name="onboarding_desc_margin_top">48dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,6 @@
   <string name="clipboard_password_toast_text">Password copied to clipboard, you have %d seconds to paste it somewhere.</string>
   <string name="clipboard_password_no_clear_toast_text">Password copied to clipboard</string>
   <string name="clipboard_copied_text">Copied to clipboard</string>
-  <string name="clipboard_otp_copied_text">OTP code copied to clipboard</string>
   <string name="file_toast_text">Please provide a file name</string>
   <string name="path_toast_text">Please provide a file path</string>
   <string name="empty_toast_text">You cannot use an empty password or empty extra content</string>
@@ -77,7 +76,6 @@
   <string name="external_repository_dialog_title">Choose where to store the passwords</string>
   <string name="external_repository_dialog_text">You must select a directory where to store your passwords. If you want to store your passwords within the hidden storage of the application, cancel this dialog and disable the \"External Repository\" option.</string>
 
-  <string name="server_name">Server</string>
   <string name="server_url">Repository URL</string>
   <string name="server_branch">Branch</string>
 
@@ -101,13 +99,10 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Search</string>
   <string name="password">Password</string>
-  <string name="otp">OTP</string>
-  <string name="extra_content">Extra content:</string>
   <string name="username">Username</string>
   <string name="edit_password">Edit password</string>
   <string name="copy_password">Copy password</string>
   <string name="share_as_plaintext">Share as plaintext</string>
-  <string name="last_changed">Last changed %s</string>
 
   <!-- Preferences -->
   <string name="pref_category_repository_title">Repository</string>
@@ -219,8 +214,6 @@
   <string name="git_log">Show commit log</string>
   <string name="show_password_pref_title">Show the password</string>
   <string name="show_password_pref_summary">Control the visibility of the passwords once decrypted. This does not disable copying to clipboard.</string>
-  <string name="show_extra_content_pref_title">Show extra content</string>
-  <string name="show_extra_content_pref_summary">Control the visibility of the extra content once decrypted.</string>
   <string name="pwd_generate_button">Generate</string>
   <string name="refresh_list">Refresh list</string>
   <string name="send_plaintext_password_to">Send password as plaintext using…</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -39,7 +39,7 @@
     <item name="chipSurfaceColor">@color/chip_surface_color</item>
     <item name="android:textColor">@color/chip_text_color</item>
     <item name="shapeAppearanceOverlay">@style/ShapeAppearance.AppTheme.SmallComponent</item>
-    <item name="textAppearanceBody2">@style/TextAppearance.AppTheme.Body2</item>
+    <item name="android:textAppearance">?attr/textAppearanceButton</item>
   </style>
 
   <style name="TextAppearance.AppTheme.Body2" parent="TextAppearance.MaterialComponents.Body2">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -42,10 +42,6 @@
     <item name="android:textAppearance">?attr/textAppearanceButton</item>
   </style>
 
-  <style name="TextAppearance.AppTheme.Body2" parent="TextAppearance.MaterialComponents.Body2">
-    <item name="android:textStyle">bold</item>
-  </style>
-
   <style name="ShapeAppearance.AppTheme.SmallComponent" parent="ShapeAppearance.MaterialComponents.SmallComponent">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">8dp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -28,6 +28,7 @@
     <item name="materialButtonOutlinedStyle">@style/AppTheme.OutlinedButton</item>
     <item name="bottomSheetDialogTheme">@style/BottomSheetDialogTheme</item>
     <item name="textInputStyle">@style/AppTheme.TextInputLayout</item>
+    <item name="chipStyle">@style/AppTheme.Chip.Choice</item>
   </style>
 
   <style name="AppTheme" parent="APSTheme" />


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Tweaks Chips to use a bolder typography that matches buttons, tweaks some padding in the server config screen, and removes resources that are now unused.


## :bulb: Motivation and Context

The slightly off alignment and extremely thin typography made for a rather terrible looking screen.

## :green_heart: How did you test it?

Visual change.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :camera_flash: Screenshots / GIFs

<details>
<summary>Before</summary>

![screenshot-20210523-133222](https://user-images.githubusercontent.com/13348378/119253188-b25c1100-bbcd-11eb-8db7-9aa71639396b.png)

</details>

<details>
<summary>After</summary>

![screenshot-20210523-133350](https://user-images.githubusercontent.com/13348378/119253193-bab44c00-bbcd-11eb-8707-372c97927eac.png)

</details>
