### PR TITLE
Fix decryption-related regressions

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -138,10 +138,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
     intent.putExtra("REPO_PATH", repoPath)
     intent.putExtra(PasswordCreationActivity.EXTRA_FILE_NAME, name)
     intent.putExtra(PasswordCreationActivity.EXTRA_PASSWORD, passwordEntry?.password)
-    intent.putExtra(
-      PasswordCreationActivity.EXTRA_EXTRA_CONTENT,
-      passwordEntry?.extraContentWithoutAuthData
-    )
+    intent.putExtra(PasswordCreationActivity.EXTRA_EXTRA_CONTENT, passwordEntry?.extraContentString)
     intent.putExtra(PasswordCreationActivity.EXTRA_EDITING, true)
     startActivity(intent)
     finish()

--- a/format-common/api/format-common.api
+++ b/format-common/api/format-common.api
@@ -2,6 +2,7 @@ public final class dev/msfjarvis/aps/data/passfile/PasswordEntry {
 	public static final field Companion Ldev/msfjarvis/aps/data/passfile/PasswordEntry$Companion;
 	public fun <init> (Ldev/msfjarvis/aps/util/time/UserClock;Ldev/msfjarvis/aps/util/totp/TotpFinder;Lkotlinx/coroutines/CoroutineScope;[B)V
 	public final fun getExtraContent ()Ljava/util/Map;
+	public final fun getExtraContentString ()Ljava/lang/String;
 	public final fun getExtraContentWithoutAuthData ()Ljava/lang/String;
 	public final fun getPassword ()Ljava/lang/String;
 	public final fun getTotp ()Lkotlinx/coroutines/flow/StateFlow;

--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -5,7 +5,6 @@
 
 package dev.msfjarvis.aps.data.passfile
 
-import androidx.annotation.VisibleForTesting
 import com.github.michaelbull.result.mapBoth
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -52,6 +51,12 @@ constructor(
   public val extraContent: Map<String, String>
 
   /**
+   * Direct [String] representation of the extra content of this entry, before any transforms are
+   * applied. Only use this when the extra content is required in a formatting-preserving manner.
+   */
+  public val extraContentString: String
+
+  /**
    * A [StateFlow] providing the current TOTP. It will emit a single empty string on initialization
    * which is replaced with a real TOTP if applicable. Call [hasTotp] to verify whether or not you
    * need to observe this value.
@@ -67,7 +72,6 @@ constructor(
   private val totpSecret: String?
   private val totpPeriod: Long
   private val totpAlgorithm: String
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal val extraContentString: String
 
   init {
     val (foundPassword, passContent) = findAndStripPassword(content.split("\n".toRegex()))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 androidx-activityKtx = "androidx.activity:activity-ktx:1.3.0-alpha08"
 androidx-annotation = "androidx.annotation:annotation:1.2.0"
 androidx-autofill = "androidx.autofill:autofill:1.2.0-alpha01"
-androidx-appcompat = "androidx.appcompat:appcompat:1.4.0-alpha01"
+androidx-appcompat = "androidx.appcompat:appcompat:1.3.0"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0-beta02"
 androidx-coreKtx = "androidx.core:core-ktx:1.6.0-beta01"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Downgrades AppCompat to the stable 1.3.0 release, and fixes the edit action in `DecryptActivity` to correctly show extra content.

## :bulb: Motivation and Context

Fixes a crash in `DecryptActivity` that originates within AndroidX, specifically [here] (Will file an issue once I have a reproducer).

Slightly changes the `format-common` API to allow passing in the unmodified extra content when editing an entry.

## :green_heart: How did you test it?

Verified `DecryptActivity` no longer crashes and editing a password entry with just auth data in the extra content does not result in an empty extra content field in the edit screen.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

[here]: https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:emoji/core/src/main/java/androidx/emoji/widget/EmojiEditTextHelper.java;l=128;drc=237c8946756af4b0fe9d0fa3965593e247d53698
