### PR TITLE
Fix 'View generated SSH key' option showing when not applicable

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/settings/RepositorySettings.kt
@@ -38,6 +38,7 @@ import dev.msfjarvis.aps.util.extensions.getString
 import dev.msfjarvis.aps.util.extensions.sharedPrefs
 import dev.msfjarvis.aps.util.extensions.snackbar
 import dev.msfjarvis.aps.util.extensions.unsafeLazy
+import dev.msfjarvis.aps.util.git.sshj.SshKey
 import dev.msfjarvis.aps.util.settings.GitSettings
 import dev.msfjarvis.aps.util.settings.PreferenceKeys
 
@@ -117,7 +118,7 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       }
       pref(PreferenceKeys.SSH_SEE_KEY) {
         titleRes = R.string.pref_ssh_see_key_title
-        visible = PasswordRepository.isGitRepo()
+        visible = PasswordRepository.isGitRepo() && SshKey.canShowSshPublicKey
         onClick {
           ShowSshKeyFragment().show(activity.supportFragmentManager, "public_key")
           true

--- a/app/src/main/java/dev/msfjarvis/aps/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/settings/RepositorySettings.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.ShortcutManager
 import android.os.Build
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
@@ -44,12 +45,19 @@ import dev.msfjarvis.aps.util.settings.PreferenceKeys
 
 class RepositorySettings(private val activity: FragmentActivity) : SettingsProvider {
 
+  private val generateSshKey =
+    activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      showSshKeyPref?.visible = SshKey.canShowSshPublicKey
+    }
+
   private val hiltEntryPoint by unsafeLazy {
     EntryPointAccessors.fromApplication(
       activity.applicationContext,
       RepositorySettingsEntryPoint::class.java,
     )
   }
+
+  private var showSshKeyPref: Preference? = null
 
   private fun <T : FragmentActivity> launchActivity(clazz: Class<T>) {
     activity.startActivity(Intent(activity, clazz))
@@ -112,18 +120,19 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       pref(PreferenceKeys.SSH_KEYGEN) {
         titleRes = R.string.pref_ssh_keygen_title
         onClick {
-          launchActivity(SshKeyGenActivity::class.java)
+          generateSshKey.launch(Intent(activity, SshKeyGenActivity::class.java))
           true
         }
       }
-      pref(PreferenceKeys.SSH_SEE_KEY) {
-        titleRes = R.string.pref_ssh_see_key_title
-        visible = PasswordRepository.isGitRepo() && SshKey.canShowSshPublicKey
-        onClick {
-          ShowSshKeyFragment().show(activity.supportFragmentManager, "public_key")
-          true
+      showSshKeyPref =
+        pref(PreferenceKeys.SSH_SEE_KEY) {
+          titleRes = R.string.pref_ssh_see_key_title
+          visible = PasswordRepository.isGitRepo() && SshKey.canShowSshPublicKey
+          onClick {
+            ShowSshKeyFragment().show(activity.supportFragmentManager, "public_key")
+            true
+          }
         }
-      }
       pref(PreferenceKeys.CLEAR_SAVED_PASS) {
         fun Preference.updatePref() {
           val sshPass = encryptedPreferences.getString(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/sshkeygen/SshKeyGenActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/sshkeygen/SshKeyGenActivity.kt
@@ -64,7 +64,10 @@ class SshKeyGenActivity : AppCompatActivity() {
             setPositiveButton(R.string.ssh_keygen_existing_replace) { _, _ ->
               lifecycleScope.launch { generate() }
             }
-            setNegativeButton(R.string.ssh_keygen_existing_keep) { _, _ -> finish() }
+            setNegativeButton(R.string.ssh_keygen_existing_keep) { _, _ ->
+              setResult(RESULT_CANCELED)
+              finish()
+            }
             show()
           }
         } else {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Fixes `RepositorySettings` to only show the 'View generated SSH key' when it is supposed to be, making the semantics match the previous settings UI.

## :bulb: Motivation and Context

Fixes a regression from the settings UI rewrite which essentially removed [this](https://github.com/Android-Password-Store/Android-Password-Store/commit/8bd156dea6e8#diff-c9fd249b3355cbcffdef5446acaa6355d42c799b504105ecd6775d9c2754af63L489) call.

## :green_heart: How did you test it?

Verified 'View generated SSH key' option does not show up with imported SSH keys.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
