### PR TITLE
Configure Spotless for all projects and tweak Dagger flags

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,4 @@ plugins {
   `aps-plugin`
 }
 
-allprojects { apply(plugin = "com.diffplug.spotless") }
+allprojects { configureSpotless() }

--- a/buildSrc/src/main/java/KaptConfigs.kt
+++ b/buildSrc/src/main/java/KaptConfigs.kt
@@ -1,0 +1,34 @@
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.plugin.KaptExtension
+
+/** Apply default kapt configs to the [Project]. */
+internal fun Project.configureKapt() {
+  extensions.configure<KaptExtension> {
+    javacOptions {
+      if (hasDaggerCompilerDependency) {
+        // https://dagger.dev/dev-guide/compiler-options#fastinit-mode
+        option("-Adagger.fastInit=enabled")
+        // Enable the better, experimental error messages
+        // https://github.com/google/dagger/commit/0d2505a727b54f47b8677f42dd4fc5c1924e37f5
+        option("-Adagger.experimentalDaggerErrorMessages=enabled")
+        // Share test components for when we start leveraging Hilt for tests
+        // https://github.com/google/dagger/releases/tag/dagger-2.34
+        option("-Adagger.hilt.shareTestComponents=true")
+        // KAPT nests errors causing real issues to be suppressed in CI logs
+        option("-Xmaxerrs", 500)
+        // Enables per-module validation for faster error detection
+        // https://github.com/google/dagger/commit/325b516ac6a53d3fc973d247b5231fafda9870a2
+        option("-Adagger.moduleBindingValidation=ERROR")
+      }
+    }
+  }
+  // disable kapt tasks for unit tests
+  tasks
+    .matching { it.name.startsWith("kapt") && it.name.endsWith("UnitTestKotlin") }
+    .configureEach { enabled = false }
+}
+
+private val Project.hasDaggerCompilerDependency: Boolean
+  get() =
+    configurations.any { it.dependencies.any { dependency -> dependency.name == "hilt-compiler" } }

--- a/buildSrc/src/main/java/PasswordStorePlugin.kt
+++ b/buildSrc/src/main/java/PasswordStorePlugin.kt
@@ -18,6 +18,7 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.internal.Kapt3GradleSubplugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -56,6 +57,9 @@ class PasswordStorePlugin : Plugin<Project> {
         }
         is KotlinPluginWrapper -> {
           project.configureExplicitApi()
+        }
+        is Kapt3GradleSubplugin -> {
+          project.configureKapt()
         }
       }
     }

--- a/buildSrc/src/main/java/PasswordStorePlugin.kt
+++ b/buildSrc/src/main/java/PasswordStorePlugin.kt
@@ -7,8 +7,6 @@ import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.plugins.AppPlugin
 import com.android.build.gradle.internal.plugins.LibraryPlugin
-import com.diffplug.gradle.spotless.SpotlessExtension
-import com.diffplug.gradle.spotless.SpotlessPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaLibraryPlugin
@@ -52,9 +50,6 @@ class PasswordStorePlugin : Plugin<Project> {
             .configureAndroidApplicationOptions(project)
           project.extensions.getByType<BaseAppModuleExtension>().configureBuildSigning(project)
           project.extensions.getByType<TestedExtension>().configureCommonAndroidOptions()
-        }
-        is SpotlessPlugin -> {
-          project.extensions.getByType<SpotlessExtension>().configureSpotless()
         }
         is SigningPlugin -> {
           project.extensions.getByType<SigningExtension>().configureBuildSigning()

--- a/buildSrc/src/main/java/Spotless.kt
+++ b/buildSrc/src/main/java/Spotless.kt
@@ -4,16 +4,28 @@
  */
 
 import com.diffplug.gradle.spotless.SpotlessExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
 
-internal fun SpotlessExtension.configureSpotless() {
-  kotlin {
-    ktfmt().googleStyle()
-    target("src/**/*.kt", "**/*.kts")
-  }
-  format("xml") {
-    target("**/*.xml")
-    trimTrailingWhitespace()
-    indentWithSpaces()
-    endWithNewline()
+fun Project.configureSpotless() {
+  apply(plugin = "com.diffplug.spotless")
+  configure<SpotlessExtension> {
+    kotlin {
+      ktfmt().googleStyle()
+      target("**/*.kt")
+      targetExclude("**/build/")
+    }
+    kotlinGradle {
+      ktfmt().googleStyle()
+      target("**/*.kts")
+    }
+    format("xml") {
+      target("**/*.xml")
+      targetExclude("**/build/", ".idea/")
+      trimTrailingWhitespace()
+      indentWithSpaces()
+      endWithNewline()
+    }
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Improves the Spotless setup to include `buildSrc` as well, and add a set of `javac` flags for the Dagger annotation processor to improve behavior.

The Dagger flags are documented in the `KaptConfigs.kt` file.

## :bulb: Motivation and Context

Before this change Spotless would not be able to format `buildSrc` sources, which is a downside for our otherwise reproducibly formatted codebase.

The Dagger changes help with application performance as well as build times and development feedback.

## :green_heart: How did you test it?

Verified app builds and runs as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

