### PR TITLE
Add Styx to supported Autofill browsers

### DIFF
--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 - Removed Bromite from supported Autofill browsers, since they [disable Android autofill](https://github.com/bromite/bromite/blob/master/FAQ.md#does-bromite-support-the-android-autofill-framework).
 
+- Added [Styx](https://github.com/jamal2362/Styx) to supported Autofill browsers.
+
 ### Fixed
 
 - Fix build warning from undeclared unsigned type use.

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -67,6 +67,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
         "u3uzHFc8RqHaf8XFKKas9DIQhFb+7FCBDH8zaU6z0tQ=",
         "8HB9AhwL8+b43MEbo/VwBCXVl9yjAaMeIQVWk067Gwo="
       ),
+    "com.jamal2367.styx" to arrayOf("Lph3oaG1C8WLhLiK5PVxOp5+6wTU9ipJSBYlD2bA3VI="),
     "com.microsoft.emmx" to arrayOf("AeGZlxCoLCdJtNUMRF3IXWcLYTYInQp2anOCfIKh6sk="),
     "com.opera.mini.native" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.mini.native.beta" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds [Styx](https://github.com/jamal2362/Styx) as a supported Autofill browser. In my brief testing, while it did not actively trigger an Autofill request, using the context menu on GitHub's login form made Autofill work correctly and the TOTP page was correctly seen as an autofill compatible field.

## :bulb: Motivation and Context

Requested in #1428

## :green_heart: How did you test it?

Described above.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Do more involved testing to determine other Autofill features this qualifies for.

