### PR TITLE
Rollback AppCompat upgrade

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,8 @@ androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx_activity" }
 androidx-annotation = "androidx.annotation:annotation:1.2.0"
 androidx-autofill = "androidx.autofill:autofill:1.2.0-alpha02"
-androidx-appcompat = "androidx.appcompat:appcompat:1.4.0-alpha02"
+# 1.4.x update blocked on https://issuetracker.google.com/issues/189559345
+androidx-appcompat = "androidx.appcompat:appcompat:1.3.0"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0-beta02"
 androidx-core-ktx = "androidx.core:core-ktx:1.6.0-beta02"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Rolls back AppCompat to 1.3.0 stable to fix a regression in 1.4.0 alphas. This bump was never supposed to go in, but I mishandled my local patchstack for #1430 and it slipped in.

## :bulb: Motivation and Context

We're facing [this bug](https://issuetracker.google.com/issues/189559345) which causes `DecryptActivity` to immediately crash when trying to display passwords.

## :green_heart: How did you test it?

Verified I can see my passwords again.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
