### PR TITLE
Remove LeakCanary from snapshot builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,7 +131,7 @@ dependencies {
   }
 
   debugImplementation(libs.thirdparty.leakcanary)
-  "nonFreeImplementation"(libs.thirdparty.nonfree.googlePlayAuthApiPhone)
+  add("nonFreeImplementation", libs.thirdparty.nonfree.googlePlayAuthApiPhone)
 
   androidTestImplementation(libs.bundles.testDependencies)
   androidTestImplementation(libs.bundles.androidTestDependencies)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -125,13 +125,12 @@ dependencies {
   implementation(libs.thirdparty.timberkt)
 
   if (isSnapshot()) {
-    implementation(libs.thirdparty.leakcanary)
     implementation(libs.thirdparty.whatthestack)
   } else {
-    debugImplementation(libs.thirdparty.leakcanary)
     debugImplementation(libs.thirdparty.whatthestack)
   }
 
+  debugImplementation(libs.thirdparty.leakcanary)
   "nonFreeImplementation"(libs.thirdparty.nonfree.googlePlayAuthApiPhone)
 
   androidTestImplementation(libs.bundles.testDependencies)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Makes LeakCanary a debug-only dependency and fixes up an instance of usage of Gradle `@Incubating` APIs.

## :bulb: Motivation and Context

LeakCanary is prohibitively spammy about `Service` leaks which is detrimental to user experience. In the nearly 16 months since we started shipping LeakCanary (ab5aebeda3388ec776c34130cf9039ae4f623562) we have not received any leak reports from users, which means we don't necessarily require it for public snapshots.

## :green_heart: How did you test it?

Verified snapshot builds no longer have LeakCanary bundled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
