### PR TITLE
Upgrade dependencies and temporarily disable Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
   `crowdin-plugin`
 }
 
+/*
 repositories {
   val composeSnapshot = libs.versions.composeSnapshot.get()
   if (composeSnapshot.length > 1) {
@@ -29,6 +30,7 @@ repositories {
     }
   }
 }
+*/
 
 configure<CrowdinExtension> { projectName = "android-password-store" }
 
@@ -47,7 +49,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
-  buildFeatures.compose = true
+  // buildFeatures.compose = true
 
   lintOptions {
     isAbortOnError = true
@@ -99,14 +101,14 @@ dependencies {
   implementation(libs.kotlin.coroutines.android)
   implementation(libs.kotlin.coroutines.core)
 
-  implementation(libs.androidx.activity.compose)
-  implementation(libs.androidx.hilt.compose)
-  implementation(libs.compose.foundation.core)
-  implementation(libs.compose.foundation.layout)
-  implementation(libs.compose.material)
-  implementation(libs.compose.ui.core)
-  implementation(libs.compose.ui.viewbinding)
-  compileOnly(libs.compose.ui.tooling)
+  // implementation(libs.androidx.activity.compose)
+  // implementation(libs.androidx.hilt.compose)
+  // implementation(libs.compose.foundation.core)
+  // implementation(libs.compose.foundation.layout)
+  // implementation(libs.compose.material)
+  // implementation(libs.compose.ui.core)
+  // implementation(libs.compose.ui.viewbinding)
+  // compileOnly(libs.compose.ui.tooling)
 
   implementation(libs.aps.sublimeFuzzy)
   implementation(libs.aps.zxingAndroidEmbedded)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -49,6 +49,6 @@ dependencies {
   implementation("com.vdurmont:semver4j:3.1.0")
   implementation("de.undercouch:gradle-download-task:4.1.1")
   implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.32")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
   implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.5.0")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 # Centralized versions for dependencies that share versions
 [versions]
-androidx_activity = "1.3.0-rc01"
+androidx_activity = "1.3.0-rc02"
 androidx_test = "1.4.0"
-compose = "1.0.0-rc01"
+compose = "1.0.0-rc02"
 composeSnapshot = "-"
-coroutines = "1.5.0"
+coroutines = "1.5.1"
 hilt = "2.37"
 kotlin = "1.5.21"
 lifecycle = "2.4.0-alpha02"
@@ -42,7 +42,7 @@ androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java
 androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref="lifecycle" }
 androidx-lifecycle-viewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref="lifecycle" }
 androidx-lifecycle-viewmodel-compose = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha05"
-androidx-material = "com.google.android.material:material:1.4.0"
+androidx-material = "com.google.android.material:material:1.5.0-alpha01"
 androidx-preference = "androidx.preference:preference:1.1.1"
 androidx-recyclerview = "androidx.recyclerview:recyclerview:1.2.1"
 androidx-recyclerviewSelection = "androidx.recyclerview:recyclerview-selection:1.2.0-alpha01"
@@ -90,13 +90,13 @@ thirdparty-sshj = "com.hierynomus:sshj:0.31.0"
 thirdparty-sshauth = "com.github.open-keychain.open-keychain:sshauthentication-api:5.7.5"
 thirdparty-timber = "com.jakewharton.timber:timber:4.7.1"
 thirdparty-timberkt = "com.github.ajalt:timberkt:1.5.1"
-thirdparty-whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.0"
+thirdparty-whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.1"
 thirdparty-nonfree-googlePlayAuthApiPhone = "com.google.android.gms:play-services-auth-api-phone:17.5.1"
 
 # Testing dependencies
 testing-junit = "junit:junit:4.13.2"
 testing-kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-testing-robolectric = "org.robolectric:robolectric:4.6"
+testing-robolectric = "org.robolectric:robolectric:4.6.1"
 testing-sharedPrefsMock = "com.github.IvanShafran:shared-preferences-mock:1.0"
 androidx-testing-rules = { module = "androidx.test:rules", version.ref="androidx_test" }
 androidx-testing-runner = { module = "androidx.test:runner", version.ref="androidx_test" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compose = "1.0.0-rc01"
 composeSnapshot = "-"
 coroutines = "1.5.0"
 hilt = "2.37"
-kotlin = "1.5.10"
+kotlin = "1.5.21"
 lifecycle = "2.4.0-alpha02"
 
 [libraries]


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

Updates Kotlin, Robolectric, Material and AndroidX dependencies. Disables Compose due to incompatibility with Kotlin 1.5.20+, and the fact that we're not actively using it as of now.

## :green_heart: How did you test it?

Ran unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
