### PR TITLE
Don't crash on null Autofill hints

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
@@ -115,7 +115,7 @@ internal class FormField(
         .toList()
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun isSupportedHint(hint: String) = hint in HINTS_FILLABLE
+    private fun isSupportedHint(hint: String?) = hint in HINTS_FILLABLE
     private val EXCLUDED_TERMS =
       listOf(
         "url_bar", // Chrome/Edge/Firefox address bar


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
For whatever reason, the Twitter app appears to set a `null` Autofill hint on its OTP field. Even though that is weird, it should not cause APS to crash.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1468.


## :green_heart: How did you test it?
Verified that I can fill an OTP into the Twitter app rather than having Autofill crash.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->
Decide whether this warrants a point release.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
