### PR TITLE
Correctly update MutableStateFlow values

### DIFF
--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /** Represents a single entry in the password store. */
@@ -192,7 +193,7 @@ constructor(
   ) {
     if (totpSecret != null) {
       Otp.calculateCode(totpSecret, millis / (1000 * totpPeriod), totpAlgorithm, digits, issuer)
-        .mapBoth({ code -> _totp.value = code }, { throwable -> throw throwable })
+        .mapBoth({ code -> _totp.update { code } }, { throwable -> throw throwable })
     }
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Changes `PasswordEntry._totp` accessors to correctly update it through the `update` function rather than raw access to the `value` field


## :bulb: Motivation and Context

Recommendations from [this](https://patrykkosieradzki.medium.com/make-sure-to-update-your-stateflow-safely-in-kotlin-9ad023db12ba) Medium post which made sense to me.

## :green_heart: How did you test it?

Verified TOTP still updates properly in UI and tests pass.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
