### PR TITLE
Upgrade Compose and other AndroidX libraries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
   `crowdin-plugin`
 }
 
-/*
 repositories {
   val composeSnapshot = libs.versions.composeSnapshot.get()
   if (composeSnapshot.length > 1) {
@@ -30,7 +29,6 @@ repositories {
     }
   }
 }
-*/
 
 configure<CrowdinExtension> { projectName = "android-password-store" }
 
@@ -49,7 +47,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
-  // buildFeatures.compose = true
+  buildFeatures.compose = true
 
   lintOptions {
     isAbortOnError = true
@@ -60,10 +58,10 @@ android {
     disable("CoroutineCreationDuringComposition")
   }
 
-  //  composeOptions {
-  //    kotlinCompilerVersion = libs.versions.kotlin.get()
-  //    kotlinCompilerExtensionVersion = libs.versions.compose.get()
-  //  }
+  composeOptions {
+    kotlinCompilerVersion = libs.versions.kotlin.get()
+    kotlinCompilerExtensionVersion = libs.versions.compose.get()
+  }
 }
 
 dependencies {
@@ -94,14 +92,14 @@ dependencies {
   implementation(libs.kotlin.coroutines.android)
   implementation(libs.kotlin.coroutines.core)
 
-  // implementation(libs.androidx.activity.compose)
-  // implementation(libs.androidx.hilt.compose)
-  // implementation(libs.compose.foundation.core)
-  // implementation(libs.compose.foundation.layout)
-  // implementation(libs.compose.material)
-  // implementation(libs.compose.ui.core)
-  // implementation(libs.compose.ui.viewbinding)
-  // compileOnly(libs.compose.ui.tooling)
+  implementation(libs.androidx.activity.compose)
+  implementation(libs.androidx.hilt.compose)
+  implementation(libs.compose.foundation.core)
+  implementation(libs.compose.foundation.layout)
+  implementation(libs.compose.material)
+  implementation(libs.compose.ui.core)
+  implementation(libs.compose.ui.viewbinding)
+  compileOnly(libs.compose.ui.tooling)
 
   implementation(libs.aps.sublimeFuzzy)
   implementation(libs.aps.zxingAndroidEmbedded)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,10 +56,7 @@ android {
     disable("CoroutineCreationDuringComposition")
   }
 
-  composeOptions {
-    kotlinCompilerVersion = libs.versions.kotlin.get()
-    kotlinCompilerExtensionVersion = libs.versions.compose.get()
-  }
+  composeOptions { kotlinCompilerExtensionVersion = libs.versions.compose.get() }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,8 +53,6 @@ android {
     isAbortOnError = true
     isCheckReleaseBuilds = false
     disable("MissingTranslation", "PluralsCandidate", "ImpliedQuantity")
-    // https://issuetracker.google.com/issues/187524311
-    disable("DialogFragmentCallbacksDetector")
     disable("CoroutineCreationDuringComposition")
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 # Centralized versions for dependencies that share versions
 [versions]
-androidx_activity = "1.3.0-rc02"
+androidx_activity = "1.3.1"
 androidx_test = "1.4.0"
-compose = "1.0.0-rc02"
+compose = "1.1.0-alpha01"
 composeSnapshot = "-"
 coroutines = "1.5.1"
 hilt = "2.38.1"
 kotlin = "1.5.21"
-lifecycle = "2.4.0-alpha02"
+lifecycle = "2.4.0-alpha03"
 
 [libraries]
 # Kotlin dependencies
@@ -24,7 +24,7 @@ androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0-rc01"
 androidx-core-ktx = "androidx.core:core-ktx:1.7.0-alpha01"
 androidx-documentfile = "androidx.documentfile:documentfile:1.0.1"
-androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0-alpha05"
+androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0-alpha06"
 androidx-hilt-compose = "androidx.hilt:hilt-navigation-compose:1.0.0-alpha03"
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref="lifecycle" }
 androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref="lifecycle" }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

Re-enables and upgrades Jetpack Compose now that it is compatible with Kotlin 1.5.21, as well as other AndroidX libraries.
