### PR TITLE
Disable explicit API for tests

### DIFF
--- a/autofill-parser/src/test/kotlin/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoaderTest.kt
+++ b/autofill-parser/src/test/kotlin/mozilla/components/lib/publicsuffixlist/PublicSuffixListLoaderTest.kt
@@ -7,7 +7,7 @@ package mozilla.components.lib.publicsuffixlist
 
 import org.junit.Test
 
-internal class PublicSuffixListLoaderTest {
+class PublicSuffixListLoaderTest {
   @Test
   fun testLoadingBundledPublicSuffixList() {
     requireNotNull(javaClass.classLoader).getResourceAsStream("publicsuffixes").buffered().use {

--- a/buildSrc/src/main/java/PasswordStorePlugin.kt
+++ b/buildSrc/src/main/java/PasswordStorePlugin.kt
@@ -68,9 +68,12 @@ class PasswordStorePlugin : Plugin<Project> {
   }
 
   private fun Project.configureExplicitApi() {
-    configure<KotlinProjectExtension> { explicitApi() }
+    val project = this
     tasks.withType<KotlinCompile> {
-      kotlinOptions { freeCompilerArgs = freeCompilerArgs + listOf("-Xexplicit-api=strict") }
+      if (!name.contains("test", ignoreCase = true)) {
+        project.configure<KotlinProjectExtension> { explicitApi() }
+        kotlinOptions { freeCompilerArgs += listOf("-Xexplicit-api=strict") }
+      }
     }
   }
 }

--- a/format-common/src/test/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntryTest.kt
+++ b/format-common/src/test/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntryTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
-internal class PasswordEntryTest {
+class PasswordEntryTest {
 
   private fun makeEntry(content: String) =
     PasswordEntry(fakeClock, testFinder, testScope, content.encodeToByteArray())

--- a/format-common/src/test/kotlin/dev/msfjarvis/aps/util/time/TestClocks.kt
+++ b/format-common/src/test/kotlin/dev/msfjarvis/aps/util/time/TestClocks.kt
@@ -13,7 +13,7 @@ import java.time.ZoneOffset.UTC
 /**
  * Implementation of [UserClock] that is fixed to [Instant.EPOCH] for deterministic time-based tests
  */
-internal class TestUserClock(instant: Instant) : UserClock() {
+class TestUserClock(instant: Instant) : UserClock() {
 
   constructor() : this(Instant.EPOCH)
 

--- a/format-common/src/test/kotlin/dev/msfjarvis/aps/util/totp/OtpTest.kt
+++ b/format-common/src/test/kotlin/dev/msfjarvis/aps/util/totp/OtpTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.Test
 
-internal class OtpTest {
+class OtpTest {
 
   private fun generateOtp(
     counter: Long,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Skips enabling explicit API for test classes since there's no value obtained.

## :green_heart: How did you test it?

`gradle test -PslimTests` passes with visibility modifiers removed.
