### PR TITLE
Update AndroidX deps

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/proxy/ProxySelectorActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/proxy/ProxySelectorActivity.kt
@@ -6,6 +6,8 @@
 package dev.msfjarvis.aps.ui.proxy
 
 import android.content.SharedPreferences
+import android.net.InetAddresses
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -25,7 +27,6 @@ import dev.msfjarvis.aps.util.settings.GitSettings
 import dev.msfjarvis.aps.util.settings.PreferenceKeys
 import javax.inject.Inject
 
-private val IP_ADDRESS_REGEX = Patterns.IP_ADDRESS.toRegex()
 private val WEB_ADDRESS_REGEX = Patterns.WEB_URL.toRegex()
 
 @AndroidEntryPoint
@@ -34,9 +35,7 @@ class ProxySelectorActivity : AppCompatActivity() {
   @Inject lateinit var gitSettings: GitSettings
   @ProxyPreferences @Inject lateinit var proxyPrefs: SharedPreferences
   @Inject lateinit var proxyUtils: ProxyUtils
-
   private val binding by viewBinding(ActivityProxySelectorBinding::inflate)
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(binding.root)
@@ -51,13 +50,21 @@ class ProxySelectorActivity : AppCompatActivity() {
       proxyHost.doOnTextChanged { text, _, _, _ ->
         if (text != null) {
           proxyHost.error =
-            if (text.matches(IP_ADDRESS_REGEX) || text.matches(WEB_ADDRESS_REGEX)) {
+            if (isNumericAddress(text) || text.matches(WEB_ADDRESS_REGEX)) {
               null
             } else {
               getString(R.string.invalid_proxy_url)
             }
         }
       }
+    }
+  }
+
+  private fun isNumericAddress(text: CharSequence): Boolean {
+    return if (Build.VERSION.SDK_INT >= 29) {
+      InetAddresses.isNumericAddress(text as String)
+    } else {
+      @Suppress("DEPRECATION") Patterns.IP_ADDRESS.matcher(text).matches()
     }
   }
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
@@ -5,6 +5,8 @@
 package com.github.androidpasswordstore.autofillparser
 
 import android.content.Context
+import android.net.InetAddresses
+import android.os.Build
 import android.util.Patterns
 import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
@@ -43,12 +45,18 @@ internal fun getPublicSuffixPlusOne(
   // We do not check whether the domain actually exists (actually, not even whether its TLD
   // exists). As long as we restrict ourselves to syntactically valid domain names,
   // getPublicSuffixPlusOne will return non-colliding results.
-  if (!Patterns.DOMAIN_NAME.matcher(domain).matches() ||
-      Patterns.IP_ADDRESS.matcher(domain).matches()
-  ) {
+  if (!Patterns.DOMAIN_NAME.matcher(domain).matches() || isNumericAddress(domain)) {
     domain
   } else {
     getCanonicalSuffix(context, domain, customSuffixes)
+  }
+}
+
+private fun isNumericAddress(domain: String): Boolean {
+  return if (Build.VERSION.SDK_INT >= 29) {
+    InetAddresses.isNumericAddress(domain)
+  } else {
+    @Suppress("DEPRECATION") Patterns.IP_ADDRESS.matcher(domain).matches()
   }
 }
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/PublicSuffixListCache.kt
@@ -19,7 +19,7 @@ private object PublicSuffixListCache {
     if (!::publicSuffixList.isInitialized) {
       publicSuffixList = PublicSuffixList(context)
       // Trigger loading the actual public suffix list, but don't block.
-      @Suppress("DeferredResultUnused") publicSuffixList.prefetch()
+      @Suppress("DeferredResultUnused") publicSuffixList.prefetchAsync()
     }
     return publicSuffixList
   }
@@ -80,7 +80,8 @@ private suspend fun getCanonicalSuffix(
   customSuffixes: Sequence<String>
 ): String {
   val publicSuffixList = PublicSuffixListCache.getOrCachePublicSuffixList(context)
-  val publicSuffixPlusOne = publicSuffixList.getPublicSuffixPlusOne(domain).await() ?: return domain
+  val publicSuffixPlusOne =
+    publicSuffixList.getPublicSuffixPlusOneAsync(domain).await() ?: return domain
   var longestSuffix = publicSuffixPlusOne
   for (customSuffix in customSuffixes) {
     val suffixPlusUpToOne = getSuffixPlusUpToOne(domain, customSuffix) ?: continue

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixList.kt
@@ -38,7 +38,7 @@ internal class PublicSuffixList(
   }
 
   /** Prefetch the public suffix list from disk so that it is available in memory. */
-  fun prefetch(): Deferred<Unit> = scope.async { data.run { Unit } }
+  fun prefetchAsync(): Deferred<Unit> = scope.async { data.run {} }
 
   /**
    * Returns the public suffix and one more level; known as the registrable domain. Returns `null`
@@ -55,7 +55,7 @@ internal class PublicSuffixList(
    * unexpected values are passed (e.g., a full URL, a domain with a trailing '/', etc) this may
    * return an incorrect result.
    */
-  fun getPublicSuffixPlusOne(domain: String): Deferred<String?> =
+  fun getPublicSuffixPlusOneAsync(domain: String): Deferred<String?> =
     scope.async {
       when (val offset = data.getPublicSuffixOffset(domain)) {
         is PublicSuffixOffset.Offset ->

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -38,14 +38,13 @@ internal fun Project.configureForAllProjects() {
       content {
         includeModule("com.github.haroldadmin", "WhatTheStack")
         includeModule("com.github.open-keychain.open-keychain", "sshauthentication-api")
-        includeModule("com.github.IvanShafran", "shared-preferences-mock")
       }
     }
   }
   tasks.withType<KotlinCompile> {
     kotlinOptions {
       allWarningsAsErrors = true
-      jvmTarget = JavaVersion.VERSION_1_8.toString()
+      jvmTarget = JavaVersion.VERSION_11.toString()
       freeCompilerArgs = freeCompilerArgs + additionalCompilerArgs
       languageVersion = "1.5"
     }
@@ -110,7 +109,7 @@ internal fun BaseAppModuleExtension.configureAndroidApplicationOptions(project: 
 /** Apply baseline configurations for all Android projects (Application and Library). */
 @Suppress("UnstableApiUsage")
 internal fun TestedExtension.configureCommonAndroidOptions() {
-  setCompileSdkVersion(30)
+  setCompileSdkVersion(31)
 
   defaultConfig {
     minSdk = 23
@@ -133,8 +132,8 @@ internal fun TestedExtension.configureCommonAndroidOptions() {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 
   testOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 # Centralized versions for dependencies that share versions
 [versions]
 androidx_activity = "1.3.1"
-androidx_test = "1.4.0"
-compose = "1.1.0-alpha01"
+androidx_test = "1.4.1-alpha01"
+compose = "1.0.1"
 composeSnapshot = "-"
 coroutines = "1.5.1"
 flowbinding = "1.2.0"
@@ -24,8 +24,8 @@ androidx-appcompat = "androidx.appcompat:appcompat:1.4.0-alpha03"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.0"
 androidx-core-ktx = "androidx.core:core-ktx:1.7.0-alpha01"
-androidx-documentfile = "androidx.documentfile:documentfile:1.0.1"
-androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0-alpha06"
+androidx-documentfile = "androidx.documentfile:documentfile:1.1.0-alpha01"
+androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0-alpha07"
 androidx-hilt-compose = "androidx.hilt:hilt-navigation-compose:1.0.0-alpha03"
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref="lifecycle" }
 androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref="lifecycle" }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [x] Dependency updates

## :scroll: Description
Updates AndroidX dependencies and raises compileSdk to 31 as required by new Compose releases. This had a knock-on effect in the proxy code and autofill-parser where an API deprecation required fixing, and while there I made small changes to appease IntelliJ's Kotlin lints.

## :green_heart: How did you test it?

`gradle test -PslimTests`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
