### PR TITLE
Fix auto-focus issue on Dialogs with TextInputFields

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
@@ -7,6 +7,7 @@ package dev.msfjarvis.aps.ui.dialogs
 import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -67,7 +68,7 @@ class FolderCreationDialogFragment : DialogFragment() {
     alertDialogBuilder.setPositiveButton(getString(R.string.button_create), null)
     alertDialogBuilder.setNegativeButton(getString(android.R.string.cancel)) { _, _ -> dismiss() }
     val dialog = alertDialogBuilder.create()
-    dialog.requestInputFocusOnView<TextInputEditText>(R.id.folder_name_text)
+    dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
     dialog.setOnShowListener {
       dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
         createDirectory(requireArguments().getString(CURRENT_DIR_EXTRA)!!)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
@@ -24,7 +24,6 @@ import dev.msfjarvis.aps.ui.crypto.BasePgpActivity
 import dev.msfjarvis.aps.ui.crypto.GetKeyIdsActivity
 import dev.msfjarvis.aps.ui.passwords.PasswordStore
 import dev.msfjarvis.aps.util.extensions.commitChange
-import dev.msfjarvis.aps.util.extensions.requestInputFocusOnView
 import java.io.File
 import kotlinx.coroutines.launch
 import me.msfjarvis.openpgpktx.util.OpenPgpApi

--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/OtpImportDialogFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/OtpImportDialogFragment.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.aps.ui.dialogs
 import android.app.Dialog
 import android.net.Uri
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
@@ -31,7 +32,7 @@ class OtpImportDialogFragment : DialogFragment() {
       )
     }
     val dialog = builder.create()
-    dialog.requestInputFocusOnView<TextInputEditText>(R.id.secret)
+    dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
     return dialog
   }
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/OtpImportDialogFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/OtpImportDialogFragment.kt
@@ -13,11 +13,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.textfield.TextInputEditText
-import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.databinding.FragmentManualOtpEntryBinding
 import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivity
-import dev.msfjarvis.aps.util.extensions.requestInputFocusOnView
 
 class OtpImportDialogFragment : DialogFragment() {
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -14,6 +14,7 @@ import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
+import android.view.WindowManager
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
@@ -56,7 +57,6 @@ import dev.msfjarvis.aps.util.extensions.getString
 import dev.msfjarvis.aps.util.extensions.isInsideRepository
 import dev.msfjarvis.aps.util.extensions.isPermissionGranted
 import dev.msfjarvis.aps.util.extensions.listFilesRecursively
-import dev.msfjarvis.aps.util.extensions.requestInputFocusOnView
 import dev.msfjarvis.aps.util.extensions.sharedPrefs
 import dev.msfjarvis.aps.util.settings.AuthMode
 import dev.msfjarvis.aps.util.settings.PreferenceKeys
@@ -583,7 +583,7 @@ class PasswordStore : BaseGitActivity() {
         .setNegativeButton(R.string.dialog_skip, null)
         .create()
 
-    dialog.requestInputFocusOnView<TextInputEditText>(R.id.folder_name_text)
+    dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
     dialog.show()
   }
 

--- a/app/src/main/java/dev/msfjarvis/aps/util/extensions/AndroidExtensions.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/extensions/AndroidExtensions.kt
@@ -15,10 +15,7 @@ import android.util.Base64
 import android.util.TypedValue
 import android.view.View
 import android.view.autofill.AutofillManager
-import android.view.inputmethod.InputMethodManager
-import androidx.annotation.IdRes
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
@@ -32,25 +29,6 @@ import dev.msfjarvis.aps.BuildConfig
 import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.data.repo.PasswordRepository
 import dev.msfjarvis.aps.util.git.operation.GitOperation
-
-/**
- * Extension function for [AlertDialog] that requests focus for the view whose id is [id]. Solution
- * based on a StackOverflow answer: https://stackoverflow.com/a/13056259/297261
- */
-fun <T : View> AlertDialog.requestInputFocusOnView(@IdRes id: Int) {
-  setOnShowListener {
-    findViewById<T>(id)?.apply {
-      setOnFocusChangeListener { v, _ ->
-        v.post {
-          context
-            .getSystemService<InputMethodManager>()
-            ?.showSoftInput(v, InputMethodManager.SHOW_IMPLICIT)
-        }
-      }
-      requestFocus()
-    }
-  }
-}
 
 /** Get an instance of [AutofillManager]. Only available on Android Oreo and above */
 val Context.autofillManager: AutofillManager?

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/operation/CredentialFinder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/operation/CredentialFinder.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.aps.util.git.operation
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import android.view.LayoutInflater
+import android.view.WindowManager
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.core.widget.doOnTextChanged
@@ -100,7 +101,7 @@ class CredentialFinder(val callingActivity: FragmentActivity, val authMode: Auth
           create()
         }
         .run {
-          requestInputFocusOnView<TextInputEditText>(R.id.git_auth_credential)
+          window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
           show()
         }
     } else {

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/operation/CredentialFinder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/operation/CredentialFinder.kt
@@ -23,7 +23,6 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.injection.prefs.GitPreferences
-import dev.msfjarvis.aps.util.extensions.requestInputFocusOnView
 import dev.msfjarvis.aps.util.git.sshj.InteractivePasswordFinder
 import dev.msfjarvis.aps.util.settings.AuthMode
 import dev.msfjarvis.aps.util.settings.PreferenceKeys

--- a/app/src/main/res/layout/folder_dialog_fragment.xml
+++ b/app/src/main/res/layout/folder_dialog_fragment.xml
@@ -25,6 +25,8 @@
       android:layout_height="wrap_content"
       android:inputType="textNoSuggestions|textVisiblePassword" />
 
+    <requestFocus />
+
   </com.google.android.material.textfield.TextInputLayout>
 
   <com.google.android.material.checkbox.MaterialCheckBox

--- a/app/src/main/res/layout/fragment_manual_otp_entry.xml
+++ b/app/src/main/res/layout/fragment_manual_otp_entry.xml
@@ -26,6 +26,8 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent" />
 
+    <requestFocus />
+
   </com.google.android.material.textfield.TextInputLayout>
 
   <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/layout/git_credential_layout.xml
+++ b/app/src/main/res/layout/git_credential_layout.xml
@@ -26,6 +26,8 @@
       android:layout_height="wrap_content"
       android:hint="@string/ssh_keygen_passphrase"
       android:inputType="textPassword" />
+
+    <requestFocus />
   </com.google.android.material.textfield.TextInputLayout>
 
   <com.google.android.material.checkbox.MaterialCheckBox


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
App dialog with text fields now auto-focus and open up soft keyboard

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/android-password-store/Android-Password-Store/blob/144694781175f4a856d66ea92c603489a6e0b99d/app/src/main/java/dev/msfjarvis/aps/util/extensions/AndroidExtensions.kt#L40-L53 This extension used earlier no longer works so the new changes can be used as a replacement for the same

## :green_heart: How did you test it?
Tested on my device by building the debug apk

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->

https://user-images.githubusercontent.com/33605526/131181112-92f27629-c66a-44f1-9da8-83a2eb8d076b.mp4
