### PR TITLE
Gopenpgp related fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.crypto.GopenpgpDecryptActivity"
+      android:name=".ui.crypto.DecryptActivityV2"
       android:exported="true" />
 
     <activity
@@ -95,7 +95,7 @@
       android:label="@string/new_password_title"
       android:windowSoftInputMode="adjustResize" />
 
-    <activity android:name=".ui.crypto.GopenpgpPasswordCreationActivity"
+    <activity android:name=".ui.crypto.PasswordCreationActivityV2"
       android:label="@string/new_password_title"
       android:windowSoftInputMode="adjustResize" />
 
@@ -137,7 +137,7 @@
       android:name=".ui.autofill.AutofillDecryptActivity"
       android:theme="@style/NoBackgroundTheme" />
     <activity
-      android:name=".ui.autofill.GopenpgpAutofillDecryptActivity"
+      android:name=".ui.autofill.AutofillDecryptActivityV2"
       android:theme="@style/NoBackgroundTheme" />
     <activity
       android:name=".ui.autofill.AutofillFilterView"

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
@@ -25,7 +25,7 @@ import com.github.michaelbull.result.runCatching
 import dagger.hilt.android.AndroidEntryPoint
 import dev.msfjarvis.aps.injection.crypto.CryptoSet
 import dev.msfjarvis.aps.injection.password.PasswordEntryFactory
-import dev.msfjarvis.aps.ui.crypto.GopenpgpDecryptActivity
+import dev.msfjarvis.aps.ui.crypto.DecryptActivityV2
 import dev.msfjarvis.aps.util.autofill.AutofillPreferences
 import dev.msfjarvis.aps.util.autofill.AutofillResponseBuilder
 import dev.msfjarvis.aps.util.autofill.DirectoryStructure
@@ -37,7 +37,7 @@ import kotlinx.coroutines.withContext
 
 @RequiresApi(Build.VERSION_CODES.O)
 @AndroidEntryPoint
-class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
+class AutofillDecryptActivityV2 : AppCompatActivity() {
 
   companion object {
 
@@ -47,7 +47,7 @@ class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
     private var decryptFileRequestCode = 1
 
     fun makeDecryptFileIntent(file: File, forwardedExtras: Bundle, context: Context): Intent {
-      return Intent(context, GopenpgpAutofillDecryptActivity::class.java).apply {
+      return Intent(context, AutofillDecryptActivityV2::class.java).apply {
         putExtras(forwardedExtras)
         putExtra(EXTRA_SEARCH_ACTION, true)
         putExtra(EXTRA_FILE_PATH, file.absolutePath)
@@ -56,7 +56,7 @@ class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
 
     fun makeDecryptFileIntentSender(file: File, context: Context): IntentSender {
       val intent =
-        Intent(context, GopenpgpAutofillDecryptActivity::class.java).apply {
+        Intent(context, AutofillDecryptActivityV2::class.java).apply {
           putExtra(EXTRA_SEARCH_ACTION, false)
           putExtra(EXTRA_FILE_PATH, file.absolutePath)
         }
@@ -80,14 +80,14 @@ class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
     val filePath =
       intent?.getStringExtra(EXTRA_FILE_PATH)
         ?: run {
-          e { "GopenpgpAutofillDecryptActivity started without EXTRA_FILE_PATH" }
+          e { "AutofillDecryptActivityV2 started without EXTRA_FILE_PATH" }
           finish()
           return
         }
     val clientState =
       intent?.getBundleExtra(AutofillManager.EXTRA_CLIENT_STATE)
         ?: run {
-          e { "GopenpgpAutofillDecryptActivity started without EXTRA_CLIENT_STATE" }
+          e { "AutofillDecryptActivityV2 started without EXTRA_CLIENT_STATE" }
           finish()
           return
         }
@@ -102,7 +102,7 @@ class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
       } else {
         val fillInDataset =
           AutofillResponseBuilder.makeFillInDataset(
-            this@GopenpgpAutofillDecryptActivity,
+            this@AutofillDecryptActivityV2,
             credentials,
             clientState,
             action
@@ -129,14 +129,14 @@ class GopenpgpAutofillDecryptActivity : AppCompatActivity() {
           val crypto = cryptos.first { it.canHandle(file.absolutePath) }
           withContext(Dispatchers.IO) {
             crypto.decrypt(
-              GopenpgpDecryptActivity.PRIV_KEY,
-              GopenpgpDecryptActivity.PASS.toByteArray(charset = Charsets.UTF_8),
+              DecryptActivityV2.PRIV_KEY,
+              DecryptActivityV2.PASS.toByteArray(charset = Charsets.UTF_8),
               encryptedInput.readBytes()
             )
           }
         }
           .onFailure { e ->
-            e(e) { "Decryption with Gopenpgp failed" }
+            e(e) { "Decryption failed" }
             return null
           }
           .onSuccess { result ->

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
@@ -221,7 +221,7 @@ class AutofillFilterView : AppCompatActivity() {
       AutofillMatcher.addMatchFor(applicationContext, formOrigin, item.file)
     // intent?.extras? is checked to be non-null in onCreate
     decryptAction.launch(
-      if (FeatureFlags.ENABLE_GOPENPGP) {
+      if (FeatureFlags.ENABLE_PGP_V2_BACKEND) {
         AutofillDecryptActivityV2.makeDecryptFileIntent(item.file, intent!!.extras!!, this)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntent(item.file, intent!!.extras!!, this)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterActivity.kt
@@ -222,7 +222,7 @@ class AutofillFilterView : AppCompatActivity() {
     // intent?.extras? is checked to be non-null in onCreate
     decryptAction.launch(
       if (FeatureFlags.ENABLE_GOPENPGP) {
-        GopenpgpAutofillDecryptActivity.makeDecryptFileIntent(item.file, intent!!.extras!!, this)
+        AutofillDecryptActivityV2.makeDecryptFileIntent(item.file, intent!!.extras!!, this)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntent(item.file, intent!!.extras!!, this)
       }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
@@ -27,6 +27,7 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.injection.prefs.SettingsPreferences
+import dev.msfjarvis.aps.util.FeatureFlags
 import dev.msfjarvis.aps.util.extensions.OPENPGP_PROVIDER
 import dev.msfjarvis.aps.util.extensions.clipboard
 import dev.msfjarvis.aps.util.extensions.getString
@@ -126,6 +127,7 @@ open class BasePgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBou
 
   /** Method for subclasses to initiate binding with [OpenPgpServiceConnection]. */
   fun bindToOpenKeychain(onBoundListener: OpenPgpServiceConnection.OnBound) {
+    if (FeatureFlags.ENABLE_GOPENPGP) return
     val installed =
       runCatching {
           packageManager.getPackageInfo(OPENPGP_PROVIDER, 0)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
@@ -127,7 +127,7 @@ open class BasePgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBou
 
   /** Method for subclasses to initiate binding with [OpenPgpServiceConnection]. */
   fun bindToOpenKeychain(onBoundListener: OpenPgpServiceConnection.OnBound) {
-    if (FeatureFlags.ENABLE_GOPENPGP) return
+    if (FeatureFlags.ENABLE_PGP_V2_BACKEND) return
     val installed =
       runCatching {
           packageManager.getPackageInfo(OPENPGP_PROVIDER, 0)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
-class GopenpgpDecryptActivity : BasePgpActivity() {
+class DecryptActivityV2 : BasePgpActivity() {
 
   private val binding by viewBinding(DecryptLayoutBinding::inflate)
   @Inject lateinit var passwordEntryFactory: PasswordEntryFactory

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
@@ -96,13 +96,16 @@ class DecryptActivityV2 : BasePgpActivity() {
    * result triggers they can be repopulated with new data.
    */
   private fun editPassword() {
-    val intent = Intent(this, PasswordCreationActivity::class.java)
+    val intent = Intent(this, PasswordCreationActivityV2::class.java)
     intent.putExtra("FILE_PATH", relativeParentPath)
     intent.putExtra("REPO_PATH", repoPath)
-    intent.putExtra(PasswordCreationActivity.EXTRA_FILE_NAME, name)
-    intent.putExtra(PasswordCreationActivity.EXTRA_PASSWORD, passwordEntry?.password)
-    intent.putExtra(PasswordCreationActivity.EXTRA_EXTRA_CONTENT, passwordEntry?.extraContentString)
-    intent.putExtra(PasswordCreationActivity.EXTRA_EDITING, true)
+    intent.putExtra(PasswordCreationActivityV2.EXTRA_FILE_NAME, name)
+    intent.putExtra(PasswordCreationActivityV2.EXTRA_PASSWORD, passwordEntry?.password)
+    intent.putExtra(
+      PasswordCreationActivityV2.EXTRA_EXTRA_CONTENT,
+      passwordEntry?.extraContentString
+    )
+    intent.putExtra(PasswordCreationActivityV2.EXTRA_EDITING, true)
     startActivity(intent)
     finish()
   }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordCreationActivityV2.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
-class GopenpgpPasswordCreationActivity : BasePgpActivity() {
+class PasswordCreationActivityV2 : BasePgpActivity() {
 
   private val binding by viewBinding(PasswordCreationActivityBinding::inflate)
   @Inject lateinit var passwordEntryFactory: PasswordEntryFactory
@@ -96,7 +96,7 @@ class GopenpgpPasswordCreationActivity : BasePgpActivity() {
       otpImportButton.setOnClickListener {
         supportFragmentManager.setFragmentResultListener(
           OTP_RESULT_REQUEST_KEY,
-          this@GopenpgpPasswordCreationActivity
+          this@PasswordCreationActivityV2
         ) { requestKey, bundle ->
           if (requestKey == OTP_RESULT_REQUEST_KEY) {
             val contents = bundle.getString(RESULT)
@@ -113,12 +113,12 @@ class GopenpgpPasswordCreationActivity : BasePgpActivity() {
               getString(R.string.otp_import_qr_code),
               getString(R.string.otp_import_manual_entry)
             )
-          MaterialAlertDialogBuilder(this@GopenpgpPasswordCreationActivity)
+          MaterialAlertDialogBuilder(this@PasswordCreationActivityV2)
             .setItems(items) { _, index ->
               when (index) {
                 0 ->
                   otpImportAction.launch(
-                    IntentIntegrator(this@GopenpgpPasswordCreationActivity)
+                    IntentIntegrator(this@PasswordCreationActivityV2)
                       .setOrientationLocked(false)
                       .setBeepEnabled(false)
                       .setDesiredBarcodeFormats(QR_CODE)
@@ -156,7 +156,7 @@ class GopenpgpPasswordCreationActivity : BasePgpActivity() {
       // in the encrypted extras. This only makes sense if the directory structure is
       // FileBased.
       if (suggestedName == null &&
-          AutofillPreferences.directoryStructure(this@GopenpgpPasswordCreationActivity) ==
+          AutofillPreferences.directoryStructure(this@PasswordCreationActivityV2) ==
             DirectoryStructure.FileBased
       ) {
         encryptUsername.apply {
@@ -367,7 +367,7 @@ class GopenpgpPasswordCreationActivity : BasePgpActivity() {
             val oldFile = File("$repoPath/${oldCategory?.trim('/')}/$oldFileName.gpg")
             if (oldFile.path != file.path && !oldFile.delete()) {
               setResult(RESULT_CANCELED)
-              MaterialAlertDialogBuilder(this@GopenpgpPasswordCreationActivity)
+              MaterialAlertDialogBuilder(this@PasswordCreationActivityV2)
                 .setTitle(R.string.password_creation_file_fail_title)
                 .setMessage(
                   getString(R.string.password_creation_file_delete_fail_message, oldFileName)
@@ -395,7 +395,7 @@ class GopenpgpPasswordCreationActivity : BasePgpActivity() {
             if (e is IOException) {
               e(e) { "Failed to write password file" }
               setResult(RESULT_CANCELED)
-              MaterialAlertDialogBuilder(this@GopenpgpPasswordCreationActivity)
+              MaterialAlertDialogBuilder(this@PasswordCreationActivityV2)
                 .setTitle(getString(R.string.password_creation_file_fail_title))
                 .setMessage(getString(R.string.password_creation_file_write_fail_message))
                 .setCancelable(false)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -426,7 +426,7 @@ class PasswordStore : BaseGitActivity() {
       (authDecryptIntent.clone() as Intent).setComponent(
         ComponentName(
           this,
-          if (FeatureFlags.ENABLE_GOPENPGP) {
+          if (FeatureFlags.ENABLE_PGP_V2_BACKEND) {
             DecryptActivityV2::class.java
           } else {
             DecryptActivity::class.java

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -39,7 +39,7 @@ import dev.msfjarvis.aps.data.password.PasswordItem
 import dev.msfjarvis.aps.data.repo.PasswordRepository
 import dev.msfjarvis.aps.ui.crypto.BasePgpActivity.Companion.getLongName
 import dev.msfjarvis.aps.ui.crypto.DecryptActivity
-import dev.msfjarvis.aps.ui.crypto.GopenpgpDecryptActivity
+import dev.msfjarvis.aps.ui.crypto.DecryptActivityV2
 import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivity
 import dev.msfjarvis.aps.ui.dialogs.BasicBottomSheet
 import dev.msfjarvis.aps.ui.dialogs.FolderCreationDialogFragment
@@ -427,7 +427,7 @@ class PasswordStore : BaseGitActivity() {
         ComponentName(
           this,
           if (FeatureFlags.ENABLE_GOPENPGP) {
-            GopenpgpDecryptActivity::class.java
+            DecryptActivityV2::class.java
           } else {
             DecryptActivity::class.java
           }

--- a/app/src/main/java/dev/msfjarvis/aps/util/FeatureFlags.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/FeatureFlags.kt
@@ -2,5 +2,5 @@ package dev.msfjarvis.aps.util
 
 /** Naive feature flagging functionality to allow merging incomplete features */
 object FeatureFlags {
-  const val ENABLE_GOPENPGP = false
+  const val ENABLE_PGP_V2_BACKEND = false
 }

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
@@ -22,10 +22,10 @@ import com.github.androidpasswordstore.autofillparser.fillWith
 import com.github.michaelbull.result.fold
 import dev.msfjarvis.aps.autofill.oreo.ui.AutofillSmsActivity
 import dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivity
+import dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivityV2
 import dev.msfjarvis.aps.ui.autofill.AutofillFilterView
 import dev.msfjarvis.aps.ui.autofill.AutofillPublisherChangedActivity
 import dev.msfjarvis.aps.ui.autofill.AutofillSaveActivity
-import dev.msfjarvis.aps.ui.autofill.GopenpgpAutofillDecryptActivity
 import dev.msfjarvis.aps.util.FeatureFlags
 import java.io.File
 
@@ -72,7 +72,7 @@ class Api30AutofillResponseBuilder(form: FillableForm) {
     val metadata = makeFillMatchMetadata(context, file)
     val intentSender =
       if (FeatureFlags.ENABLE_GOPENPGP) {
-        GopenpgpAutofillDecryptActivity.makeDecryptFileIntentSender(file, context)
+        AutofillDecryptActivityV2.makeDecryptFileIntentSender(file, context)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntentSender(file, context)
       }

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/Api30AutofillResponseBuilder.kt
@@ -71,7 +71,7 @@ class Api30AutofillResponseBuilder(form: FillableForm) {
     if (!scenario.hasFieldsToFillOn(AutofillAction.Match)) return null
     val metadata = makeFillMatchMetadata(context, file)
     val intentSender =
-      if (FeatureFlags.ENABLE_GOPENPGP) {
+      if (FeatureFlags.ENABLE_PGP_V2_BACKEND) {
         AutofillDecryptActivityV2.makeDecryptFileIntentSender(file, context)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntentSender(file, context)

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
@@ -22,10 +22,10 @@ import com.github.androidpasswordstore.autofillparser.fillWith
 import com.github.michaelbull.result.fold
 import dev.msfjarvis.aps.autofill.oreo.ui.AutofillSmsActivity
 import dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivity
+import dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivityV2
 import dev.msfjarvis.aps.ui.autofill.AutofillFilterView
 import dev.msfjarvis.aps.ui.autofill.AutofillPublisherChangedActivity
 import dev.msfjarvis.aps.ui.autofill.AutofillSaveActivity
-import dev.msfjarvis.aps.ui.autofill.GopenpgpAutofillDecryptActivity
 import dev.msfjarvis.aps.util.FeatureFlags
 import java.io.File
 
@@ -60,7 +60,7 @@ class AutofillResponseBuilder(form: FillableForm) {
     val metadata = makeFillMatchMetadata(context, file)
     val intentSender =
       if (FeatureFlags.ENABLE_GOPENPGP) {
-        GopenpgpAutofillDecryptActivity.makeDecryptFileIntentSender(file, context)
+        AutofillDecryptActivityV2.makeDecryptFileIntentSender(file, context)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntentSender(file, context)
       }

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillResponseBuilder.kt
@@ -59,7 +59,7 @@ class AutofillResponseBuilder(form: FillableForm) {
     if (!scenario.hasFieldsToFillOn(AutofillAction.Match)) return null
     val metadata = makeFillMatchMetadata(context, file)
     val intentSender =
-      if (FeatureFlags.ENABLE_GOPENPGP) {
+      if (FeatureFlags.ENABLE_PGP_V2_BACKEND) {
         AutofillDecryptActivityV2.makeDecryptFileIntentSender(file, context)
       } else {
         AutofillDecryptActivity.makeDecryptFileIntentSender(file, context)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
- Renames `Gopenpgp*` classes and fields to have a V2 prefix instead which makes the intent clearer
- Changes the edit action for V2 to use the correct activity
- Skips OpenKeychain binding method when alt backends are being used

## :bulb: Motivation and Context

We're exploring alternative PGP implementations that are not necessarily Gopenpgp so the naming doesn't really work.

## :green_heart: How did you test it?

App builds and runs as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
