### PR TITLE
Cancel redundant PR workflow runs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,11 @@
 on: [pull_request]
 
 name: Check pull request
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Uses a beta feature in Actions called [concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) to force all PR builds to be in the same concurrency group, which caps the number of concurrent builds at 1. Setting `cancel-in-progress: true` means that a new push to an open PR will cancel any existing checks running against that PR.

## :bulb: Motivation and Context

A PR run takes ~10 minutes for us which means if you force push before an existing build has finished you'd enqueue another build and the previous, redundant build will still complete while serving virtually no value.

## :green_heart: How did you test it?

:shrug: trusting the system

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
