### PR TITLE
Cleanup and improve CI checks

### DIFF
--- a/.github/check-changed-files.js
+++ b/.github/check-changed-files.js
@@ -1,0 +1,20 @@
+module.exports = async ({github, context}) => {
+  const result = await github.pulls.listFiles({
+    owner: context.payload.repository.owner.login,
+    repo: context.payload.repository.name,
+    pull_number: context.payload.number,
+    per_page: 100,
+  });
+
+  const files = result.data.filter((file) => {
+    const filename = file.filename
+    // Markdown files are not tested
+    return !filename.endsWith("md") &&
+      // Exclude YAML files as long as they are not the PR workflow itself
+      !(filename.endsWith("yml") && !filename.endsWith("pull_request.yml")) && !filename.endsWith("yaml") &&
+      // Fastlane metadata does not need tests
+      !filename.startsWith("fastlane/");
+  });
+  console.log(`Remaining changed files: ${files.map(file => file.filename)}`)
+  return files.length != 0;
+}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,40 +10,24 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      with:
+        fetch-depth: 0
+
     - name: Check if relevant files have changed
       uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
       id: service-changed
       with:
         result-encoding: string
         script: |
-          const result = await github.pulls.listFiles({
-            owner: context.payload.repository.owner.login,
-            repo: context.payload.repository.name,
-            pull_number: context.payload.number,
-            per_page: 100
-          })
-          const files = result.data.filter(file =>
-            // We wanna run this if the PR workflow is modified
-            (file.filename.endsWith(".yml") && !file.filename.endsWith("pull_request.yml")) ||
-            // Changes in Markdown files don't need tests
-            file.filename.endsWith(".md") ||
-            // Changes to fastlane metadata aren't covered by tests
-            file.filename.startsWith("fastlane/")
-          )
-          // If filtered file count and source file count is equal, it means all files
-          // in this PR are skip-worthy.
-          return files.length != result.data.length
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
 
     - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       with:
         java-version: '11'
-
-    - name: Checkout repository
-      if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      with:
-        fetch-depth: 0
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}
@@ -71,29 +55,19 @@ jobs:
   instrumentation-tests:
     runs-on: macos-11
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      with:
+        fetch-depth: 0
+
     - name: Check if relevant files have changed
       uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
       id: service-changed
       with:
         result-encoding: string
         script: |
-          const result = await github.pulls.listFiles({
-            owner: context.payload.repository.owner.login,
-            repo: context.payload.repository.name,
-            pull_number: context.payload.number,
-            per_page: 100
-          })
-          const files = result.data.filter(file =>
-            // We wanna run this if the PR workflow is modified
-            (file.filename.endsWith(".yml") && !file.filename.endsWith("pull_request.yml")) ||
-            // Changes in Markdown files don't need tests
-            file.filename.endsWith(".md") ||
-            // Changes to fastlane metadata aren't covered by tests
-            file.filename.startsWith("fastlane/")
-          )
-          // If filtered file count and source file count is equal, it means all files
-          // in this PR are skip-worthy.
-          return files.length != result.data.length
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
 
     - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
       if: ${{ steps.service-changed.outputs.result == 'true' }}
@@ -108,12 +82,6 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       with:
         java-version: '11'
-
-    - name: Checkout repository
-      if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      with:
-        fetch-depth: 0
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,6 +49,12 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
+    - name: Build debug APKs
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
+      with:
+        arguments: assembleFreeDebug assembleNonFreeDebug
+
     - name: Run unit tests
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,8 +62,8 @@ jobs:
           name: Test report
           path: app/build/reports
 
-  run-screenshot-tests:
-    runs-on: macOS-latest
+  instrumentation-tests:
+    runs-on: macos-11
     steps:
     - name: Check if relevant files have changed
       uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293

--- a/app/src/nonFree/java/dev/msfjarvis/aps/autofill/oreo/ui/AutofillSmsActivity.kt
+++ b/app/src/nonFree/java/dev/msfjarvis/aps/autofill/oreo/ui/AutofillSmsActivity.kt
@@ -37,7 +37,9 @@ import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
 import logcat.LogPriority.WARN
+import logcat.asLog
 import logcat.logcat
 
 suspend fun <T> Task<T>.suspendableAwait() =
@@ -134,7 +136,7 @@ class AutofillSmsActivity : AppCompatActivity() {
         if (e is ResolvableApiException) {
           e.startResolutionForResult(this@AutofillSmsActivity, 1)
         } else {
-          e(e)
+          logcat(ERROR) { e.asLog() }
           withContext(Dispatchers.Main) { finish() }
         }
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

- Fixes instrumentation test job name
- Cleans up and extracts the JS used for checking changed files
- Adds basic compile checking for both build types
- Fixes a lingering Timber use missed in #1509

## :bulb: Motivation and Context

Our builds do not check the `nonFree` source set which allowed a compile error to slip through to `develop` and break snapshot deployment.

## :green_heart: How did you test it?

Verified nonFreeDebug builds correctly and the new JS code executes correctly in a REPL

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
