### PR TITLE
Add `installGitHooks` task for pre-push Git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ The app comes in two 'flavors', a FOSS-only **free** variant and a **nonFree** v
 
 You can find the generated APK at `app/build/outputs/apk/<variant>/debug/app-<variant>-debug.apk`.
 
+## Pre-push checks
+
+The project enforces codestyle conventions and library API stability by virtue of a carefully curated Gradle build. To setup a Git pre-push hook to run them automatically, run `./gradlew installGitHooks`.
+
 # Things to do before you start writing code
 
 If you're trying to fix a bug that already has an open issue, it's a good idea to drop a comment mentioning that you're working on a fix. If no open issue exists, ensure that you explain the bug you're fixing in some detail in the pull request body. This helps us as maintainers get a better sense of why you're making specific changes, and we might have insight into better ways of fixing the problem.

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.wrapper.Wrapper
 import org.gradle.kotlin.dsl.maven
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.nativeplatform.internal.BuildType
@@ -26,6 +27,11 @@ internal fun Project.configureForRootProject() {
     distributionSha256Sum = "f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd"
   }
   configureBinaryCompatibilityValidator()
+  tasks.register<GitHooks>("installGitHooks") {
+    val projectDirectory = layout.projectDirectory
+    hookScript.set(projectDirectory.file("scripts/pre-push-hook.sh").asFile.readText())
+    hookOutput.set(projectDirectory.file(".git/hooks/pre-push").asFile)
+  }
 }
 
 /** Configure all projects including the root project */

--- a/buildSrc/src/main/java/GitHooks.kt
+++ b/buildSrc/src/main/java/GitHooks.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.GROUP_READ
+import java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OTHERS_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class GitHooks : DefaultTask() {
+  @get:Input abstract val hookScript: Property<String>
+
+  @get:OutputFile abstract val hookOutput: Property<File>
+
+  @TaskAction
+  fun install() {
+    hookOutput.get().writeText(hookScript.get())
+    Files.setPosixFilePermissions(
+      hookOutput.get().toPath(),
+      setOf(
+        OWNER_READ,
+        OWNER_WRITE,
+        OWNER_EXECUTE,
+        GROUP_READ,
+        GROUP_EXECUTE,
+        OTHERS_READ,
+        OTHERS_EXECUTE,
+      )
+    )
+  }
+}

--- a/scripts/pre-push-hook.sh
+++ b/scripts/pre-push-hook.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+GRADLE_EXEC="${GRADLE_EXEC:-./gradlew}"
+
+"${GRADLE_EXEC}" spotlessCheck apiCheck


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds a Gradle task to install a Git pre-push hook and documents it in the contributing guidelines.

## :bulb: Motivation and Context

Having more mundane things checked before push prevents having to make fixes for them during review.

## :green_heart: How did you test it?

Ran `git push` :shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
