### PR TITLE
Upgrade plugin dependencies and fix Javadoc generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 
   buildFeatures.compose = true
 
-  lintOptions {
+  lint {
     isAbortOnError = true
     isCheckReleaseBuilds = false
     disable("MissingTranslation", "PluralsCandidate", "ImpliedQuantity")

--- a/autofill-parser/build.gradle.kts
+++ b/autofill-parser/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   id("com.android.library")
   id("com.vanniktech.maven.publish")
   kotlin("android")
+  id("org.jetbrains.dokka")
   `aps-plugin`
   `psl-plugin`
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,21 +6,9 @@
 plugins { `kotlin-dsl` }
 
 repositories {
-  google()
-  gradlePluginPortal()
   mavenCentral()
-  // Dokka's transitive kotlinx-html dependency is only published to their Space repo
-  // https://github.com/Kotlin/dokka/releases/tag/v1.4.32
-  maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {
-    name = "KotlinX HTML Maven"
-    content {
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html")
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html-assembly")
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html-common")
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html-js")
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-    }
-  }
+  gradlePluginPortal()
+  google()
 }
 
 gradlePlugin {
@@ -46,13 +34,13 @@ gradlePlugin {
 
 dependencies {
   implementation("com.android.tools.build:gradle:7.0.2")
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:5.14.2")
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:5.16.0")
   implementation("com.google.dagger:hilt-android-gradle-plugin:2.39.1")
   implementation("com.squareup.okhttp3:okhttp:4.9.0")
-  implementation("com.vanniktech:gradle-maven-publish-plugin:0.17.0")
+  implementation("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
   implementation("com.vdurmont:semver4j:3.1.0")
   implementation("de.undercouch:gradle-download-task:4.1.2")
-  implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
+  implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.5.31")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
   implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0")
 }

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -10,9 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.wrapper.Wrapper
-import org.gradle.kotlin.dsl.maven
 import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.repositories
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.nativeplatform.internal.BuildType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -36,18 +34,7 @@ internal fun Project.configureForRootProject() {
 
 /** Configure all projects including the root project */
 internal fun Project.configureForAllProjects() {
-  repositories {
-    google()
-    mavenCentral()
-    maven("https://jitpack.io") {
-      name = "JitPack"
-      content {
-        includeModule("com.github.haroldadmin", "WhatTheStack")
-        includeModule("com.github.open-keychain.open-keychain", "sshauthentication-api")
-      }
-    }
-  }
-  tasks.withType<KotlinCompile> {
+  tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
       allWarningsAsErrors = true
       jvmTarget = JavaVersion.VERSION_11.toString()

--- a/openpgp-ktx/build.gradle.kts
+++ b/openpgp-ktx/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   id("com.android.library")
   id("com.vanniktech.maven.publish")
   kotlin("android")
+  id("org.jetbrains.dokka")
   `aps-plugin`
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,16 +24,16 @@ enableFeaturePreview("VERSION_CATALOGS")
 // Plugin repositories
 pluginManagement {
   repositories {
-    gradlePluginPortal()
     mavenCentral()
+    gradlePluginPortal()
   }
 }
 
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
-    google()
     mavenCentral()
+    google()
     maven("https://jitpack.io") {
       name = "JitPack"
       content {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,3 +28,18 @@ pluginManagement {
     mavenCentral()
   }
 }
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+    maven("https://jitpack.io") {
+      name = "JitPack"
+      content {
+        includeModule("com.github.haroldadmin", "WhatTheStack")
+        includeModule("com.github.open-keychain.open-keychain", "sshauthentication-api")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

- Upgrades plugin dependencies
- Moves dependency repository configuration to `settings.gradle.kts`
- Fixes a deprecation warning
- Makes Javadoc generation actually work

## :bulb: Motivation and Context

Without the Dokka plugin explicitly applied, maven-publish does not generate Javadoc and simply ships an empty JAR. We fix this by adding the plugin to our library projects.

## :green_heart: How did you test it?

`./gradlew :autofill-parser:publishToMavenLocal` generated proper Javadoc jars.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
