### PR TITLE
Fix proguard rules which prevent whole program minification

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,8 +21,7 @@
 -keep class com.jcraft.jsch.**
 -keep class org.eclipse.jgit.internal.JGitText { *; }
 -keep class org.bouncycastle.jcajce.provider.** { *; }
--keep class org.bouncycastle.jce.provider.** { *; }
--keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi { *; }
+-keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi,org.bouncycastle.jce.provider.** { *; }
 # WhatTheStack
 -keep class com.haroldadmin.whatthestack.WhatTheStackInitializer {
   <init>();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Replaces the fixes mentioned in #1520 for preventing R8 from skipping minification.

## :bulb: Motivation and Context
﻿
Fixes #1520

## :green_heart: How did you test it?

Built release APKs on `develop` and this branch then compared their sizes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
