### PR TITLE
Add encrypt/decrypt tests for PGPainless

### DIFF
--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/CryptoConstants.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/CryptoConstants.kt
@@ -5,10 +5,10 @@
 
 package dev.msfjarvis.aps.crypto
 
-internal object CryptoConstants {
-  internal const val KEY_PASSPHRASE = "hunter2"
-  internal const val PLAIN_TEXT = "encryption worthy content"
-  internal const val KEY_NAME = "John Doe"
-  internal const val KEY_EMAIL = "john.doe@example.com"
-  internal const val KEY_ID = "08edf7567183ce27"
+object CryptoConstants {
+  const val KEY_PASSPHRASE = "hunter2"
+  const val PLAIN_TEXT = "encryption worthy content"
+  const val KEY_NAME = "John Doe"
+  const val KEY_EMAIL = "john.doe@example.com"
+  const val KEY_ID = "08edf7567183ce27"
 }

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
@@ -13,9 +13,9 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 @OptIn(ExperimentalCoroutinesApi::class)
-public class PGPKeyManagerTest {
+class PGPKeyManagerTest {
 
-  @get:Rule public val temporaryFolder: TemporaryFolder = TemporaryFolder()
+  @get:Rule val temporaryFolder: TemporaryFolder = TemporaryFolder()
   private val filesDir by lazy(LazyThreadSafetyMode.NONE) { temporaryFolder.root }
   private val keysDir by lazy(LazyThreadSafetyMode.NONE) {
     File(filesDir, PGPKeyManager.KEY_DIR_NAME)
@@ -27,7 +27,7 @@ public class PGPKeyManagerTest {
   private val key = PGPKeyManager.makeKey(getArmoredKey())
 
   @Test
-  public fun testAddingKey() {
+  fun testAddingKey() {
     runBlockingTest {
       // Check if the key id returned is correct
       val keyId = keyManager.addKey(key).unwrap().getKeyId()
@@ -43,7 +43,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testAddingKeyWithoutReplaceFlag() {
+  fun testAddingKeyWithoutReplaceFlag() {
     runBlockingTest {
       // Check adding the keys twice
       keyManager.addKey(key, false).unwrap()
@@ -54,7 +54,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testAddingKeyWithReplaceFlag() {
+  fun testAddingKeyWithReplaceFlag() {
     runBlockingTest {
       // Check adding the keys twice
       keyManager.addKey(key, true).unwrap()
@@ -65,7 +65,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testRemovingKey() {
+  fun testRemovingKey() {
     runBlockingTest {
       // Add key using KeyManager
       keyManager.addKey(key).unwrap()
@@ -81,7 +81,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testGetExistingKey() {
+  fun testGetExistingKey() {
     runBlockingTest {
       // Add key using KeyManager
       keyManager.addKey(key).unwrap()
@@ -94,7 +94,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testGetNonExistentKey() {
+  fun testGetNonExistentKey() {
     runBlockingTest {
       // Add key using KeyManager
       keyManager.addKey(key).unwrap()
@@ -109,7 +109,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testFindKeysWithoutAdding() {
+  fun testFindKeysWithoutAdding() {
     runBlockingTest {
       // Check returned key
       val error = keyManager.getKeyById("0x123456789").unwrapError()
@@ -119,7 +119,7 @@ public class PGPKeyManagerTest {
   }
 
   @Test
-  public fun testGettingAllKeys() {
+  fun testGettingAllKeys() {
     runBlockingTest {
       // TODO: Should we check for more than 1 keys?
       // Check if KeyManager returns no key

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
@@ -24,7 +24,7 @@ class PGPKeyManagerTest {
   private val keyManager by lazy(LazyThreadSafetyMode.NONE) {
     PGPKeyManager(filesDir.absolutePath, testCoroutineDispatcher)
   }
-  private val key = PGPKeyManager.makeKey(getArmoredKey())
+  private val key = PGPKeyManager.makeKey(TestUtils.getArmoredPrivateKey())
 
   @Test
   fun testAddingKey() {
@@ -134,6 +134,4 @@ class PGPKeyManagerTest {
       assertEquals(1, singleKeyList.size)
     }
   }
-
-  private fun getArmoredKey() = this::class.java.classLoader.getResource("private_key").readText()
 }

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyPairTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyPairTest.kt
@@ -13,11 +13,10 @@ class PGPKeyPairTest {
 
   @Test
   fun testIfKeyIdIsCorrect() {
-    val secretKey = PGPainless.readKeyRing().secretKeyRing(getKey()).secretKey
+    val secretKey =
+      PGPainless.readKeyRing().secretKeyRing(TestUtils.getArmoredPrivateKey()).secretKey
     val keyPair = PGPKeyPair(secretKey)
 
     assertEquals(CryptoConstants.KEY_ID, keyPair.getKeyId())
   }
-
-  private fun getKey(): String = this::class.java.classLoader.getResource("private_key").readText()
 }

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyPairTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyPairTest.kt
@@ -9,10 +9,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.pgpainless.PGPainless
 
-public class PGPKeyPairTest {
+class PGPKeyPairTest {
 
   @Test
-  public fun testIfKeyIdIsCorrect() {
+  fun testIfKeyIdIsCorrect() {
     val secretKey = PGPainless.readKeyRing().secretKeyRing(getKey()).secretKey
     val keyPair = PGPKeyPair(secretKey)
 

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPainlessCryptoHandlerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPainlessCryptoHandlerTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package dev.msfjarvis.aps.crypto
+
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PGPainlessCryptoHandlerTest {
+
+  private val cryptoHandler = PGPainlessCryptoHandler()
+
+  @Test
+  fun encrypt_and_decrypt() {
+    val key = TestUtils.getArmoredPrivateKey()
+    val ciphertextStream = ByteArrayOutputStream()
+    cryptoHandler.encrypt(
+      listOf(key),
+      CryptoConstants.PLAIN_TEXT.byteInputStream(Charsets.UTF_8),
+      ciphertextStream,
+    )
+    val plaintextStream = ByteArrayOutputStream()
+    cryptoHandler.decrypt(
+      key,
+      CryptoConstants.KEY_PASSPHRASE,
+      ciphertextStream.toByteArray().inputStream(),
+      plaintextStream,
+    )
+    assertEquals(CryptoConstants.PLAIN_TEXT, plaintextStream.toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun can_handle_filters_formats() {
+    assertFalse { cryptoHandler.canHandle("example.com") }
+    assertTrue { cryptoHandler.canHandle("example.com.gpg") }
+    assertFalse { cryptoHandler.canHandle("example.com.asc") }
+  }
+}

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/TestUtils.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/TestUtils.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package dev.msfjarvis.aps.crypto
+
+object TestUtils {
+  fun getArmoredPrivateKey() = this::class.java.classLoader.getResource("private_key").readText()
+}


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Cleans up crypto-pgpainless tests and adds a cryptography test for PGPainlessCryptoHandler

## :bulb: Motivation and Context

Tests are cool!

## :green_heart: How did you test it?

`gradle :crypto-pgpainless:test --tests PGPainlessCryptoHandlerTest`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

More tests? Actual integration?

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
