### PR TITLE
Allow unauthenticated HTTPS Git access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 -   Removed Bromite from supported Autofill browsers, since they [disable Android autofill](https://github.com/bromite/bromite/blob/master/FAQ.md#does-bromite-support-the-android-autofill-framework).
 -   Changing password generator parameters now automatically updates the password without needing to press the 'Generate' button again
 -   The app UI was reskinned to match Google's Material You guidelines
+-   Using HTTPS without authentication is now fully supported, and no longer asks for a username
 
 ## [1.13.5] - 2021-07-28
 

--- a/app/src/main/java/dev/msfjarvis/aps/util/settings/GitSettings.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/settings/GitSettings.kt
@@ -149,7 +149,9 @@ constructor(
         in listOf("ssh", null) -> Protocol.Ssh
         else -> return UpdateConnectionSettingsResult.FailedToParseUrl
       }
-    if (newAuthMode != AuthMode.None && parsedUrl.user.isNullOrBlank())
+    if ((newAuthMode != AuthMode.None && newProtocol != Protocol.Https) &&
+        parsedUrl.user.isNullOrBlank()
+    )
       return UpdateConnectionSettingsResult.MissingUsername(newProtocol)
     val validHttpsAuth = listOf(AuthMode.None, AuthMode.Password)
     val validSshAuth = listOf(AuthMode.OpenKeychain, AuthMode.Password, AuthMode.SshKey)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Enables cloning of HTTPS repositories without authentication or a username

## :bulb: Motivation and Context

It makes little sense on the security front but it makes testing things with our public `pass-test` repository significantly easier.

## :green_heart: How did you test it?

Successfully cloned the `pass-test` repository with the URL `https://github.com/android-password-store/pass-test.git`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

We should probably cover this with unit tests at some point
