### PR TITLE
Fix password saving for V2 backend

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
-import logcat.asLog
 import logcat.logcat
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillSaveActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillSaveActivity.kt
@@ -20,6 +20,8 @@ import com.github.androidpasswordstore.autofillparser.Credentials
 import com.github.androidpasswordstore.autofillparser.FormOrigin
 import dev.msfjarvis.aps.data.repo.PasswordRepository
 import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivity
+import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivityV2
+import dev.msfjarvis.aps.util.FeatureFlags
 import dev.msfjarvis.aps.util.autofill.AutofillMatcher
 import dev.msfjarvis.aps.util.autofill.AutofillPreferences
 import dev.msfjarvis.aps.util.autofill.AutofillResponseBuilder
@@ -85,7 +87,7 @@ class AutofillSaveActivity : AppCompatActivity() {
           context,
           saveRequestCode++,
           intent,
-          PendingIntent.FLAG_CANCEL_CURRENT
+          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
         .intentSender
     }
@@ -106,8 +108,11 @@ class AutofillSaveActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val repo = PasswordRepository.getRepositoryDirectory()
+    val creationActivity =
+      if (FeatureFlags.ENABLE_PGP_V2_BACKEND) PasswordCreationActivityV2::class.java
+      else PasswordCreationActivity::class.java
     val saveIntent =
-      Intent(this, PasswordCreationActivity::class.java).apply {
+      Intent(this, creationActivity).apply {
         putExtras(
           bundleOf(
             "REPO_PATH" to repo.absolutePath,

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/BasePgpActivity.kt
@@ -250,6 +250,8 @@ open class BasePgpActivity : AppCompatActivity(), OpenPgpServiceConnection.OnBou
   companion object {
 
     private const val TAG = "APS/BasePgpActivity"
+    const val EXTRA_FILE_PATH = "FILE_PATH"
+    const val EXTRA_REPO_PATH = "REPO_PATH"
 
     /** Gets the relative path to the repository */
     fun getRelativePath(fullPath: String, repositoryPath: String): String =

--- a/app/src/main/java/dev/msfjarvis/aps/ui/main/LaunchActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/main/LaunchActivity.kt
@@ -10,6 +10,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
+import dev.msfjarvis.aps.ui.crypto.BasePgpActivity
 import dev.msfjarvis.aps.ui.crypto.DecryptActivity
 import dev.msfjarvis.aps.ui.passwords.PasswordStore
 import dev.msfjarvis.aps.util.auth.BiometricAuthenticator
@@ -45,10 +46,14 @@ class LaunchActivity : AppCompatActivity() {
     val intentToStart =
       if (intent.action == ACTION_DECRYPT_PASS)
         Intent(this, DecryptActivity::class.java).apply {
-          putExtra("NAME", intent.getStringExtra("NAME"))
-          putExtra("FILE_PATH", intent.getStringExtra("FILE_PATH"))
-          putExtra("REPO_PATH", intent.getStringExtra("REPO_PATH"))
-          putExtra("LAST_CHANGED_TIMESTAMP", intent.getLongExtra("LAST_CHANGED_TIMESTAMP", 0L))
+          putExtra(
+            BasePgpActivity.EXTRA_FILE_PATH,
+            intent.getStringExtra(BasePgpActivity.EXTRA_FILE_PATH)
+          )
+          putExtra(
+            BasePgpActivity.EXTRA_REPO_PATH,
+            intent.getStringExtra(BasePgpActivity.EXTRA_REPO_PATH)
+          )
         }
       else Intent(this, PasswordStore::class.java)
     startActivity(intentToStart)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -34,6 +34,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.data.password.PasswordItem
 import dev.msfjarvis.aps.data.repo.PasswordRepository
+import dev.msfjarvis.aps.ui.crypto.BasePgpActivity
 import dev.msfjarvis.aps.ui.crypto.BasePgpActivity.Companion.getLongName
 import dev.msfjarvis.aps.ui.crypto.DecryptActivity
 import dev.msfjarvis.aps.ui.crypto.DecryptActivityV2
@@ -456,8 +457,11 @@ class PasswordStore : BaseGitActivity() {
     val currentDir = currentDir
     logcat(INFO) { "Adding file to : ${currentDir.absolutePath}" }
     val intent = Intent(this, PasswordCreationActivity::class.java)
-    intent.putExtra("FILE_PATH", currentDir.absolutePath)
-    intent.putExtra("REPO_PATH", PasswordRepository.getRepositoryDirectory().absolutePath)
+    intent.putExtra(BasePgpActivity.EXTRA_FILE_PATH, currentDir.absolutePath)
+    intent.putExtra(
+      BasePgpActivity.EXTRA_REPO_PATH,
+      PasswordRepository.getRepositoryDirectory().absolutePath
+    )
     listRefreshAction.launch(intent)
   }
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/passwords/PasswordStore.kt
@@ -39,6 +39,7 @@ import dev.msfjarvis.aps.ui.crypto.BasePgpActivity.Companion.getLongName
 import dev.msfjarvis.aps.ui.crypto.DecryptActivity
 import dev.msfjarvis.aps.ui.crypto.DecryptActivityV2
 import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivity
+import dev.msfjarvis.aps.ui.crypto.PasswordCreationActivityV2
 import dev.msfjarvis.aps.ui.dialogs.BasicBottomSheet
 import dev.msfjarvis.aps.ui.dialogs.FolderCreationDialogFragment
 import dev.msfjarvis.aps.ui.folderselect.SelectFolderActivity
@@ -456,7 +457,10 @@ class PasswordStore : BaseGitActivity() {
     if (!validateState()) return
     val currentDir = currentDir
     logcat(INFO) { "Adding file to : ${currentDir.absolutePath}" }
-    val intent = Intent(this, PasswordCreationActivity::class.java)
+    val creationActivity =
+      if (FeatureFlags.ENABLE_PGP_V2_BACKEND) PasswordCreationActivityV2::class.java
+      else PasswordCreationActivity::class.java
+    val intent = Intent(this, creationActivity)
     intent.putExtra(BasePgpActivity.EXTRA_FILE_PATH, currentDir.absolutePath)
     intent.putExtra(
       BasePgpActivity.EXTRA_REPO_PATH,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Removes open-coded intent extras in some places, and adds missing `PGP_V2_BACKEND` switches in password creation paths.

## :bulb: Motivation and Context

Without this creating a new password entry through the app UI or autofill fails due to the wrong activity being launched.

## :green_heart: How did you test it?

Verified I can now create passwords through the app and autofill.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
