### PR TITLE
Cleanup extra content handling

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
@@ -19,7 +19,7 @@ import dev.msfjarvis.aps.databinding.ItemFieldBinding
 class FieldItemAdapter(
   private var fieldItemList: List<FieldItem>,
   private val showPassword: Boolean,
-  private val copyTextToClipBoard: (text: String?) -> Unit,
+  private val copyTextToClipboard: (text: String?) -> Unit,
 ) : RecyclerView.Adapter<FieldItemAdapter.FieldItemViewHolder>() {
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FieldItemViewHolder {
@@ -28,7 +28,7 @@ class FieldItemAdapter(
   }
 
   override fun onBindViewHolder(holder: FieldItemViewHolder, position: Int) {
-    holder.bind(fieldItemList[position], showPassword, copyTextToClipBoard)
+    holder.bind(fieldItemList[position], showPassword, copyTextToClipboard)
   }
 
   override fun getItemCount(): Int {
@@ -58,7 +58,7 @@ class FieldItemAdapter(
   class FieldItemViewHolder(itemView: View, val binding: ItemFieldBinding) :
     RecyclerView.ViewHolder(itemView) {
 
-    fun bind(fieldItem: FieldItem, showPassword: Boolean, copyTextToClipBoard: (String?) -> Unit) {
+    fun bind(fieldItem: FieldItem, showPassword: Boolean, copyTextToClipboard: (String?) -> Unit) {
       with(binding) {
         itemText.hint = fieldItem.key
         itemTextContainer.hint = fieldItem.key
@@ -70,19 +70,19 @@ class FieldItemAdapter(
               endIconDrawable =
                 ContextCompat.getDrawable(itemView.context, R.drawable.ic_content_copy)
               endIconMode = TextInputLayout.END_ICON_CUSTOM
-              setEndIconOnClickListener { copyTextToClipBoard(itemText.text.toString()) }
+              setEndIconOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
           }
           FieldItem.ActionType.HIDE -> {
             itemTextContainer.apply {
               endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
-              setOnClickListener { copyTextToClipBoard(itemText.text.toString()) }
+              setOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
             itemText.apply {
               if (!showPassword) {
                 transformationMethod = PasswordTransformationMethod.getInstance()
               }
-              setOnClickListener { copyTextToClipBoard(itemText.text.toString()) }
+              setOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
           }
         }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
@@ -50,11 +50,6 @@ class FieldItemAdapter(
     notifyItemChanged(otpItemPosition)
   }
 
-  fun updateItems(itemList: List<FieldItem>) {
-    fieldItemList = itemList
-    notifyDataSetChanged()
-  }
-
   class FieldItemViewHolder(itemView: View, val binding: ItemFieldBinding) :
     RecyclerView.ViewHolder(itemView) {
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/adapters/FieldItemAdapter.kt
@@ -72,6 +72,7 @@ class FieldItemAdapter(
               endIconMode = TextInputLayout.END_ICON_CUSTOM
               setEndIconOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
+            itemText.transformationMethod = null
           }
           FieldItem.ActionType.HIDE -> {
             itemTextContainer.apply {
@@ -79,9 +80,12 @@ class FieldItemAdapter(
               setOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
             itemText.apply {
-              if (!showPassword) {
-                transformationMethod = PasswordTransformationMethod.getInstance()
-              }
+              transformationMethod =
+                if (!showPassword) {
+                  PasswordTransformationMethod.getInstance()
+                } else {
+                  null
+                }
               setOnClickListener { copyTextToClipboard(itemText.text.toString()) }
             }
           }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
@@ -20,6 +20,7 @@ import dev.msfjarvis.aps.injection.password.PasswordEntryFactory
 import dev.msfjarvis.aps.ui.adapters.FieldItemAdapter
 import dev.msfjarvis.aps.util.extensions.unsafeLazy
 import dev.msfjarvis.aps.util.extensions.viewBinding
+import dev.msfjarvis.aps.util.settings.PreferenceKeys
 import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
@@ -142,6 +143,7 @@ class DecryptActivityV2 : BasePgpActivity() {
         }
       startAutoDismissTimer()
 
+      val showPassword = settings.getBoolean(PreferenceKeys.SHOW_PASSWORD, true)
       val entry = passwordEntryFactory.create(lifecycleScope, result.toByteArray())
       passwordEntry = entry
       invalidateOptionsMenu()
@@ -163,7 +165,7 @@ class DecryptActivityV2 : BasePgpActivity() {
         items.add(FieldItem(key, value, FieldItem.ActionType.COPY))
       }
 
-      val adapter = FieldItemAdapter(items, true) { text -> copyTextToClipboard(text) }
+      val adapter = FieldItemAdapter(items, showPassword) { text -> copyTextToClipboard(text) }
       binding.recyclerView.adapter = adapter
 
       if (entry.hasTotp()) {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/BasicBottomSheet.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/BasicBottomSheet.kt
@@ -6,7 +6,6 @@
 package dev.msfjarvis.aps.ui.dialogs
 
 import android.content.Context
-import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,13 +19,11 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dev.msfjarvis.aps.R
 import dev.msfjarvis.aps.databinding.BasicBottomSheetBinding
-import dev.msfjarvis.aps.ui.dialogs.BasicBottomSheet.Builder
-import dev.msfjarvis.aps.util.extensions.resolveAttribute
 import dev.msfjarvis.aps.util.extensions.viewBinding
 
 /**
  * [BottomSheetDialogFragment] that exposes a simple [androidx.appcompat.app.AlertDialog] like API
- * through [Builder] to create a similar UI, just at the bottom of the screen.
+ * through [BasicBottomSheet.Builder] to create a similar UI, just at the bottom of the screen.
  */
 class BasicBottomSheet
 private constructor(
@@ -100,11 +97,6 @@ private constructor(
         }
       }
     )
-    val gradientDrawable =
-      GradientDrawable().apply {
-        setColor(requireContext().resolveAttribute(android.R.attr.windowBackground))
-      }
-    view.background = gradientDrawable
   }
 
   override fun dismiss() {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Cleans up a bunch of things around `FieldItemAdapter` as well as removes a now-unnecessary background drawable in `BasicBottomSheet` that was missed in 88c9a0d487ca.

## :bulb: Motivation and Context

Just stuff I noticed while investigating #1525.

## :green_heart: How did you test it?

Visual verification

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Actually fix #1525? /shrug
