### PR TITLE
Try fixing PSL update workflow

### DIFF
--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-        with:
-          persist-credentials: false
-          fetch-depth: 0
 
       - name: Download new publicsuffix data
         uses: gradle/gradle-build-action@cba1833ddecbbee649950c284416981928631008
@@ -25,18 +22,18 @@ jobs:
         uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
         if: env.UPDATED == 'true'
         with:
-          arguments: :autofill-parser:test -PslimTests
+          arguments: :autofill-parser:test
 
-      - name: Commit changes
-        if: env.UPDATED == 'true'
-        run: |
-          git config --local user.name "GitHub Actions"
-          git config --local user.email "noreply@github.com"
-          git commit -am "autofill-parser: update publicsuffixes file"
-
-      - name: Push to develop
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@01f7dd1d28f5131231ba3ede0f1c8cb413584a1d
         if: env.UPDATED == 'true'
         with:
-          github_token: ${{ secrets.PSL_UPDATE_TOKEN }}
-          branch: develop
+          assignees: msfjarvis
+          author: GitHub Actions <noreply@github.com>
+          base: develop
+          body: This is an automated pull request to update the publicsuffixes file to the latest copy from Mozilla
+          branch: bot/update-psl
+          commit-message: "autofill-parser: update publicsuffixes file"
+          labels: PSL
+          title: Update Public Suffix List data
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -1,5 +1,6 @@
 name: Update Publix Suffix List data
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 6'
 
@@ -22,9 +23,10 @@ jobs:
         uses: burrunan/gradle-cache-action@03c71a8ba93d670980695505f48f49daf43704a6
         if: env.UPDATED == 'true'
         with:
-          arguments: :autofill-parser:test
+          arguments: :autofill-parser:test -PslimTests
 
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@01f7dd1d28f5131231ba3ede0f1c8cb413584a1d
         if: env.UPDATED == 'true'
         with:
@@ -37,3 +39,18 @@ jobs:
           labels: PSL
           title: Update Public Suffix List data
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@36e19d8a79c9c62bf85a0565cb2799a3cf395343
+        with:
+          github-token: ${{ secrets.PSL_UPDATE_TOKEN }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@d2ede5636b3febc92809259995e643565e675aab
+        with:
+          token: ${{ secrets.PSL_UPDATE_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Reverts the auto-push changes from #1494 and converts it to an auto-merge mechanism instead.

## :bulb: Motivation and Context
Our `develop` branch cannot be automatically updated because it requires at least one approving reviewer to allow code changes.

## :green_heart: How did you test it?
:shrug: we'll find out I guess
