### PR TITLE
Turn off configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,6 @@ org.gradle.caching=true
 # Enable filesystem watching
 org.gradle.vfs.watch=true
 
-# Enable experimental configuration caching
-org.gradle.unsafe.configuration-cache=true
-
 # Enable Kotlin incremental compilation
 kotlin.incremental=true
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Configuration cache is still incompatible with a lot of things and using Spotless with it enabled is too much of a headache than it's worth.

## :bulb: Motivation and Context
Fixes failure in snapshot deployment caused by #1542

## :green_heart: How did you test it?
`gradle --no-daemon aNFR` succeeds locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
