### PR TITLE
Skip debuggable checks for logger installation

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/Application.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/Application.kt
@@ -25,6 +25,8 @@ import dev.msfjarvis.aps.util.settings.PreferenceKeys
 import dev.msfjarvis.aps.util.settings.runMigrations
 import javax.inject.Inject
 import logcat.AndroidLogcatLogger
+import logcat.LogPriority.DEBUG
+import logcat.LogcatLogger
 
 @Suppress("Unused")
 @HiltAndroidApp
@@ -41,7 +43,7 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
     if (BuildConfig.ENABLE_DEBUG_FEATURES ||
         prefs.getBoolean(PreferenceKeys.ENABLE_DEBUG_LOGGING, false)
     ) {
-      AndroidLogcatLogger.installOnDebuggableApp(this)
+      LogcatLogger.install(AndroidLogcatLogger(DEBUG))
       StrictMode.setVmPolicy(VmPolicy.Builder().detectAll().penaltyLog().build())
       StrictMode.setThreadPolicy(ThreadPolicy.Builder().detectAll().penaltyLog().build())
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Switches to installing the `AndroidLogcatLogger` by hand, to skip the check in `logcat` library for the debuggable flag.

## :bulb: Motivation and Context
Fixes a regression from #1509 that prevented logging from being enabled in release builds.

## :green_heart: How did you test it?
Turned on debug logging and verified that everything is correctly logged in a snapshot build.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
