### PR TITLE
Implement workarounds for Dependabot to update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+    open-pull-requests-limit: 1
+    labels:
+      - "A-dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/dependency_sync.yml
+++ b/.github/workflows/dependency_sync.yml
@@ -1,0 +1,53 @@
+name: DependencySync
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    branches:
+      - develop
+
+jobs:
+  cancel-other-jobs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # cancel previous jobs
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        env:
+          access_token: '${{ secrets.PSL_UPDATE_TOKEN }}'
+
+  dependency-sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PSL_UPDATE_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK
+        uses : actions/setup-java@v2
+        with :
+          distribution : 'adopt'
+          java-version : '11'
+          cache: 'gradle'
+
+      - uses: gradle/gradle-build-action@cba1833ddecbbee649950c284416981928631008
+        name: run dependencySync
+        with:
+          arguments: |
+            dependencySync
+
+      # If the copy generated changes, commit and push those changes.
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: sync dependency definitions
+          commit_options: '--no-verify --signoff'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
   implementation(libs.compose.foundation.core)
   implementation(libs.compose.foundation.layout)
   implementation(libs.compose.material)
-  implementation(libs.compose.material3)
+  implementation(libs.androidx.compose.material3)
   implementation(libs.compose.ui.core)
   implementation(libs.compose.ui.viewbinding)
   compileOnly(libs.compose.ui.tooling)

--- a/dependency-sync/build.gradle.kts
+++ b/dependency-sync/build.gradle.kts
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+plugins { id("com.rickbusarow.gradle-dependency-sync") version "0.11.4" }
+
+dependencies {
+  val androidx_activity = "1.4.0"
+  val androidx_test = "1.4.1-alpha03"
+  val compose = "1.1.0-beta02"
+  val composeSnapshot = "-"
+  val coroutines = "1.5.2"
+  val flowbinding = "1.2.0"
+  val hilt = "2.40.1"
+  val kotlin = "1.5.31"
+  val lifecycle = "2.4.0"
+
+  dependencySync("com.android.tools.build:gradle:7.0.3")
+  dependencySync("org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0")
+  dependencySync("org.jetbrains.dokka:dokka-gradle-plugin:$kotlin")
+  dependencySync("de.undercouch:gradle-download-task:4.1.2")
+  dependencySync("com.google.dagger:hilt-android-gradle-plugin:$hilt")
+  dependencySync("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin")
+  dependencySync("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
+  dependencySync("com.squareup.okhttp3:okhttp:4.9.0")
+  dependencySync("com.vdurmont:semver4j:3.1.0")
+  dependencySync("com.diffplug.spotless:spotless-plugin-gradle:6.0.0")
+
+  // Kotlin dependencies
+  dependencySync("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines")
+  dependencySync("org.jetbrains.kotlinx:kotlinx-coroutines-core$coroutines")
+
+  // AndroidX dependencies
+  dependencySync("androidx.activity:activity-ktx:$androidx_activity")
+  dependencySync("androidx.activity:activity-compose:$androidx_activity")
+  dependencySync("androidx.annotation:annotation:1.3.0")
+  dependencySync("androidx.autofill:autofill:1.2.0-beta01")
+  dependencySync("androidx.appcompat:appcompat:1.4.0-rc01")
+  dependencySync("androidx.biometric:biometric-ktx:1.2.0-alpha03")
+  dependencySync("androidx.constraintlayout:constraintlayout:2.1.1")
+  dependencySync("androidx.core:core-ktx:1.7.0")
+  dependencySync("androidx.documentfile:documentfile:1.1.0-alpha01")
+  dependencySync("androidx.fragment:fragment-ktx:1.4.0-rc01")
+  dependencySync("androidx.hilt:hilt-navigation-compose:1.0.0-alpha03")
+  dependencySync("androidx.lifecycle:lifecycle-common:$lifecycle")
+  dependencySync("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle")
+  dependencySync("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle")
+  dependencySync("androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07")
+  dependencySync("com.google.android.material:material:1.5.0-beta01")
+  dependencySync("androidx.preference:preference:1.2.0-alpha02")
+  dependencySync("androidx.recyclerview:recyclerview:1.3.0-alpha01")
+  dependencySync("androidx.recyclerview:recyclerview-selection:1.2.0-alpha01")
+  dependencySync("androidx.security:security-crypto:1.1.0-alpha03")
+  dependencySync("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01")
+
+  // Compose dependencies
+  dependencySync("androidx.compose.animation:animation:$compose")
+  dependencySync("androidx.compose.compiler:compiler:$compose")
+  dependencySync("androidx.compose.foundation:foundation:$compose")
+  dependencySync("androidx.compose.foundation:foundation-layout:$compose")
+  dependencySync("androidx.compose.material:material:$compose")
+  dependencySync("androidx.compose.material3:material3:1.0.0-alpha01")
+  dependencySync("androidx.compose.runtime:runtime:$compose")
+  dependencySync("androidx.compose.ui:ui:$compose")
+  dependencySync("androidx.compose.ui:ui-test-junit4:$compose")
+  dependencySync("androidx.compose.ui:ui-tooling:$compose")
+  dependencySync("androidx.compose.ui:ui-util:$compose")
+  dependencySync("androidx.compose.ui:ui-viewbinding:$compose")
+
+  // Dagger/Hilt dependencies
+  dependencySync("com.google.dagger:hilt-android:$hilt")
+  dependencySync("com.google.dagger:hilt-compiler:$hilt")
+  dependencySync("com.google.dagger:hilt-core:$hilt")
+
+  // Desugaring
+  dependencySync("com.android.tools:desugar_jdk_libs:1.1.5")
+
+  // First-party libraries
+  dependencySync("com.github.android-password-store:sublime-fuzzy:1.0.0")
+  dependencySync("com.github.android-password-store:zxing-android-embedded:4.2.1")
+
+  // Third-party dependencies
+  dependencySync("org.bouncycastle:bcprov-jdk15on:1.69")
+  dependencySync("commons-codec:commons-codec:1.14")
+  dependencySync("net.i2p.crypto:eddsa:0.3.0")
+  dependencySync("me.zhanghai.android.fastscroll:library:1.1.7")
+  dependencySync("io.github.reactivecircus.flowbinding:flowbinding-android:$flowbinding")
+  dependencySync("org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r")
+  dependencySync("com.michael-bull.kotlin-result:kotlin-result:1.1.13")
+  dependencySync("com.squareup.leakcanary:leakcanary-android:2.7")
+  dependencySync("com.squareup.logcat:logcat:0.1")
+  dependencySync("de.maxr1998:modernandroidpreferences:2.2.1")
+  dependencySync("org.pgpainless:pgpainless-core:1.0.0-rc1")
+  dependencySync("com.squareup.leakcanary:plumber-android:2.7")
+  dependencySync("com.hierynomus:sshj:0.32.0")
+  dependencySync("com.github.open-keychain.open-keychain:sshauthentication-api:5.7.5")
+  dependencySync("com.github.haroldadmin:WhatTheStack:0.3.1")
+  dependencySync("com.google.android.gms:play-services-auth-api-phone:17.5.1")
+
+  // Testing dependencies
+  dependencySync("junit:junit:4.13.2")
+  dependencySync("org.jetbrains.kotlin:kotlin-test-junit")
+  dependencySync("org.robolectric:robolectric:4.7")
+  dependencySync("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
+  dependencySync("org.jetbrains.kotlin:kotlin-test-junit:1.5.31")
+  dependencySync("com.github.android-password-store:shared-preferences-fake:2.0.0")
+  dependencySync("androidx.test:rules:$androidx_test")
+  dependencySync("androidx.test:runner:$androidx_test")
+  dependencySync("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,100 +11,133 @@ kotlin = "1.5.31"
 lifecycle = "2.4.0"
 
 [libraries]
-# Plugins and other build tooling
-build-agp = "com.android.tools.build:gradle:7.0.3"
-build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0"
-build-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.5.31"
-build-download = "de.undercouch:gradle-download-task:4.1.2"
-build-hilt = "com.google.dagger:hilt-android-gradle-plugin:2.39.1"
-build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
-build-mavenpublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
-build-okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
-build-semver = "com.vdurmont:semver4j:3.1.0"
-build-spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.0.0"
+android-desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.5"
 
-# Kotlin dependencies
-kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-
-# AndroidX dependencies
-androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx_activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx_activity" }
+androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx_activity" }
+
 androidx-annotation = "androidx.annotation:annotation:1.3.0"
-androidx-autofill = "androidx.autofill:autofill:1.2.0-beta01"
+
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.0-rc01"
+
+androidx-autofill = "androidx.autofill:autofill:1.2.0-beta01"
+
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha03"
+
+androidx-compose-material3 = "androidx.compose.material3:material3:1.0.0-alpha01"
+
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.1"
+
 androidx-core-ktx = "androidx.core:core-ktx:1.7.0"
+
 androidx-documentfile = "androidx.documentfile:documentfile:1.1.0-alpha01"
+
 androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0-rc01"
+
 androidx-hilt-compose = "androidx.hilt:hilt-navigation-compose:1.0.0-alpha03"
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref="lifecycle" }
-androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref="lifecycle" }
-androidx-lifecycle-viewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref="lifecycle" }
+
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
+androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07"
+androidx-lifecycle-viewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+
 androidx-material = "com.google.android.material:material:1.5.0-beta01"
+
 androidx-preference = "androidx.preference:preference:1.2.0-alpha02"
+
 androidx-recyclerview = "androidx.recyclerview:recyclerview:1.3.0-alpha01"
 androidx-recyclerviewSelection = "androidx.recyclerview:recyclerview-selection:1.2.0-alpha01"
+
 androidx-security = "androidx.security:security-crypto:1.1.0-alpha03"
+
 androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01"
 
-# Compose dependencies
+androidx-testing-rules = { module = "androidx.test:rules", version.ref = "androidx_test" }
+androidx-testing-runner = { module = "androidx.test:runner", version.ref = "androidx_test" }
+
+aps-sublimeFuzzy = "com.github.android-password-store:sublime-fuzzy:1.0.0"
+aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embedded:4.2.1"
+testing-sharedPrefsMock = "com.github.android-password-store:shared-preferences-fake:2.0.0"
+
+build-agp = "com.android.tools.build:gradle:7.0.3"
+
+build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0"
+kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+build-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.5.31"
+
+build-download = "de.undercouch:gradle-download-task:4.1.2"
+
+build-hilt = "com.google.dagger:hilt-android-gradle-plugin:2.40.1"
+dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }
+
+build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+testing-kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+
+build-mavenpublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+
+build-okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
+
+build-semver = "com.vdurmont:semver4j:3.1.0"
+
+build-spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.0.0"
+
 compose-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
+
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose" }
+
 compose-foundation-core = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }
+
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-material3 = { module = "androidx.compose.material3:material3", version = "1.0.0-alpha01" }
+
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+
 compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
 compose-ui-viewbinding = { module = "androidx.compose.ui:ui-viewbinding", version.ref = "compose" }
 
+testing-junit = "junit:junit:4.13.2"
 
-# Dagger/Hilt dependencies
-dagger-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
-dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
-dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }
+testing-robolectric = "org.robolectric:robolectric:4.7"
 
-# Desugaring
-android-desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.5"
-
-# First-party libraries
-aps-sublimeFuzzy = "com.github.android-password-store:sublime-fuzzy:1.0.0"
-aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embedded:4.2.1"
-
-# Third-party dependencies
 thirdparty-bouncycastle = "org.bouncycastle:bcprov-jdk15on:1.69"
+
 thirdparty-commons_codec = "commons-codec:commons-codec:1.14"
+
 thirdparty-eddsa = "net.i2p.crypto:eddsa:0.3.0"
+
 thirdparty-fastscroll = "me.zhanghai.android.fastscroll:library:1.1.7"
+
 thirdparty-flowbinding-android = { module = "io.github.reactivecircus.flowbinding:flowbinding-android", version.ref = "flowbinding" }
+
 thirdparty-jgit = "org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r"
+
 thirdparty-kotlinResult = "com.michael-bull.kotlin-result:kotlin-result:1.1.13"
+
 thirdparty-leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
-thirdparty-logcat = "com.squareup.logcat:logcat:0.1"
-thirdparty-modernAndroidPrefs = "de.maxr1998:modernandroidpreferences:2.2.1"
-thirdparty-pgpainless = "org.pgpainless:pgpainless-core:1.0.0-rc1"
 thirdparty-plumber = "com.squareup.leakcanary:plumber-android:2.7"
-thirdparty-sshj = "com.hierynomus:sshj:0.32.0"
-thirdparty-sshauth = "com.github.open-keychain.open-keychain:sshauthentication-api:5.7.5"
-thirdparty-whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.1"
+
+thirdparty-logcat = "com.squareup.logcat:logcat:0.1"
+
+thirdparty-modernAndroidPrefs = "de.maxr1998:modernandroidpreferences:2.2.1"
+
 thirdparty-nonfree-googlePlayAuthApiPhone = "com.google.android.gms:play-services-auth-api-phone:17.5.1"
 
-# Testing dependencies
-testing-junit = "junit:junit:4.13.2"
-testing-kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-testing-robolectric = "org.robolectric:robolectric:4.7"
-testing-sharedPrefsMock = "com.github.android-password-store:shared-preferences-fake:2.0.0"
-androidx-testing-rules = { module = "androidx.test:rules", version.ref="androidx_test" }
-androidx-testing-runner = { module = "androidx.test:runner", version.ref="androidx_test" }
-kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+thirdparty-pgpainless = "org.pgpainless:pgpainless-core:1.0.0-rc1"
 
-# Bundles of dependencies usually used together so they can be included in one go
+thirdparty-sshauth = "com.github.open-keychain.open-keychain:sshauthentication-api:5.7.5"
+
+thirdparty-sshj = "com.hierynomus:sshj:0.32.0"
+
+thirdparty-whatthestack = "com.github.haroldadmin:WhatTheStack:0.3.1"
+
 [bundles]
 androidxLifecycle = ["androidx-lifecycle-common", "androidx-lifecycle-livedataKtx", "androidx-lifecycle-viewmodelKtx"]
 testDependencies = ["testing-junit", "testing-kotlintest-junit"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,8 @@ include(":format-common")
 
 include(":openpgp-ktx")
 
+include(":dependency-sync")
+
 // Experimental features
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Leverages https://github.com/RBusarow/gradle-dependency-sync to implement a two-way sync with automation.

This enables the following workflow

- Dependabot scans `dependency-sync/build.gradle.kts` to update dependencies
- It creates a PR for the version bump
- `dependency_sync` workflow runs to sync the update dependency with `gradle/libs.version.toml`
- The PR is updated and kicks off CI checks

## :bulb: Motivation and Context
Fixes #1544

## :green_heart: How did you test it?

https://github.com/msfjarvis/Android-Password-Store/pull/28

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Figure out if there is a way to make Dependabot update to alpha releases
