### PR TITLE
Reorder workflow steps to fix cache failure

### DIFF
--- a/.github/workflows/dependency_sync.yml
+++ b/.github/workflows/dependency_sync.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
         with:
           token: ${{ secrets.PSL_UPDATE_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/deploy_github_releases.yml
+++ b/.github/workflows/deploy_github_releases.yml
@@ -9,15 +9,15 @@ jobs:
     name: Build release binaries
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+
     - name: Set up JDK
       uses : actions/setup-java@v2.4.0
       with :
         distribution : 'zulu'
         java-version : '11'
         cache: 'gradle'
-
-    - name: Checkout repository
-      uses: actions/checkout@v2.4.0
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"

--- a/.github/workflows/deploy_library_releases.yml
+++ b/.github/workflows/deploy_library_releases.yml
@@ -9,15 +9,15 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+
     - name: Set up JDK
       uses : actions/setup-java@v2.4.0
       with :
         distribution : 'zulu'
         java-version : '11'
         cache: 'gradle'
-
-    - name: Checkout repository
-      uses: actions/checkout@v2.4.0
 
     - name: Determine publishing task
       id: task-select

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+
     - name: Set up JDK
       uses : actions/setup-java@v2.4.0
       with :
         distribution : 'zulu'
         java-version : '11'
         cache: 'gradle'
-
-    - name: Checkout repository
-      uses: actions/checkout@v2.4.0
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,13 +9,6 @@ jobs:
     name: "Draft a new release"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK
-        uses : actions/setup-java@v2.4.0
-        with :
-          distribution : 'zulu'
-          java-version : '11'
-          cache: 'gradle'
-
       - name: Extract version from milestone
         run: |
           VERSION="${{ github.event.milestone.title }}"
@@ -41,6 +34,13 @@ jobs:
       - uses: actions/checkout@v2.4.0
         with:
           ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Set up JDK
+        uses : actions/setup-java@v2.4.0
+        with :
+          distribution : 'zulu'
+          java-version : '11'
+          cache: 'gradle'
 
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@1.3.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Moves the `actions/checkout` step before each `actions/setup-java` step to allow Gradle-based caching to work.

## :bulb: Motivation and Context

`actions/setup-java` can cache package dependencies for Gradle and Maven but it tries to use the wrapper.properties file to compute a cache key which isn't present until `actions/checkout` runs so we're reordering all workflows to checkout before setting up Java.
