### PR TITLE
Add code coverage for library modules

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,84 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-codestyle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+
+    - name: Check if relevant files have changed
+      uses: actions/github-script@v4.0.0
+      id: service-changed
+      with:
+        result-encoding: string
+        script: |
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
+
+    - name: Set up JDK
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses : actions/setup-java@v2.4.0
+      with :
+        distribution : 'zulu'
+        java-version : '11'
+        cache: 'gradle'
+
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Check codestyle
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: gradle/gradle-build-action@v2.0.1
+      with:
+        arguments: spotlessCheck
+
   unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+
+    - name: Check if relevant files have changed
+      uses: actions/github-script@v4.0.0
+      id: service-changed
+      with:
+        result-encoding: string
+        script: |
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
+
+    - name: Set up JDK
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses : actions/setup-java@v2.4.0
+      with :
+        distribution : 'zulu'
+        java-version : '11'
+        cache: 'gradle'
+
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Run unit tests
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: gradle/gradle-build-action@v2.0.1
+      with:
+        arguments: test -PslimTests
+
+    - name: (Fail-only) Upload test report
+      if: failure()
+      uses: actions/upload-artifact@v2.2.4
+      with:
+          name: Test report
+          path: app/build/reports
+
+  build-apks:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -42,15 +119,72 @@ jobs:
       with:
         arguments: assembleFreeDebug assembleNonFreeDebug
 
-    - name: Run unit tests
+  check-api:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+
+    - name: Check if relevant files have changed
+      uses: actions/github-script@v4.0.0
+      id: service-changed
+      with:
+        result-encoding: string
+        script: |
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
+
+    - name: Set up JDK
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses : actions/setup-java@v2.4.0
+      with :
+        distribution : 'zulu'
+        java-version : '11'
+        cache: 'gradle'
+
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Check library API
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.0.1
       with:
-        arguments: apiCheck test lintFreeDebug spotlessCheck -PslimTests
+        arguments: apiCheck
 
-    - name: (Fail-only) upload test report
-      if: failure()
-      uses: actions/upload-artifact@v2.2.4
+  lint-debug:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
       with:
-          name: Test report
-          path: app/build/reports
+        fetch-depth: 0
+
+    - name: Check if relevant files have changed
+      uses: actions/github-script@v4.0.0
+      id: service-changed
+      with:
+        result-encoding: string
+        script: |
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
+
+    - name: Set up JDK
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses : actions/setup-java@v2.4.0
+      with :
+        distribution : 'zulu'
+        java-version : '11'
+        cache: 'gradle'
+
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Run Lint on debug variants
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: gradle/gradle-build-action@v2.0.1
+      with:
+        arguments: lintDebug

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -240,7 +240,7 @@ jobs:
         echo ::set-output name=REPORT_PATHS::${REPORTS}
 
     - name: Publish JaCoCo report to PR
-      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      if: false
       uses: madrapps/jacoco-report@v1.2
       with:
         paths: ${{ steps.coverage-export.outputs.REPORT_PATHS }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -188,3 +188,63 @@ jobs:
       uses: gradle/gradle-build-action@v2.0.1
       with:
         arguments: lintDebug
+
+  code-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+
+    - name: Check if relevant files have changed
+      uses: actions/github-script@v4.0.0
+      id: service-changed
+      with:
+        result-encoding: string
+        script: |
+          const script = require('.github/check-changed-files.js')
+          return await script({github, context})
+
+    - name: Set up JDK
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses : actions/setup-java@v2.4.0
+      with :
+        distribution : 'zulu'
+        java-version : '11'
+        cache: 'gradle'
+
+    - name: Copy CI gradle.properties
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Generate coverage reports with kotlinx-kover
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: gradle/gradle-build-action@v2.0.1
+      with:
+        arguments: koverXmlReport
+
+    - name: Collect coverage reports
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: gradle/gradle-build-action@v2.0.1
+      with:
+        arguments: koverCollectReports
+
+    - name: Export coverage XMLs
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      id: coverage-export
+      shell: bash
+      run: |
+        REPORTS="$(find ./build/coverage-reports/ -maxdepth 1 -type f -printf "${GITHUB_WORKSPACE}/%p," -name "*.xml")"
+        REPORTS="${REPORTS::${#REPORTS}-1}"
+        echo ::set-output name=REPORT_PATHS::${REPORTS}
+
+    - name: Publish JaCoCo report to PR
+      if: ${{ steps.service-changed.outputs.result == 'true' }}
+      uses: madrapps/jacoco-report@v1.2
+      with:
+        paths: ${{ steps.coverage-export.outputs.REPORT_PATHS }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 0
+        min-coverage-changed-files: 40
+        title: Code Coverage

--- a/build-logic/kotlin-plugins/build.gradle.kts
+++ b/build-logic/kotlin-plugins/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 dependencies {
   implementation(libs.build.agp)
   implementation(libs.build.binarycompat)
+  implementation(libs.build.kover)
   implementation(libs.build.kotlin)
   implementation(libs.build.spotless)
 }

--- a/build-logic/kotlin-plugins/src/main/kotlin/com.github.android-password-store.kotlin-library.gradle.kts
+++ b/build-logic/kotlin-plugins/src/main/kotlin/com.github.android-password-store.kotlin-library.gradle.kts
@@ -6,7 +6,10 @@
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-plugins { id("com.github.android-password-store.kotlin-common") }
+plugins {
+  id("com.github.android-password-store.kotlin-common")
+  id("org.jetbrains.kotlinx.kover")
+}
 
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
@@ -14,4 +17,8 @@ tasks.withType<KotlinCompile>().configureEach {
       freeCompilerArgs += listOf("-Xexplicit-api=strict")
     }
   }
+}
+
+tasks.koverCollectReports {
+  outputDir.set(rootProject.layout.buildDirectory.dir("coverage-reports"))
 }

--- a/dependency-sync/build.gradle.kts
+++ b/dependency-sync/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   dependencySync("com.squareup.okhttp3:okhttp:4.9.3")
   dependencySync("com.vdurmont:semver4j:3.1.0")
   dependencySync("com.diffplug.spotless:spotless-plugin-gradle:6.0.4")
+  dependencySync("org.jetbrains.kotlinx:kover:0.4.4")
 
   // Kotlin dependencies
   dependencySync("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0-RC")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ testing-sharedPrefsMock = "com.github.android-password-store:shared-preferences-
 build-agp = "com.android.tools.build:gradle:7.0.3"
 
 build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
+build-kover = "org.jetbrains.kotlinx:kover:0.4.4"
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Splits the CI checks into separate jobs and adds kotlinx-kover to generate coverage reports for Kotlin library modules.

## :bulb: Motivation and Context
Fixes #1541 

## :green_heart: How did you test it?

https://github.com/msfjarvis/Android-Password-Store/pull/40

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Figure out a way to present the code-coverage job's output in a better way
