### PR TITLE
Prevent Git files from turning up in search and listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 -   Changing password generator parameters now automatically updates the password without needing to press the 'Generate' button again
 -   The app UI was reskinned to match Google's Material You guidelines
 -   Using HTTPS without authentication is now fully supported, and no longer asks for a username
+-   Enabling 'Show hidden files and folders' no longer shows Git-related files and folders
 
 ## [1.13.5] - 2021-07-28
 

--- a/app/src/main/java/dev/msfjarvis/aps/util/viewmodel/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/viewmodel/SearchableRepositoryViewModel.kt
@@ -242,7 +242,9 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
 
   private fun shouldTake(file: File) =
     with(file) {
-      if (showHiddenContents) return true
+      if (showHiddenContents) {
+        return !file.name.startsWith(".git")
+      }
       if (isDirectory) {
         !isHidden
       } else {
@@ -251,7 +253,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
     }
 
   private fun listFiles(dir: File): Flow<File> {
-    return dir.listFiles { file -> shouldTake(file) }?.asFlow() ?: emptyFlow()
+    return dir.listFiles(::shouldTake)?.asFlow() ?: emptyFlow()
   }
 
   private fun listFilesRecursively(dir: File): Flow<File> {
@@ -266,7 +268,7 @@ class SearchableRepositoryViewModel(application: Application) : AndroidViewModel
         yield()
         it
       }
-      .filter { file -> shouldTake(file) }
+      .filter(::shouldTake)
   }
 
   private val _currentDir = MutableLiveData(root)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Ignores files and folders that start with `.git` from search and listing


## :bulb: Motivation and Context

Fixes #1453

## :green_heart: How did you test it?

Turned on show hidden option and verified `.git/` does not show in the password list.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
