### PR TITLE
Miscellaneous build and CI cleanups

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -224,12 +224,6 @@ jobs:
       with:
         arguments: koverXmlReport
 
-    - name: Collect coverage reports
-      if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: gradle/gradle-build-action@v2.0.1
-      with:
-        arguments: koverCollectReports
-
     - name: Export coverage XMLs
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       id: coverage-export

--- a/autofill-parser/build.gradle.kts
+++ b/autofill-parser/build.gradle.kts
@@ -4,11 +4,9 @@
  */
 
 plugins {
-  id("com.github.android-password-store.android-library")
+  id("com.github.android-password-store.published-android-library")
   id("com.github.android-password-store.kotlin-android")
   id("com.github.android-password-store.kotlin-library")
-  id("com.vanniktech.maven.publish")
-  id("org.jetbrains.dokka")
   id("com.github.android-password-store.psl-plugin")
 }
 

--- a/build-logic/android-plugins/build.gradle.kts
+++ b/build-logic/android-plugins/build.gradle.kts
@@ -19,5 +19,7 @@ gradlePlugin {
 
 dependencies {
   implementation(libs.build.agp)
+  implementation(libs.build.dokka)
+  implementation(libs.build.mavenpublish)
   implementation(libs.build.semver)
 }

--- a/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.android-library.gradle.kts
+++ b/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.android-library.gradle.kts
@@ -3,18 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.plugins.signing.SigningExtension
-
 plugins {
   id("com.android.library")
   id("com.github.android-password-store.android-common")
-}
-
-afterEvaluate {
-  extensions.configure<SigningExtension> {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-  }
 }

--- a/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.published-android-library.gradle.kts
+++ b/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.published-android-library.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.plugins.signing.SigningExtension
+
+plugins {
+  id("com.github.android-password-store.android-library")
+  id("com.vanniktech.maven.publish")
+  id("org.jetbrains.dokka")
+}
+
+afterEvaluate {
+  extensions.configure<SigningExtension> {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+  }
+}

--- a/build-logic/kotlin-plugins/src/main/kotlin/com.github.android-password-store.kotlin-library.gradle.kts
+++ b/build-logic/kotlin-plugins/src/main/kotlin/com.github.android-password-store.kotlin-library.gradle.kts
@@ -19,6 +19,10 @@ tasks.withType<KotlinCompile>().configureEach {
   }
 }
 
-tasks.koverCollectReports {
-  outputDir.set(rootProject.layout.buildDirectory.dir("coverage-reports"))
+tasks.koverXmlReport {
+  xmlReportFile.set(rootProject.layout.buildDirectory.file("coverage-reports/${project.name}.xml"))
+}
+
+tasks.koverHtmlReport {
+  htmlReportDir.set(rootProject.layout.buildDirectory.dir("coverage-reports/${project.name}"))
 }

--- a/dependency-sync/build.gradle.kts
+++ b/dependency-sync/build.gradle.kts
@@ -9,9 +9,11 @@ dependencies {
   // Build tooling
   dependencySync("com.android.tools.build:gradle:7.0.3")
   dependencySync("org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0")
+  dependencySync("org.jetbrains.dokka:dokka-gradle-plugin:1.6.0")
   dependencySync("de.undercouch:gradle-download-task:4.1.2")
   dependencySync("com.google.dagger:hilt-android-gradle-plugin:2.40.5")
   dependencySync("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
+  dependencySync("com.vanniktech:gradle-maven-publish-plugin:0.18.0")
   dependencySync("com.squareup.okhttp3:okhttp:4.9.3")
   dependencySync("com.vdurmont:semver4j:3.1.0")
   dependencySync("com.diffplug.spotless:spotless-plugin-gradle:6.0.4")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,8 @@ kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
+build-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.0"
+
 build-download = "de.undercouch:gradle-download-task:4.1.2"
 
 build-hilt = "com.google.dagger:hilt-android-gradle-plugin:2.40.5"
@@ -76,6 +78,8 @@ dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt
 
 build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
 testing-kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+
+build-mavenpublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
 
 build-okhttp = "com.squareup.okhttp3:okhttp:4.9.3"
 

--- a/openpgp-ktx/build.gradle.kts
+++ b/openpgp-ktx/build.gradle.kts
@@ -4,11 +4,9 @@
  */
 
 plugins {
-  id("com.github.android-password-store.android-library")
+  id("com.github.android-password-store.published-android-library")
   id("com.github.android-password-store.kotlin-android")
   id("com.github.android-password-store.kotlin-library")
-  id("com.vanniktech.maven.publish")
-  id("org.jetbrains.dokka")
 }
 
 android {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+rootProject.name = "APS"
+
 // Plugin repositories
 pluginManagement {
   repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,10 +13,6 @@ pluginManagement {
     mavenCentral()
     gradlePluginPortal()
   }
-  plugins {
-    id("com.vanniktech.maven.publish") version "0.18.0" apply false
-    id("org.jetbrains.dokka") version "1.6.0" apply false
-  }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

﻿- Set rootProject name
- Revert "gradle: add Maven Publish and Dokka plugins to root"
- Introduce a separate plugin for published libraries
- Configure kover tasks to directly output to a shared directory
- Remove unnecessary report collection step

## :bulb: Motivation and Context

- Setting a shorter rootProject name explicitly makes it easier to look at all the individual plugin files in the sidebar
- Having a separate plugin for published libraries makes it easier to add internal library modules
- Making report collection implicitly happen in the generation task itself saves a workflow step in CI

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
