### PR TITLE
gradle: turn off Configure-On-Demand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
 org.gradle.parallel=true
-org.gradle.configureondemand=true
+org.gradle.configureondemand=false
 org.gradle.caching=true
 
 # Enable filesystem watching


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Turns off C-O-D

## :bulb: Motivation and Context

Running tasks with `gradle :project:task` is currently broken due to [this](https://github.com/gradle/gradle/issues/4823) Gradle bug, so we're turning off C-O-D in accordance with the advice in the issue.

## :green_heart: How did you test it?

`gradle :app:aNFR :app:aFR`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
