### PR TITLE
Tweak PSL automerge to use GH CLI

### DIFF
--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -43,21 +43,17 @@ jobs:
           body: This is an automated pull request to update the publicsuffixes file to the latest copy from Mozilla
           branch: bot/update-psl
           commit-message: "autofill-parser: update publicsuffixes file"
-          labels: PSL
+          labels: A-PSL
           title: Update Public Suffix List data
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto approve
+      - name: Close, re-open and enable squash merge for PR
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: juliangruber/approve-pull-request-action@v1.1.0
-        with:
-          github-token: ${{ secrets.PSL_UPDATE_TOKEN }}
-          number: ${{ steps.cpr.outputs.pull-request-number }}
-
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v1.1.0
-        with:
-          token: ${{ secrets.PSL_UPDATE_TOKEN }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+        shell: bash
+        run: |
+          gh pr close "${PR_URL}"
+          gh pr reopen "${PR_URL}"
+          gh pr merge --squash --auto "${PR_URL}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PSL_UPDATE_TOKEN }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Replaces use of separate Actions for automerge and approval with the `gh` CLI.

## :bulb: Motivation and Context

I read a [blog post](https://github.blog/2021-03-11-scripting-with-github-cli/#using-gh-in-github-actions).

## :green_heart: How did you test it?

:shrug:
