### PR TITLE
Increase timeouts for Crowdin API build task

### DIFF
--- a/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
+++ b/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
@@ -7,6 +7,7 @@ package crowdin
 
 import de.undercouch.gradle.tasks.download.Download
 import java.io.File
+import java.util.concurrent.TimeUnit
 import javax.xml.parsers.DocumentBuilderFactory
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -45,7 +46,13 @@ class CrowdinDownloadPlugin : Plugin<Project> {
             if (!key.isPresent) {
               throw GradleException("CROWDIN_PROJECT_KEY environment variable must be set")
             }
-            val client = OkHttpClient()
+            val client =
+              OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .writeTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(5, TimeUnit.SECONDS)
+                .callTimeout(10, TimeUnit.SECONDS)
+                .build()
             val url = CROWDIN_BUILD_API_URL.format(projectName, login.get(), key.get())
             val request = Request.Builder().url(url).get().build()
             client.newCall(request).execute()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Increases the network timeout for the `buildOnApi` Crowdin task

## :bulb: Motivation and Context

After a strings update Crowdin may take a few seconds to actually do a build which causes the task to fail the first time due to a timeout exception.

## :green_heart: How did you test it?

`gradle crowdin`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable