### PR TITLE
Recognize mail as alternative to email

### DIFF
--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -216,6 +216,7 @@ constructor(
         "user:",
         "account:",
         "email:",
+        "mail:",
         "name:",
         "handle:",
         "id:",

--- a/format-common/src/test/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntryTest.kt
+++ b/format-common/src/test/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntryTest.kt
@@ -119,6 +119,7 @@ class PasswordEntryTest {
     assertEquals("foo@example.com", makeEntry("\nemail: foo@example.com").username)
     assertEquals("username", makeEntry("\nidentity: username\nlogin: another_username").username)
     assertEquals("username", makeEntry("\nLOGiN:username").username)
+    assertEquals("foo@example.com", makeEntry("pass\nmail:    foo@example.com").username)
     assertNull(makeEntry("secret\nextra\ncontent\n").username)
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->

Currently I do use `mail: ` rather than `email: ` locally, I think it would be good to have it as well.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I used mail rather than email because it looks nice since both `mail` and `user` have 4 characters and it aligns together.

## :green_heart: How did you test it?

No

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
