### PR TITLE
Restore Bromite support in autofill-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ All notable changes to this project will be documented in this file.
 -   The settings UI has been completely re-done to dramatically improve discoverability and navigation for users
 -   Using the `git://` protocol in the server URL now presents an explicit discouragement rather than a generic error
 -   Encrypted data is no longer ASCII armored, bringing it in line with `pass`
--   Removed Bromite from supported Autofill browsers, since they [disable Android autofill](https://github.com/bromite/bromite/blob/master/FAQ.md#does-bromite-support-the-android-autofill-framework).
 -   Changing password generator parameters now automatically updates the password without needing to press the 'Generate' button again
 -   The app UI was reskinned to match Google's Material You guidelines
 -   Using HTTPS without authentication is now fully supported, and no longer asks for a username

--- a/app/src/main/res/xml/oreo_autofill_service.xml
+++ b/app/src/main/res/xml/oreo_autofill_service.xml
@@ -15,6 +15,7 @@
   <compatibility-package android:name="com.microsoft.emmx" />
   <compatibility-package android:name="com.opera.mini.native" />
   <compatibility-package android:name="com.opera.mini.native.beta" />
+  <compatibility-package android:name="org.bromite.bromite" />
   <compatibility-package
     android:name="org.mozilla.fennec_fdroid"
     android:maxLongVersionCode="679999" />

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -6,13 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Changed the support level for Chrome Beta/Canary/Dev/Stable and Ungoogled Chromium to `PasswordFillAndSaveIfNoAccessibility`.
+- Changed the support level for Chrome Beta/Canary/Dev/Stable, Bromite and Ungoogled Chromium to `PasswordFillAndSaveIfNoAccessibility`.
 
 - Updated `androidx.annotation` to 1.1.0 and `androidx.autofill` to `1.2.0-alpha01`.
 
 - The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
-
-- Removed Bromite from supported Autofill browsers, since they [disable Android autofill](https://github.com/bromite/bromite/blob/master/FAQ.md#does-bromite-support-the-android-autofill-framework).
 
 - Added [Styx](https://github.com/jamal2362/Styx) to supported Autofill browsers.
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -72,6 +72,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "com.opera.mini.native" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.mini.native.beta" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.touch" to arrayOf("qtjiBNJNF3k0yc0MY8xqo4779CxKaVcJfiIQ9X+qZ6o="),
+    "org.bromite.bromite" to arrayOf("4e5c0HbXsNyEyytF+3i4bfLrOaO2xWuj3CkqXgw7lQQ="),
     "org.gnu.icecat" to arrayOf("wi2iuVvK/WYZUzd2g0Qzn9ef3kAisQURZ8U1WSMTkcM="),
     "org.mozilla.fenix" to arrayOf("UAR3kIjn+YjVvFzF+HmP6/T4zQhKGypG79TI7krq8hE="),
     "org.mozilla.fenix.nightly" to arrayOf("d+rEzu02r++6dheZMd1MwZWrDNVLrzVdIV57vdKOQCo="),
@@ -160,6 +161,7 @@ private val BROWSER_SAVE_FLAG_IF_NO_ACCESSIBILITY =
     "com.chrome.beta" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.canary" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.dev" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
+    "org.bromite.bromite" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "org.ungoogled.chromium.stable" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
   )
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Reintroduces autofill support for Bromite.

## :bulb: Motivation and Context

Bromite supports Autofill again since version [v94.0.4606.109](https://github.com/bromite/bromite/blob/master/CHANGELOG.md#9404606109).

## :green_heart: How did you test it?

Verified I am able to autofill into GitHub with Bromite.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
