### PR TITLE
Release new version of autofill-parser

### DIFF
--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -8,11 +8,15 @@ All notable changes to this project will be documented in this file.
 
 - Changed the support level for Chrome Beta/Canary/Dev/Stable, Bromite and Ungoogled Chromium to `PasswordFillAndSaveIfNoAccessibility`.
 
-- Updated `androidx.annotation` to 1.1.0 and `androidx.autofill` to `1.2.0-alpha01`.
+- Updated `androidx.annotation` to 1.3.0 and `androidx.autofill` to `1.2.0-beta01`.
 
-- The library now requires Kotlin 1.5.0 configured with `kotlinOptions.languageVersion = "1.5"`.
+- The library now uses Kotlin 1.6.10 and Coroutines 1.6.0.
 
 - Added [Styx](https://github.com/jamal2362/Styx) to supported Autofill browsers.
+
+- The dependency on [timberkt](https://github.com/ajalt/timberkt) has been replaced with [logcat](https://github.com/square/logcat).
+
+- Updated `publicsuffixes` list to the latest version as of Dec 18 2021.
 
 ### Fixed
 

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [1.1.0]
+
 ### Changed
 
 - Changed the support level for Chrome Beta/Canary/Dev/Stable, Bromite and Ungoogled Chromium to `PasswordFillAndSaveIfNoAccessibility`.
@@ -35,3 +37,5 @@ All notable changes to this project will be documented in this file.
 - Initial release
 
 [1.0.0]: https://github.com/android-password-store/Android-Password-Store/commits/autofill-parser-v1.0.0/autofill-parser
+
+[1.1.0]: https://github.com/android-password-store/Android-Password-Store/commits/autofill-parser-v1.1.0/autofill-parser

--- a/autofill-parser/gradle.properties
+++ b/autofill-parser/gradle.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 #
 
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=1.1.0
 POM_ARTIFACT_ID=autofill-parser
 POM_NAME=autofill-parser
 POM_DESCRIPTION=Android library for low-level parsing of Autofill structures


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Library release

## :scroll: Description

Releases a new version of the autofill-parser library

## :bulb: Motivation and Context

It's been over a year since the last release and we've accumulated enough non-breaking changes to justify not sitting on them any longer.

## :green_heart: How did you test it?

APS has thoroughly exercised the library throughout this period.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
