### PR TITLE
Add Mull to autofill supported browsers

### DIFF
--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- [Mull](https://f-droid.org/packages/us.spotco.fennec_dos/) is now supported as an Autofill-capable browser.
+
 ## [1.1.0]
 
 ### Changed

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -87,6 +87,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "org.ungoogled.chromium.extensions.stable" to
       arrayOf("29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk="),
     "com.kiwibrowser.browser" to arrayOf("wGnqlmMy6R4KDDzFd+b1Cf49ndr3AVrQxcXvj9o/hig="),
+    "us.spotco.fennec_dos" to arrayOf("/4H1vlY5ZZTu5w/vKDIlbhUhQSLiupzt0mAF/9S8qqg="),
   )
 
 private fun isTrustedBrowser(context: Context, appPackage: String): Boolean {
@@ -128,6 +129,7 @@ private val BROWSER_MULTI_ORIGIN_METHOD =
     "org.mozilla.focus" to BrowserMultiOriginMethod.Field,
     "org.mozilla.klar" to BrowserMultiOriginMethod.Field,
     "org.torproject.torbrowser" to BrowserMultiOriginMethod.WebView,
+    "us.spotco.fennec_dos" to BrowserMultiOriginMethod.Field,
   )
 
 private fun getBrowserMultiOriginMethod(appPackage: String): BrowserMultiOriginMethod =


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds the Firefox fork [Mull](https://f-droid.org/packages/us.spotco.fennec_dos/) as an autofill supported browser

Fixes #1639 

## :green_heart: How did you test it?

Verified I can fill into web forms correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
