### PR TITLE
Raise timeouts for Crowdin task again

### DIFF
--- a/.github/workflows/sync_crowdin.yml
+++ b/.github/workflows/sync_crowdin.yml
@@ -1,5 +1,6 @@
 name: Sync localisations from Crowdin
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 6'
 

--- a/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
+++ b/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
@@ -49,10 +49,10 @@ class CrowdinDownloadPlugin : Plugin<Project> {
               }
               val client =
                 OkHttpClient.Builder()
-                  .connectTimeout(5, TimeUnit.SECONDS)
-                  .writeTimeout(5, TimeUnit.SECONDS)
-                  .readTimeout(5, TimeUnit.SECONDS)
-                  .callTimeout(10, TimeUnit.SECONDS)
+                  .connectTimeout(5, TimeUnit.MINUTES)
+                  .writeTimeout(5, TimeUnit.MINUTES)
+                  .readTimeout(5, TimeUnit.MINUTES)
+                  .callTimeout(10, TimeUnit.MINUTES)
                   .build()
               val url = CROWDIN_BUILD_API_URL.format(projectName, login.get(), key.get())
               val request = Request.Builder().url(url).get().build()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Raises the network timeouts for the Crowdin tasks to 60x the previous amount.

Also adds the ability to run the Crowdin job manually.

## :bulb: Motivation and Context

The scheduled job for updating translations is still registering [occasional failures](https://github.com/android-password-store/Android-Password-Store/runs/4629528534?check_suite_focus=true) from timeouts.

## :green_heart: How did you test it?

`gradle crowdin`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
