### PR TITLE
Delete empty values directories in Crowdin cleanup

### DIFF
--- a/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
+++ b/build-logic/automation-plugins/src/main/kotlin/crowdin/CrowdinPlugin.kt
@@ -84,10 +84,10 @@ class CrowdinDownloadPlugin : Plugin<Project> {
           doLast {
             val sourceSets = arrayOf("main", "nonFree")
             for (sourceSet in sourceSets) {
-              val stringFiles =
-                File("${projectDir}/src/$sourceSet").walkTopDown().filter {
-                  it.name == "strings.xml"
-                }
+              val fileTreeWalk = projectDir.resolve("src/$sourceSet").walkTopDown()
+              val valuesDirectories =
+                fileTreeWalk.filter { it.isDirectory }.filter { it.name.startsWith("values") }
+              val stringFiles = fileTreeWalk.filter { it.name == "strings.xml" }
               val sourceFile =
                 stringFiles.firstOrNull { it.path.endsWith("values/strings.xml") }
                   ?: throw GradleException("No root strings.xml found in '$sourceSet' sourceSet")
@@ -101,6 +101,11 @@ class CrowdinDownloadPlugin : Plugin<Project> {
                   if (stringCount < threshold) {
                     file.delete()
                   }
+                }
+              }
+              valuesDirectories.forEach { dir ->
+                if (dir.listFiles().isNullOrEmpty()) {
+                  dir.delete()
                 }
               }
             }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Find and delete all empty `values-*` directories in the cleanup phase of the Crowdin plugin task.

## :bulb: Motivation and Context

Crowdin dumps a lot of empty folders which results in failed builds due to incorrect/invalid country codes for languages that have no translations in the first place.
## :green_heart: How did you test it?

`gradle crowdin && git clean -fdx app/src` returned no empty directories that were being cleaned by Git.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
