### PR TITLE
Add support for properly dealing with incorrect passwords

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/data/crypto/CryptoRepository.kt
@@ -42,7 +42,7 @@ constructor(
   ) {
     val keys = pgpKeyManager.getAllKeys().unwrap()
     // Iterates through the keys until the first successful decryption, then returns.
-    keys.first { key ->
+    keys.firstOrNull { key ->
       runCatching { pgpCryptoHandler.decrypt(key, password, message, out) }.isOk()
     }
   }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
@@ -44,6 +44,7 @@ class DecryptActivityV2 : BasePgpActivity() {
   private val relativeParentPath by unsafeLazy { getParentPath(fullPath, repoPath) }
 
   private var passwordEntry: PasswordEntry? = null
+  private var retries = 0
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -129,6 +130,11 @@ class DecryptActivityV2 : BasePgpActivity() {
   }
 
   private fun decrypt(isError: Boolean) {
+    if (retries < MAX_RETRIES) {
+      retries += 1
+    } else {
+      finish()
+    }
     val dialog = PasswordDialog()
     if (isError) {
       dialog.setError()
@@ -199,4 +205,8 @@ class DecryptActivityV2 : BasePgpActivity() {
         }
       }
     }
+
+  private companion object {
+    private const val MAX_RETRIES = 3
+  }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
@@ -9,6 +9,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.WindowManager
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -33,6 +34,7 @@ class PasswordDialog : DialogFragment() {
     builder.setTitle(R.string.password)
     builder.setPositiveButton(android.R.string.ok) { _, _ -> tryEmitPassword() }
     val dialog = builder.create()
+    dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
     dialog.setOnShowListener {
       if (isError) {
         binding.passwordField.error = getString(R.string.git_operation_wrong_password)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.aps.ui.crypto
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dev.msfjarvis.aps.R
@@ -28,15 +29,27 @@ class PasswordDialog : DialogFragment() {
     val builder = MaterialAlertDialogBuilder(requireContext())
     builder.setView(binding.root)
     builder.setTitle(R.string.password)
-    builder.setPositiveButton(android.R.string.ok) { _, _ ->
-      do {} while (!_password.tryEmit(binding.passwordEditText.text.toString()))
-      dismiss()
+    builder.setPositiveButton(android.R.string.ok) { _, _ -> tryEmitPassword() }
+    val dialog = builder.create()
+    dialog.setOnShowListener {
+      binding.passwordEditText.setOnKeyListener { _, keyCode, _ ->
+        if (keyCode == KeyEvent.KEYCODE_ENTER) {
+          tryEmitPassword()
+          return@setOnKeyListener true
+        }
+        false
+      }
     }
-    return builder.create()
+    return dialog
   }
 
   override fun onCancel(dialog: DialogInterface) {
     super.onCancel(dialog)
     finish()
+  }
+
+  @Suppress("ControlFlowWithEmptyBody")
+  private fun tryEmitPassword() {
+    do {} while (!_password.tryEmit(binding.passwordEditText.text.toString()))
   }
 }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/PasswordDialog.kt
@@ -9,6 +9,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dev.msfjarvis.aps.R
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.asStateFlow
 class PasswordDialog : DialogFragment() {
 
   private val binding by unsafeLazy { DialogPasswordEntryBinding.inflate(layoutInflater) }
+  private var isError: Boolean = false
   private val _password = MutableStateFlow<String?>(null)
   val password = _password.asStateFlow()
 
@@ -32,6 +34,10 @@ class PasswordDialog : DialogFragment() {
     builder.setPositiveButton(android.R.string.ok) { _, _ -> tryEmitPassword() }
     val dialog = builder.create()
     dialog.setOnShowListener {
+      if (isError) {
+        binding.passwordField.error = getString(R.string.git_operation_wrong_password)
+      }
+      binding.passwordEditText.doOnTextChanged { _, _, _, _ -> binding.passwordField.error = null }
       binding.passwordEditText.setOnKeyListener { _, keyCode, _ ->
         if (keyCode == KeyEvent.KEYCODE_ENTER) {
           tryEmitPassword()
@@ -43,6 +49,10 @@ class PasswordDialog : DialogFragment() {
     return dialog
   }
 
+  fun setError() {
+    isError = true
+  }
+
   override fun onCancel(dialog: DialogInterface) {
     super.onCancel(dialog)
     finish()
@@ -51,5 +61,6 @@ class PasswordDialog : DialogFragment() {
   @Suppress("ControlFlowWithEmptyBody")
   private fun tryEmitPassword() {
     do {} while (!_password.tryEmit(binding.passwordEditText.text.toString()))
+    dismissAllowingStateLoss()
   }
 }

--- a/app/src/main/res/layout/dialog_password_entry.xml
+++ b/app/src/main/res/layout/dialog_password_entry.xml
@@ -24,6 +24,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:inputType="textPassword" />
+    <requestFocus />
   </com.google.android.material.textfield.TextInputLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

- Update `PasswordDialog` to support showing an error, to submit on error, and request focus on the edit text
- Adds support for a max of 3 retries in `DecryptActivityV2` for incorrect passwords

## :bulb: Motivation and Context

Improves UX for incorrect passwords which currently force the app to crash.

## :green_heart: How did you test it?

Enter incorrect passwords

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
