### PR TITLE
Ensure V2 backend is supported by launcher shortcuts

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/main/LaunchActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/main/LaunchActivity.kt
@@ -10,15 +10,23 @@ import android.os.Handler
 import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
+import dagger.hilt.android.AndroidEntryPoint
 import dev.msfjarvis.aps.ui.crypto.BasePgpActivity
 import dev.msfjarvis.aps.ui.crypto.DecryptActivity
+import dev.msfjarvis.aps.ui.crypto.DecryptActivityV2
 import dev.msfjarvis.aps.ui.passwords.PasswordStore
 import dev.msfjarvis.aps.util.auth.BiometricAuthenticator
 import dev.msfjarvis.aps.util.auth.BiometricAuthenticator.Result
 import dev.msfjarvis.aps.util.extensions.sharedPrefs
+import dev.msfjarvis.aps.util.features.Feature
+import dev.msfjarvis.aps.util.features.Features
 import dev.msfjarvis.aps.util.settings.PreferenceKeys
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class LaunchActivity : AppCompatActivity() {
+
+  @Inject lateinit var features: Features
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -44,10 +52,18 @@ class LaunchActivity : AppCompatActivity() {
     }
   }
 
+  private fun getDecryptIntent(): Intent {
+    return if (features.isEnabled(Feature.EnablePGPainlessBackend)) {
+      Intent(this, DecryptActivityV2::class.java)
+    } else {
+      Intent(this, DecryptActivity::class.java)
+    }
+  }
+
   private fun startTargetActivity(noAuth: Boolean) {
     val intentToStart =
       if (intent.action == ACTION_DECRYPT_PASS)
-        Intent(this, DecryptActivity::class.java).apply {
+        getDecryptIntent().apply {
           putExtra(
             BasePgpActivity.EXTRA_FILE_PATH,
             intent.getStringExtra(BasePgpActivity.EXTRA_FILE_PATH)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds V2 backend support to launcher shortcut handling.

## :bulb: Motivation and Context

Without this launcher shortcuts unconditionally triggered the older OpenKeychain backend.

## :green_heart: How did you test it?

Click on a launcher shortcut with V2 backend enabled and observe the right activity is launched.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
