### PR TITLE
Upgrade to AGP 7.1.0-rc01

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,10 +60,11 @@ android {
   buildFeatures.compose = true
 
   lint {
-    isAbortOnError = true
-    isCheckReleaseBuilds = false
-    disable("MissingTranslation", "PluralsCandidate", "ImpliedQuantity")
-    disable("CoroutineCreationDuringComposition")
+    abortOnError = true
+    checkReleaseBuilds = false
+    disable.add("MissingTranslation")
+    disable.add("PluralsCandidate")
+    disable.add("ImpliedQuantity")
   }
 
   composeOptions { kotlinCompilerExtensionVersion = libs.versions.compose.get() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.
 aps-sublimeFuzzy = "com.github.android-password-store:sublime-fuzzy:2.0.0"
 aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embedded:4.2.1"
 
-build-agp = "com.android.tools.build:gradle:7.0.4"
+build-agp = "com.android.tools.build:gradle:7.1.0-rc01"
 build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
 build-kover = "org.jetbrains.kotlinx:kover:0.4.4"
 build-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## :scroll: Description

Upgrades build to use AGP 7.1.x track

## :bulb: Motivation and Context

AGP 7.1.x is close to stabilization so we can do an early upgrade while we do not have the overhead of having to care about F-Droid.

## :green_heart: How did you test it?

Pre-push hooks

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
