### PR TITLE
Make Autofill intents mutable

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivity.kt
@@ -79,7 +79,7 @@ class AutofillDecryptActivity : AppCompatActivity() {
           context,
           decryptFileRequestCode++,
           intent,
-          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
         .intentSender
     }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillDecryptActivityV2.kt
@@ -67,7 +67,7 @@ class AutofillDecryptActivityV2 : AppCompatActivity() {
           context,
           decryptFileRequestCode++,
           intent,
-          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
         .intentSender
     }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterView.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillFilterView.kt
@@ -74,7 +74,7 @@ class AutofillFilterView : AppCompatActivity() {
           context,
           matchAndDecryptFileRequestCode++,
           intent,
-          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
         .intentSender
     }

--- a/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillPublisherChangedActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/autofill/AutofillPublisherChangedActivity.kt
@@ -54,7 +54,7 @@ class AutofillPublisherChangedActivity : AppCompatActivity() {
           context,
           publisherChangedRequestCode++,
           intent,
-          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+          PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
         .intentSender
     }

--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillViewUtils.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillViewUtils.kt
@@ -56,7 +56,7 @@ fun makeInlinePresentation(
       context,
       0,
       Intent(context, PasswordStore::class.java),
-      PendingIntent.FLAG_IMMUTABLE
+      PendingIntent.FLAG_MUTABLE
     )
   val slice =
     InlineSuggestionUi.newContentBuilder(launchIntent).run {

--- a/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/services/ClipboardService.kt
@@ -119,7 +119,7 @@ class ClipboardService : Service() {
           this,
           0,
           clearIntent,
-          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
         )
       }
     val notification =


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Flips Autofill related intents to use `FLAG_MUTABLE` instead of `FLAG_IMMUTABLE`.

## :bulb: Motivation and Context

Since #1655 autofill intents were broken due to the intent created by the autofill service being immutable when they needed to be mutable.

Fixes #1681

## :green_heart: How did you test it?

Verified I can use autofill actions on webpages.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
