### PR TITLE
Add the ability to run garbage collection on the internal Git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   Another workaround for SteamGuard's non-standard OTP format
 -   Allow importing QR code from images
 -   Introduce a new opt-in PGP backend powered by [PGPainless](https://github.com/pgpainless/pgpainless) that does not require OpenKeychain
+-   Add the ability to run garbage collection on the internal Git repository
 
 ### Fixed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
@@ -78,7 +78,12 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
         GitOp.BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(this)
         GitOp.RESET -> ResetToRemoteOperation(this)
       }
-    return op.executeAfterAuthentication(gitSettings.authMode).mapError(::transformGitError)
+    return (if (op.requiresAuth) {
+        op.executeAfterAuthentication(gitSettings.authMode)
+      } else {
+        op.execute()
+      })
+      .mapError(::transformGitError)
   }
 
   fun finishOnSuccessHandler(@Suppress("UNUSED_PARAMETER") nothing: Unit) {

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/base/BaseGitActivity.kt
@@ -19,6 +19,7 @@ import dev.msfjarvis.aps.util.extensions.sharedPrefs
 import dev.msfjarvis.aps.util.git.ErrorMessages
 import dev.msfjarvis.aps.util.git.operation.BreakOutOfDetached
 import dev.msfjarvis.aps.util.git.operation.CloneOperation
+import dev.msfjarvis.aps.util.git.operation.GcOperation
 import dev.msfjarvis.aps.util.git.operation.PullOperation
 import dev.msfjarvis.aps.util.git.operation.PushOperation
 import dev.msfjarvis.aps.util.git.operation.ResetToRemoteOperation
@@ -51,6 +52,7 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
     PUSH,
     RESET,
     SYNC,
+    GC,
   }
 
   @Inject lateinit var gitSettings: GitSettings
@@ -77,6 +79,7 @@ abstract class BaseGitActivity : ContinuationContainerActivity() {
         GitOp.SYNC -> SyncOperation(this, gitSettings.rebaseOnPull)
         GitOp.BREAK_OUT_OF_DETACHED -> BreakOutOfDetached(this)
         GitOp.RESET -> ResetToRemoteOperation(this)
+        GitOp.GC -> GcOperation(this)
       }
     return (if (op.requiresAuth) {
         op.executeAfterAuthentication(gitSettings.authMode)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitConfigActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitConfigActivity.kt
@@ -124,6 +124,15 @@ class GitConfigActivity : BaseGitActivity() {
           )
       }
     }
+    binding.gitGc.setOnClickListener {
+      lifecycleScope.launch {
+        launchGitOperation(GitOp.GC)
+          .fold(
+            success = ::finishOnSuccessHandler,
+            failure = { err -> promptOnErrorHandler(err) { finish() } },
+          )
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GcOperation.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GcOperation.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2014-2022 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package dev.msfjarvis.aps.util.git.operation
+
+import dev.msfjarvis.aps.util.git.sshj.ContinuationContainerActivity
+import org.eclipse.jgit.api.GitCommand
+
+/**
+ * Run an aggressive garbage collection job on the repository, expiring every loose object to
+ * achieve the best compression.
+ */
+class GcOperation(
+  callingActivity: ContinuationContainerActivity,
+) : GitOperation(callingActivity) {
+
+  override val requiresAuth: Boolean = false
+  override val commands: Array<GitCommand<out Any>> =
+    arrayOf(git.gc().setAggressive(true).setExpire(null))
+}

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GitOperation.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GitOperation.kt
@@ -57,7 +57,11 @@ import org.eclipse.jgit.transport.URIish
  */
 abstract class GitOperation(protected val callingActivity: FragmentActivity) {
 
+  /** List of [GitCommand]s that are executed by an operation. */
   abstract val commands: Array<GitCommand<out Any>>
+
+  /** Whether the operation requires authentication or not. */
+  open val requiresAuth: Boolean = true
   private val hostKeyFile = callingActivity.filesDir.resolve(".host_key")
   private var sshSessionFactory: SshjSessionFactory? = null
   private val hiltEntryPoint =

--- a/app/src/main/res/layout/activity_git_config.xml
+++ b/app/src/main/res/layout/activity_git_config.xml
@@ -102,4 +102,12 @@
     android:text="@string/reset_to_remote"
     app:layout_constraintTop_toBottomOf="@id/git_abort_rebase" />
 
+  <com.google.android.material.button.MaterialButton
+    android:id="@+id/git_gc"
+    android:layout_marginTop="8dp"
+    android:text="@string/git_run_gc_job"
+    app:layout_constraintTop_toBottomOf="@id/git_reset_to_remote"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,5 +392,6 @@
   <string name="pgp_key_import_succeeded_message">The key ID of the imported key is given below, please review it for correctness:\n%1$s</string>
   <string name="pref_category_pgp_title">PGP settings</string>
   <string name="pwgen_some_error_occurred">Some error occurred</string>
+  <string name="git_run_gc_job">Run garbage collection job</string>
 
 </resources>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Adds a `GcOperation` subclass of `GitOperation` alongwith the machinery required to run it without authentication.

## :bulb: Motivation and Context

Fixes #1352

## :green_heart: How did you test it?

Ran the GC job and observed minor storage use gains.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
