### PR TITLE
Unwind PasswordRepository's confusing control flow

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/dialogs/FolderCreationDialogFragment.kt
@@ -38,8 +38,7 @@ class FolderCreationDialogFragment : DialogFragment() {
         result.data?.getStringArrayExtra(OpenPgpApi.EXTRA_KEY_IDS)?.let { keyIds ->
           val gpgIdentifierFile = File(newFolder, ".gpg-id")
           gpgIdentifierFile.writeText(keyIds.joinToString("\n"))
-          val repo = PasswordRepository.getRepository(null)
-          if (repo != null) {
+          if (PasswordRepository.repository != null) {
             lifecycleScope.launch {
               val repoPath = PasswordRepository.getRepositoryDirectory().absolutePath
               requireActivity()

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitConfigActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitConfigActivity.kt
@@ -78,7 +78,7 @@ class GitConfigActivity : BaseGitActivity() {
 
   /** Sets up the UI components of the tools section. */
   private fun setupTools() {
-    val repo = PasswordRepository.getRepository(null)
+    val repo = PasswordRepository.repository
     if (repo != null) {
       binding.gitHeadStatus.text = headStatusMsg(repo)
       // enable the abort button only if we're rebasing or merging

--- a/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/git/config/GitServerConfigActivity.kt
@@ -174,8 +174,7 @@ class GitServerConfigActivity : BaseGitActivity() {
           }
         }
         GitSettings.UpdateConnectionSettingsResult.Valid -> {
-          if (isClone && PasswordRepository.getRepository(null) == null)
-            PasswordRepository.initialize()
+          if (isClone && PasswordRepository.repository == null) PasswordRepository.initialize()
           if (!isClone) {
             Snackbar.make(
                 binding.root,

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/GitLogModel.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/GitLogModel.kt
@@ -20,7 +20,7 @@ import org.eclipse.jgit.revwalk.RevCommit
 private val TAG = GitLogModel::class.java.simpleName
 
 private fun commits(): Iterable<RevCommit> {
-  val repo = PasswordRepository.getRepository(null)
+  val repo = PasswordRepository.repository
   if (repo == null) {
     logcat(TAG, ERROR) { "Could not access git repository" }
     return listOf()

--- a/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GitOperation.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/git/operation/GitOperation.kt
@@ -70,7 +70,7 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
       GitOperationEntryPoint::class.java
     )
 
-  protected val repository = PasswordRepository.getRepository(null)!!
+  protected val repository = PasswordRepository.repository!!
   protected val git = Git(repository)
   protected val remoteBranch = hiltEntryPoint.gitSettings().branch
   private val authActivity


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Splits out repository initialization from the getter to make the action of creating a repository more explicit and clear.

## :bulb: Motivation and Context

`PasswordRepository` has a `getRepository(File)` method which is a completely idiotic API since in nearly all cases the `File` parameter is actually supposed to be `null`. When a non-null `File` is passed to it, the method attempts to follow a `getOrCreate`-style pattern which further complicates the logic here.

## :green_heart: How did you test it?

Validated that the app continues to function as before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
