### PR TITLE
Workaround configuration cache bug in AGP

### DIFF
--- a/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.android-application.gradle.kts
+++ b/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.android-application.gradle.kts
@@ -25,6 +25,11 @@ android {
 
   adbOptions.installOptions("--user 0")
 
+  dependenciesInfo {
+    includeInBundle = false
+    includeInApk = false
+  }
+
   buildFeatures {
     viewBinding = true
     buildConfig = true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Disables dependency info in apps and bundles.

## :bulb: Motivation and Context

The task that writes this information is incompatible with configuration cache and the generated data is useless for us. Work towards #1708.

## :green_heart: How did you test it?

`gradle --configuration-cache clean bNFR`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

Rewrite Crowdin plugin for configuration cache compatibility
