### PR TITLE
Revert "Turn off configuration cache (#1543)"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.1.3
       with:
-        arguments: spotlessCheck
+        arguments: --stacktrace spotlessCheck
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.1.3
       with:
-        arguments: test -PslimTests
+        arguments: --stacktrace test -PslimTests
 
     - name: (Fail-only) Upload test report
       if: failure()
@@ -117,7 +117,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.1.3
       with:
-        arguments: assembleFreeDebug assembleNonFreeDebug
+        arguments: --stacktrace assembleFreeDebug assembleNonFreeDebug
 
   check-api:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.1.3
       with:
-        arguments: apiCheck
+        arguments: --stacktrace apiCheck
 
   lint-debug:
     runs-on: ubuntu-latest
@@ -187,4 +187,4 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: gradle/gradle-build-action@v2.1.3
       with:
-        arguments: lintDebug
+        arguments: --stacktrace lintDebug

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,9 @@ org.gradle.caching=true
 # Enable filesystem watching
 org.gradle.vfs.watch=true
 
+# Enable experimental configuration caching
+org.gradle.unsafe.configuration-cache=true
+
 # Enable Kotlin incremental compilation
 kotlin.incremental=true
 


### PR DESCRIPTION
This reverts commit d7bbdce1c08134ab3d09be5cf211424f11eda53c.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Enable configuration cache in gradle


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1708 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
