### PR TITLE
Switch to R8 dev releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,16 @@
  */
 @file:Suppress("DSL_SCOPE_VIOLATION", "UnstableApiUsage")
 
+buildscript {
+  repositories {
+    maven("https://storage.googleapis.com/r8-releases/raw") {
+      name = "R8 dev releases"
+      content { includeModule("com.android.tools", "r8") }
+    }
+  }
+  dependencies { classpath(libs.build.r8) }
+}
+
 plugins {
   id("com.github.android-password-store.kotlin-common")
   id("com.github.android-password-store.binary-compatibility")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ build-download = "de.undercouch:gradle-download-task:5.0.1"
 build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
 build-mavenpublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
 build-okhttp = "com.squareup.okhttp3:okhttp:4.9.3"
+build-r8 = "com.android.tools:r8:3.3.15-dev"
 build-semver = "com.vdurmont:semver4j:3.1.0"
 build-spotless = "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Overrides the default R8 version from AGP to use a newer dev release

## :bulb: Motivation and Context
Should fix the failing snapshot build

## :green_heart: How did you test it?
:shrug:

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
