### PR TITLE
Expand tests for multiple identity keys

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  SENTRY_DSN: 'https://public_key@example.com/project_id'
+
 jobs:
   check-codestyle:
     runs-on: ubuntu-latest

--- a/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.sentry.gradle.kts
+++ b/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.sentry.gradle.kts
@@ -11,11 +11,7 @@ val INVOKED_FROM_IDE_PROPERTY = "android.injected.invoked.from.ide"
 android {
   androidComponents {
     onVariants(selector().withFlavor(FlavorDimensions.FREE to ProductFlavors.NON_FREE)) { variant ->
-      val sentryDsn =
-        project
-          .providers
-          .environmentVariable(SENTRY_DSN_PROPERTY)
-          .orElse("https://public_key@example.com/project_id")
+      val sentryDsn = project.providers.environmentVariable(SENTRY_DSN_PROPERTY)
       if (sentryDsn.isPresent) {
         variant.manifestPlaceholders.put("sentryDsn", sentryDsn.get())
       } else if (project.providers.gradleProperty(INVOKED_FROM_IDE_PROPERTY).orNull != "true") {

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/KeyUtilsTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/KeyUtilsTest.kt
@@ -4,6 +4,7 @@ import dev.msfjarvis.aps.crypto.KeyUtils.tryGetId
 import dev.msfjarvis.aps.crypto.KeyUtils.tryParseKeyring
 import dev.msfjarvis.aps.crypto.TestUtils.getArmoredPrivateKeyWithMultipleIdentities
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import org.bouncycastle.openpgp.PGPSecretKeyRing
@@ -18,5 +19,6 @@ class KeyUtilsTest {
     val keyId = tryGetId(key)
     assertNotNull(keyId)
     assertIs<GpgIdentifier.KeyId>(keyId)
+    assertEquals("b950ae2813841585", keyId.toString())
   }
 }

--- a/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManagerTest.kt
@@ -4,10 +4,12 @@ import com.github.michaelbull.result.unwrap
 import com.github.michaelbull.result.unwrapError
 import dev.msfjarvis.aps.crypto.GpgIdentifier.KeyId
 import dev.msfjarvis.aps.crypto.GpgIdentifier.UserId
+import dev.msfjarvis.aps.crypto.TestUtils.getArmoredPrivateKeyWithMultipleIdentities
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -168,4 +170,17 @@ class PGPKeyManagerTest {
       val singleKeyList = keyManager.getAllKeys().unwrap()
       assertEquals(1, singleKeyList.size)
     }
+
+  @Test
+  fun testGettingMultipleIdentityKeyWithBothUserIDs() {
+    scope.runTest {
+      val key = PGPKey(getArmoredPrivateKeyWithMultipleIdentities())
+      keyManager.addKey(key).unwrap()
+
+      val johnKey = keyManager.getKeyById(UserId("john@doe.org")).unwrap()
+      val janeKey = keyManager.getKeyById(UserId("jane@doe.org")).unwrap()
+
+      assertContentEquals(johnKey.contents, janeKey.contents)
+    }
+  }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Adds some more coverage around dealing with keys that have multiple identities as well as fixing an incorrect default in the Sentry plugin.

## :bulb: Motivation and Context
Updates #1735

## :green_heart: How did you test it?

`gradle test -PslimTests`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
