### PR TITLE
Fix Autofill ANR when entry has no TOTP

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillPreferences.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/util/autofill/AutofillPreferences.kt
@@ -143,6 +143,7 @@ object AutofillPreferences {
     // Always give priority to a username stored in the encrypted extras
     val username =
       entry.username ?: directoryStructure.getUsernameFor(file) ?: context.getDefaultUsername()
-    return Credentials(username, entry.password, runBlocking { entry.totp.first() })
+    val totp = if (entry.hasTotp()) runBlocking { entry.totp.first() } else null
+    return Credentials(username, entry.password, totp)
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Guards call to `entry.totp` in `AutofillPreferences` to check `hasTotp()` first as the API demands.

## :bulb: Motivation and Context
Without this, trying to Autofill with an entry that does not have a TOTP will cause an ANR.

Fixes issue `PASSWORD-STORE-GOOGLE-PLAY-3` on Sentry

## :green_heart: How did you test it?
Verified Autofill no longer triggers deadlock

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
