### PR TITLE
Turn off StrictMode

### DIFF
--- a/app/src/main/java/dev/msfjarvis/aps/Application.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/Application.kt
@@ -5,9 +5,6 @@
 package dev.msfjarvis.aps
 
 import android.content.SharedPreferences
-import android.os.StrictMode
-import android.os.StrictMode.ThreadPolicy
-import android.os.StrictMode.VmPolicy
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
@@ -44,8 +41,6 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
         prefs.getBoolean(PreferenceKeys.ENABLE_DEBUG_LOGGING, false)
     ) {
       LogcatLogger.install(AndroidLogcatLogger(DEBUG))
-      StrictMode.setVmPolicy(VmPolicy.Builder().detectAll().penaltyLog().build())
-      StrictMode.setThreadPolicy(ThreadPolicy.Builder().detectAll().penaltyLog().build())
     }
     prefs.registerOnSharedPreferenceChangeListener(this)
     setNightMode()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Disables StrictMode completely.

## :bulb: Motivation and Context
StrictMode warnings are mostly unactionable for us and the spam in logs is an annoyance

## :green_heart: How did you test it?
Ran the app, no logspill observed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
