### PR TITLE
Cleanup IDE reported lints in autofill-parser and format-common

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
@@ -181,7 +181,7 @@ internal data class ClassifiedAutofillScenario<T : Any>(
   override val passwordFieldsToFillOnGenerate
     get() = newPassword
   override val passwordFieldsToSave
-    get() = if (newPassword.isNotEmpty()) newPassword else currentPassword
+    get() = newPassword.ifEmpty { currentPassword }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/PublicSuffixListData.kt
@@ -39,16 +39,16 @@ internal class PublicSuffixListData(
 
     val rule = findMatchingRule(domainLabels)
 
-    if (domainLabels.size == rule.size && rule[0][0] != PublicSuffixListData.EXCEPTION_MARKER) {
+    if (domainLabels.size == rule.size && rule[0][0] != EXCEPTION_MARKER) {
       // The domain is a public suffix.
-      return if (rule == PublicSuffixListData.PREVAILING_RULE) {
+      return if (rule == PREVAILING_RULE) {
         PublicSuffixOffset.PrevailingRule
       } else {
         PublicSuffixOffset.PublicSuffix
       }
     }
 
-    return if (rule[0][0] == PublicSuffixListData.EXCEPTION_MARKER) {
+    return if (rule[0][0] == EXCEPTION_MARKER) {
       // Exception rules hold the effective TLD plus one.
       PublicSuffixOffset.Offset(domainLabels.size - rule.size)
     } else {
@@ -72,15 +72,15 @@ internal class PublicSuffixListData(
     val exceptionMatch = findExceptionMatch(domainLabelsBytes, wildcardMatch)
 
     if (exceptionMatch != null) {
-      return ("${PublicSuffixListData.EXCEPTION_MARKER}$exceptionMatch").split('.')
+      return ("$EXCEPTION_MARKER$exceptionMatch").split('.')
     }
 
     if (exactMatch == null && wildcardMatch == null) {
-      return PublicSuffixListData.PREVAILING_RULE
+      return PREVAILING_RULE
     }
 
-    val exactRuleLabels = exactMatch?.split('.') ?: PublicSuffixListData.EMPTY_RULE
-    val wildcardRuleLabels = wildcardMatch?.split('.') ?: PublicSuffixListData.EMPTY_RULE
+    val exactRuleLabels = exactMatch?.split('.') ?: EMPTY_RULE
+    val wildcardRuleLabels = wildcardMatch?.split('.') ?: EMPTY_RULE
 
     return if (exactRuleLabels.size > wildcardRuleLabels.size) {
       exactRuleLabels
@@ -95,7 +95,7 @@ internal class PublicSuffixListData(
     // foo.bar.com
     // will look like: [foo, bar, com], [bar, com], [com]. The longest matching rule wins.
 
-    for (i in 0 until labels.size) {
+    for (i in labels.indices) {
       val rule = binarySearchRules(labels, i)
 
       if (rule != null) {
@@ -118,7 +118,7 @@ internal class PublicSuffixListData(
     if (labels.size > 1) {
       val labelsWithWildcard = labels.toMutableList()
       for (labelIndex in 0 until labelsWithWildcard.size) {
-        labelsWithWildcard[labelIndex] = PublicSuffixListData.WILDCARD_LABEL
+        labelsWithWildcard[labelIndex] = WILDCARD_LABEL
         val rule = binarySearchRules(labelsWithWildcard, labelIndex)
         if (rule != null) {
           return rule
@@ -135,7 +135,7 @@ internal class PublicSuffixListData(
       return null
     }
 
-    for (labelIndex in 0 until labels.size) {
+    for (labelIndex in labels.indices) {
       val rule = binarySearchExceptions(labels, labelIndex)
       if (rule != null) {
         return rule

--- a/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
+++ b/autofill-parser/src/main/java/mozilla/components/lib/publicsuffixlist/ext/ByteArray.kt
@@ -19,7 +19,6 @@ private const val BITMASK = 0xff.toByte()
  * https://github.com/square/okhttp/blob/1977136/okhttp/src/main/kotlin/okhttp3/internal/publicsuffix/PublicSuffixDatabase.kt
  */
 @Suppress("ComplexMethod", "NestedBlockDepth")
-@OptIn(ExperimentalUnsignedTypes::class)
 internal fun ByteArray.binarySearch(labels: List<ByteArray>, labelIndex: Int): String? {
   var low = 0
   var high = size

--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/data/passfile/PasswordEntry.kt
@@ -13,14 +13,12 @@ import dev.msfjarvis.aps.util.time.UserClock
 import dev.msfjarvis.aps.util.totp.Otp
 import dev.msfjarvis.aps.util.totp.TotpFinder
 import kotlin.collections.set
-import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /** Represents a single entry in the password store. */
-@OptIn(ExperimentalTime::class)
 public class PasswordEntry
 @AssistedInject
 constructor(

--- a/format-common/src/main/kotlin/dev/msfjarvis/aps/util/totp/Otp.kt
+++ b/format-common/src/main/kotlin/dev/msfjarvis/aps/util/totp/Otp.kt
@@ -19,10 +19,6 @@ internal object Otp {
   private val BASE_32 = Base32()
   private val STEAM_ALPHABET = "23456789BCDFGHJKMNPQRTVWXY".toCharArray()
 
-  init {
-    check(STEAM_ALPHABET.size == 26)
-  }
-
   fun calculateCode(
     secret: String,
     counter: Long,
@@ -51,7 +47,7 @@ internal object Otp {
       var remainingCodeInt = codeInt
       buildString {
         repeat(5) {
-          append(STEAM_ALPHABET[remainingCodeInt % 26])
+          append(STEAM_ALPHABET[remainingCodeInt % STEAM_ALPHABET.size])
           remainingCodeInt /= 26
         }
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Fix lints reported by IntelliJ in autofill-parser and format-common modules.

## :bulb: Motivation and Context
:shrug:

## :green_heart: How did you test it?

Pre-push hooks

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
