### PR TITLE
Migrate snapshot releases to GitHub Releases

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3.0.0
+      fetch-depth: 0
 
     - name: Set up JDK
       uses: actions/setup-java@v3.0.0
@@ -40,9 +41,3 @@ jobs:
 
     - name: Deploy snapshot
       run: scripts/deploy-snapshot.sh
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
-        SERVER_ADDRESS: ${{ secrets.SERVER_ADDRESS }}
-        SERVER_DESTINATION: ${{ secrets.SERVER_DESTINATION }}
-        SSH_PORT: ${{ secrets.SSH_PORT }}

--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Copyright © 2014-2021 The Android Password Store Authors. All Rights Reserved.
 # SPDX-License-Identifier: GPL-3.0-only
@@ -6,10 +6,50 @@
 
 set -ex
 
-export SSHDIR="$HOME/.ssh"
-mkdir -p "$SSHDIR"
-echo "$ACTIONS_DEPLOY_KEY" > "$SSHDIR/key"
-chmod 600 "$SSHDIR/key"
-export SERVER_DEPLOY_STRING="$SSH_USERNAME@$SERVER_ADDRESS:$SERVER_DESTINATION"
-cd "$GITHUB_WORKSPACE/app/outputs/"
-rsync -ahvcr --omit-dir-times --progress --delete --no-o --no-g -e "ssh -i $SSHDIR/key -o StrictHostKeyChecking=no -p $SSH_PORT" . "$SERVER_DEPLOY_STRING"
+LATEST_TAG="latest"
+CURRENT_REV="$(git rev-parse --short HEAD)"
+ASSET_DIRECTORY="${GITHUB_WORKSPACE}/app/outputs"
+
+function overwrite_local_tag() {
+  git tag -f "${LATEST_TAG}"
+}
+
+function overwrite_remote_tag() {
+  git push -f origin "${LATEST_TAG}"
+}
+
+function has_release() {
+  gh release view "${LATEST_TAG}"
+  echo "$?"
+}
+
+function delete_release() {
+  gh release delete --yes "${LATEST_TAG}"
+}
+
+function create_rev_file() {
+  pushd "${ASSET_DIRECTORY}"
+  echo "${CURRENT_REV}" | tee rev-hash.txt
+  popd
+}
+
+function create_release() {
+  local CHANGELOG_FILE
+  CHANGELOG_FILE="$(mktemp)"
+  echo "Latest release for APS from revision ${CURRENT_REV}" | tee "${CHANGELOG_FILE}"
+  pushd "${ASSET_DIRECTORY}"
+  gh release create --title "Latest snapshot build" -F "${CHANGELOG_FILE}" "${LATEST_TAG}" ./*
+  popd
+}
+
+overwrite_local_tag
+
+if [[ "$(has_release)" -eq 0 ]]; then
+  delete_release
+fi
+
+create_rev_file
+
+overwrite_remote_tag
+
+create_release


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Converts the snapshot release script to publish to GitHub Releases instead.

## :bulb: Motivation and Context

This is better for multiple reasons

1. GitHub Releases is far more easily automatable than an SSH key infrastructure I maintain on a personal server.
2. I am a terrible sysadmin whose infrastructure cannot be relied on.
3. This script can be executed by any maintainer of the project to create snapshot releases from their own machines.

## :green_heart: How did you test it?

https://github.com/android-password-store/Android-Password-Store/releases/tag/latest

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
- [ ] Update documentation to point to GH releases
- [ ] Setup redirects from my server to GH releases
