### PR TITLE
Meta changes to snapshots and reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Catch-all rule for the project
-* @android-password-store/devs

--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -38,7 +38,7 @@ function create_release() {
   CHANGELOG_FILE="$(mktemp)"
   echo "Latest release for APS from revision ${CURRENT_REV}" | tee "${CHANGELOG_FILE}"
   pushd "${ASSET_DIRECTORY}" || return
-  gh release create --title "Latest snapshot build" -F "${CHANGELOG_FILE}" "${LATEST_TAG}" ./*
+  gh release create --prerelease --title "Latest snapshot build" --notes-file "${CHANGELOG_FILE}" "${LATEST_TAG}" ./*
   popd || return
 }
 


### PR DESCRIPTION
## :scroll: Description

- Removes the default codeowners file, since I turned off mandatory reviews a while ago and it simply pings 3 additional people for little benefit when most PRs are authored and merged by me.

- Changes the automated snapshots to be marked as prereleases, so that the latest _stable_ release stays discoverable from the main page of the repository.