### PR TITLE
Copy rather than move in artifact collection jobs

### DIFF
--- a/build-logic/android-plugins/src/main/kotlin/artifacts/CollectApksTask.kt
+++ b/build-logic/android-plugins/src/main/kotlin/artifacts/CollectApksTask.kt
@@ -1,7 +1,9 @@
 package artifacts
 
 import com.android.build.api.variant.BuiltArtifactsLoader
-import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -32,8 +34,11 @@ abstract class CollectApksTask : DefaultTask() {
     val builtArtifacts =
       builtArtifactsLoader.get().load(apkFolder.get()) ?: throw RuntimeException("Cannot load APKs")
     builtArtifacts.elements.forEach { artifact ->
-      File(artifact.outputFile)
-        .renameTo(outputDir.resolve("APS-${variantName.get()}-${artifact.versionName}.apk"))
+      Files.copy(
+        Paths.get(artifact.outputFile),
+        outputDir.resolve("APS-${variantName.get()}-${artifact.versionName}.apk").toPath(),
+        StandardCopyOption.REPLACE_EXISTING,
+      )
     }
   }
 }

--- a/build-logic/android-plugins/src/main/kotlin/artifacts/CollectBundleTask.kt
+++ b/build-logic/android-plugins/src/main/kotlin/artifacts/CollectBundleTask.kt
@@ -1,5 +1,7 @@
 package artifacts
 
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -22,9 +24,10 @@ abstract class CollectBundleTask : DefaultTask() {
   fun taskAction() {
     val outputDir = outputDirectory.asFile.get()
     outputDir.mkdirs()
-    bundleFile
-      .get()
-      .asFile
-      .renameTo(outputDir.resolve("APS-${variantName.get()}-${versionName.get()}.aab"))
+    Files.copy(
+      bundleFile.get().asFile.toPath(),
+      outputDir.resolve("APS-${variantName.get()}-${versionName.get()}.aab").toPath(),
+      StandardCopyOption.REPLACE_EXISTING,
+    )
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description
Converts the APK and Bundle collection tasks to copy the discovered artifacts to the output directory rather than move the files.

## :bulb: Motivation and Context
On AGP 7.0 this behaviour results in a build-breaking cache bug where Gradle assumes the final APK is in the default location but our collection task moved it out already. This seems to be fixed on AGP 7.1 and thus doesn't affect APS directly, it's just good practice to not move out the file if there's no practical need to.

## :green_heart: How did you test it?
`gradle collectNonFreeReleaseApks`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
