### PR TITLE
Fix TOTP field flashing on each update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 -   Introduce a new opt-in PGP backend powered by [PGPainless](https://github.com/pgpainless/pgpainless) that does not require OpenKeychain
 -   Add the ability to run garbage collection on the internal Git repository
 -   Introduce crash reporting backed by Sentry
+-   TOTP field now shows the remaining time for which it is valid
 
 ### Fixed
 

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivity.kt
@@ -208,6 +208,7 @@ class DecryptActivity : BasePgpActivity(), OpenPgpServiceConnection.OnBound {
             val adapter =
               FieldItemAdapter(items, showPassword) { text -> copyTextToClipboard(text) }
             binding.recyclerView.adapter = adapter
+            binding.recyclerView.itemAnimator = null
 
             if (entry.hasTotp()) {
               entry.totp.onEach(adapter::updateOTPCode).launchIn(lifecycleScope)

--- a/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
+++ b/app/src/main/java/dev/msfjarvis/aps/ui/crypto/DecryptActivityV2.kt
@@ -196,6 +196,7 @@ class DecryptActivityV2 : BasePgpActivity() {
 
       val adapter = FieldItemAdapter(items, showPassword) { text -> copyTextToClipboard(text) }
       binding.recyclerView.adapter = adapter
+      binding.recyclerView.itemAnimator = null
 
       if (entry.hasTotp()) {
         entry.totp.onEach(adapter::updateOTPCode).launchIn(lifecycleScope)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Fixes the TOTP field having a flashing animation when it is updated.

Also adds the changelog entry that should have gone in with #1766

## :bulb: Motivation and Context
The default RecyclerView ItemAnimator has a fade in/out style animation which results in a janky looking flash in the password entry recyclerview. Since we don't care for that and the data is fairly static, we fix the problem by removing the ItemAnimator altogether.

## :green_heart: How did you test it?
Verified visually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
