### PR TITLE
fix: ignore `CancellationException` in suspend functions

### DIFF
--- a/coroutine-utils/build.gradle.kts
+++ b/coroutine-utils/build.gradle.kts
@@ -10,5 +10,5 @@ plugins {
 dependencies {
   implementation(libs.kotlin.coroutines.core)
   implementation(libs.dagger.hilt.core)
-  implementation(libs.thirdparty.kotlinResult)
+  api(libs.thirdparty.kotlinResult)
 }

--- a/coroutine-utils/build.gradle.kts
+++ b/coroutine-utils/build.gradle.kts
@@ -10,4 +10,5 @@ plugins {
 dependencies {
   implementation(libs.kotlin.coroutines.core)
   implementation(libs.dagger.hilt.core)
+  implementation(libs.thirdparty.kotlinResult)
 }

--- a/coroutine-utils/src/main/kotlin/dev/msfjarvis/aps/util/coroutines/RunSuspendCatching.kt
+++ b/coroutine-utils/src/main/kotlin/dev/msfjarvis/aps/util/coroutines/RunSuspendCatching.kt
@@ -1,0 +1,48 @@
+@file:OptIn(ExperimentalContracts::class)
+@file:Suppress("RedundantSuspendModifier")
+
+package dev.msfjarvis.aps.util.coroutines
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Calls the specified function [block] with [this] value as its receiver and returns its
+ * encapsulated result if invocation was successful, catching any [Throwable] except
+ * [CancellationException] that was thrown from the [block] function execution and encapsulating it
+ * as a failure.
+ */
+public suspend inline fun <V> runSuspendCatching(block: () -> V): Result<V, Throwable> {
+  contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+  return try {
+    Ok(block())
+  } catch (e: Throwable) {
+    if (e is CancellationException) throw e
+    Err(e)
+  }
+}
+
+/**
+ * Calls the specified function [block] with [this] value as its receiver and returns its
+ * encapsulated result if invocation was successful, catching any [Throwable] except
+ * [CancellationException] that was thrown from the [block] function execution and encapsulating it
+ * as a failure.
+ */
+public suspend inline infix fun <T, V> T.runSuspendCatching(
+  block: T.() -> V
+): Result<V, Throwable> {
+  contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+  return try {
+    Ok(block())
+  } catch (e: Throwable) {
+    if (e is CancellationException) throw e
+    Err(e)
+  }
+}

--- a/crypto-pgpainless/build.gradle.kts
+++ b/crypto-pgpainless/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 dependencies {
   api(projects.cryptoCommon)
+  implementation(projects.coroutineUtils)
   implementation(libs.androidx.annotation)
   implementation(libs.dagger.hilt.core)
   implementation(libs.kotlin.coroutines.core)

--- a/crypto-pgpainless/src/main/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManager.kt
+++ b/crypto-pgpainless/src/main/kotlin/dev/msfjarvis/aps/crypto/PGPKeyManager.kt
@@ -8,9 +8,9 @@ package dev.msfjarvis.aps.crypto
 
 import androidx.annotation.VisibleForTesting
 import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.runCatching
 import dev.msfjarvis.aps.crypto.KeyUtils.tryGetId
 import dev.msfjarvis.aps.crypto.KeyUtils.tryParseKeyring
+import dev.msfjarvis.aps.util.coroutines.runSuspendCatching
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -28,7 +28,7 @@ constructor(
 
   override suspend fun addKey(key: PGPKey, replace: Boolean): Result<PGPKey, Throwable> =
     withContext(dispatcher) {
-      runCatching {
+      runSuspendCatching {
         if (!keyDirExists()) throw KeyManagerException.KeyDirectoryUnavailableException
         if (tryParseKeyring(key) == null) throw KeyManagerException.InvalidKeyException
         val keyFile = File(keyDir, "${tryGetId(key)}.$KEY_EXTENSION")
@@ -49,7 +49,7 @@ constructor(
 
   override suspend fun removeKey(key: PGPKey): Result<PGPKey, Throwable> =
     withContext(dispatcher) {
-      runCatching {
+      runSuspendCatching {
         if (!keyDirExists()) throw KeyManagerException.KeyDirectoryUnavailableException
         if (tryParseKeyring(key) == null) throw KeyManagerException.InvalidKeyException
         val keyFile = File(keyDir, "${tryGetId(key)}.$KEY_EXTENSION")
@@ -63,7 +63,7 @@ constructor(
 
   override suspend fun getKeyById(id: GpgIdentifier): Result<PGPKey, Throwable> =
     withContext(dispatcher) {
-      runCatching {
+      runSuspendCatching {
         if (!keyDirExists()) throw KeyManagerException.KeyDirectoryUnavailableException
         val keyFiles = keyDir.listFiles()
         if (keyFiles.isNullOrEmpty()) throw KeyManagerException.NoKeysAvailableException
@@ -89,7 +89,7 @@ constructor(
           }
 
         if (matchResult != null) {
-          return@runCatching matchResult
+          return@runSuspendCatching matchResult
         }
 
         throw KeyManagerException.KeyNotFoundException("$id")
@@ -98,10 +98,10 @@ constructor(
 
   override suspend fun getAllKeys(): Result<List<PGPKey>, Throwable> =
     withContext(dispatcher) {
-      runCatching {
+      runSuspendCatching {
         if (!keyDirExists()) throw KeyManagerException.KeyDirectoryUnavailableException
         val keyFiles = keyDir.listFiles()
-        if (keyFiles.isNullOrEmpty()) return@runCatching emptyList()
+        if (keyFiles.isNullOrEmpty()) return@runSuspendCatching emptyList()
         keyFiles.map { keyFile -> PGPKey(keyFile.readBytes()) }.toList()
       }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Suspend functions can throw cancellation exceptions, here we are making sure that we do not catch it.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Had a chat with @msfjarvis on Telegram


## :green_heart: How did you test it?
All the current tests work fine, should I add a test that tries to throw `CancellationException`?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
