### PR TITLE
doc (README): update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Documentation
 
-We're in the process of rewriting our documentation from scratch, and the work-in-progress state can be seen [here](https://android-password-store.github.io/docs). See the [wiki](https://github.com/android-password-store/Android-Password-Store/wiki/) for the old documentation.
+We're in the process of rewriting our documentation from scratch, and the work-in-progress state can be seen [here](https://docs.passwordstore.app). See the [wiki](https://github.com/android-password-store/Android-Password-Store/wiki/) for the old documentation.
 
 ## Contributing
 
@@ -26,7 +26,9 @@ Want to contribute? See if you can [find an issue](https://github.com/android-pa
 
 Interested in helping to translate Password Store? Contribute [here](https://crowdin.com/project/android-password-store)!
 
-Wanna test development builds to find bugs and offer feedback? Read the [release channels](https://android-password-store.github.io/docs/users/release-channels) documentation to get access!
+Wanna test development builds to find bugs and offer feedback? Read the [release channels](https://docs.passwordstore.app/docs/Users/release-channels) documentation to get access!
+
+Code contributions? [Here](CONTRIBUTING.md) you are welcomed!
 
 ## Community
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
<!--- Describe your changes in detail -->
Links in [README](README.md) point to the now non-existent `/docs` directory of the repo or the github.io subdomain page. Both are outdated.

I changed them to point to the right locations under <https://docs.passwordstore.app>


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required because I wanted to test the snapshot release, but could not understand `free` vs `nonFree` -- something that's answered in the [release channels page](https://docs.passwordstore.app/docs/Users/release-channels)

I would expect other potential testers to go thru the same experience.

## :green_heart: How did you test it?
I didn't. It's a documentation change.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps
<!-- If this change unblocks further improvements or needs some changes down the line, note them here -->

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
