### PR TITLE
Migrate namespaces to Gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,8 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
+  namespace = "dev.msfjarvis.aps"
+
   lint {
     abortOnError = true
     checkReleaseBuilds = false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  package="dev.msfjarvis.aps"
   android:installLocation="auto">
 
   <uses-permission android:name="android.permission.INTERNET" />

--- a/autofill-parser/build.gradle.kts
+++ b/autofill-parser/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 android {
   defaultConfig { consumerProguardFiles("consumer-rules.pro") }
   sourceSets { getByName("test") { resources.srcDir("src/main/assets") } }
+  namespace = "com.github.androidpasswordstore.autofillparser"
 }
 
 dependencies {

--- a/autofill-parser/src/main/AndroidManifest.xml
+++ b/autofill-parser/src/main/AndroidManifest.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
   -->
 
-<manifest package="com.github.androidpasswordstore.autofillparser"></manifest>
+<manifest />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,12 +21,10 @@ androidx-annotation = "androidx.annotation:annotation:1.3.0"
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
 androidx-autofill = "androidx.autofill:autofill:1.2.0-beta01"
 androidx-biometricKtx = "androidx.biometric:biometric-ktx:1.2.0-alpha04"
-androidx-compose-material3 = "androidx.compose.material3:material3:1.0.0-alpha08"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.3"
 androidx-core-ktx = "androidx.core:core-ktx:1.8.0-alpha06"
 androidx-documentfile = "androidx.documentfile:documentfile:1.1.0-alpha01"
 androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.1"
-androidx-hilt-compose = "androidx.hilt:hilt-navigation-compose:1.0.0"
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
 androidx-lifecycle-livedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
@@ -61,7 +59,9 @@ compose-animation = { module = "androidx.compose.animation:animation", version.r
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose" }
 compose-foundation-core = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }
+compose-hilt = "androidx.hilt:hilt-navigation-compose:1.0.0"
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+compose-material3 = "androidx.compose.material3:material3:1.0.0-alpha08"
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }

--- a/openpgp-ktx/build.gradle.kts
+++ b/openpgp-ktx/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
 
 android {
   defaultConfig { consumerProguardFiles("consumer-proguard-rules.pro") }
-
   buildFeatures.aidl = true
+  namespace = "me.msfjarvis.openpgpktx"
 }
 
 dependencies { implementation(libs.kotlin.coroutines.core) }

--- a/openpgp-ktx/src/main/AndroidManifest.xml
+++ b/openpgp-ktx/src/main/AndroidManifest.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<manifest package="me.msfjarvis.openpgpktx" />
+<manifest />

--- a/passgen/diceware/build.gradle.kts
+++ b/passgen/diceware/build.gradle.kts
@@ -9,7 +9,10 @@ plugins {
   id("com.github.android-password-store.kotlin-library")
 }
 
-android { sourceSets { getByName("test") { resources.srcDir("src/main/res/raw") } } }
+android {
+  sourceSets { getByName("test") { resources.srcDir("src/main/res/raw") } }
+  namespace = "dev.msfjarvis.aps.passgen.diceware"
+}
 
 dependencies {
   implementation(libs.dagger.hilt.core)

--- a/passgen/diceware/src/main/AndroidManifest.xml
+++ b/passgen/diceware/src/main/AndroidManifest.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
   -->
 
-<manifest package="dev.msfjarvis.aps.passgen.diceware" />
+<manifest />

--- a/ui-compose/build.gradle.kts
+++ b/ui-compose/build.gradle.kts
@@ -18,6 +18,6 @@ dependencies {
   api(libs.compose.foundation.core)
   api(libs.compose.foundation.layout)
   api(libs.compose.material)
-  api(libs.androidx.compose.material3)
+  api(libs.compose.material3)
   api(libs.compose.ui.core)
 }

--- a/ui-compose/build.gradle.kts
+++ b/ui-compose/build.gradle.kts
@@ -12,6 +12,7 @@ android {
       kotlinCompilerExtensionVersion = libs.versions.compose.get()
     }
   }
+  namespace = "dev.msfjarvis.aps.ui.compose"
 }
 
 dependencies {

--- a/ui-compose/build.gradle.kts
+++ b/ui-compose/build.gradle.kts
@@ -4,14 +4,20 @@ plugins {
   id("com.github.android-password-store.kotlin-library")
 }
 
+android {
+  buildFeatures {
+    compose = true
+    composeOptions {
+      useLiveLiterals = false
+      kotlinCompilerExtensionVersion = libs.versions.compose.get()
+    }
+  }
+}
+
 dependencies {
-  implementation(libs.androidx.activity.compose)
-  implementation(libs.androidx.hilt.compose)
-  implementation(libs.compose.foundation.core)
-  implementation(libs.compose.foundation.layout)
-  implementation(libs.compose.material)
-  implementation(libs.androidx.compose.material3)
-  implementation(libs.compose.ui.core)
-  implementation(libs.compose.ui.viewbinding)
-  compileOnly(libs.compose.ui.tooling)
+  api(libs.compose.foundation.core)
+  api(libs.compose.foundation.layout)
+  api(libs.compose.material)
+  api(libs.androidx.compose.material3)
+  api(libs.compose.ui.core)
 }

--- a/ui-compose/src/main/AndroidManifest.xml
+++ b/ui-compose/src/main/AndroidManifest.xml
@@ -3,4 +3,4 @@
   ~ SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
   -->
 
-<manifest package="dev.msfjarvis.aps.ui.compose" />
+<manifest />


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## :scroll: Description

Migrates to Gradle-based namespaces and adds missing Compose configuration to the `ui-compose` module.


## :bulb: Motivation and Context

Matches a [similar change](https://github.com/androidx/androidx/commit/dcfa035a961fd1daabb7dcccf97d77fa2a006abf) in AndroidX.

## :green_heart: How did you test it?

`gradle aNFR`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [ ] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
