### PR TITLE
Remove setup-java Gradle cache

### DIFF
--- a/.github/workflows/deploy_github_releases.yml
+++ b/.github/workflows/deploy_github_releases.yml
@@ -17,7 +17,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"

--- a/.github/workflows/deploy_library_releases.yml
+++ b/.github/workflows/deploy_library_releases.yml
@@ -17,7 +17,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Determine publishing task
       id: task-select

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -19,7 +19,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Decrypt secrets
       run: scripts/signing-setup.sh "$ENCRYPT_KEY"

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-          cache: gradle
 
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@1.3.0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
@@ -68,7 +67,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
@@ -110,7 +108,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
@@ -145,7 +142,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
@@ -180,7 +176,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
@@ -215,7 +210,6 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-        cache: gradle
 
     - name: Copy CI gradle.properties
       if: "${{ steps.service-changed.outputs.result == 'true' }}"

--- a/.github/workflows/sync_crowdin.yml
+++ b/.github/workflows/sync_crowdin.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-          cache: gradle
 
       - name: Download new translations from Crowdin
         uses: gradle/gradle-build-action@v2.1.5

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
-          cache: gradle
 
       - name: Download new publicsuffix data
         uses: gradle/gradle-build-action@v2.1.5


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Removes the setup-java cache to let gradle-build-action handle it.
