### PR TITLE
Use full canonical path for classes in manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,17 @@ The app comes in two 'flavors', a FOSS-only **free** variant and a **nonFree** v
 
 You can find the generated APK at `app/outputs`.
 
+The project makes use of the unstable [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) feature of Gradle. This has the potential to cause spurious build failures that look something like this:
+
+```
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Could not find build ':kotlin-plugins:generatePrecompiledScriptPluginAccessors:accessors8052664764592233112'
+```
+
+This can be resolved by simply re-running the command, or adding the `--no-configuration-cache` parameter.
+
 ## Pre-push checks
 
 The project enforces codestyle conventions and library API stability by virtue of a carefully curated Gradle build. To setup a Git pre-push hook to run them automatically, run `./gradlew installGitHooks`.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     android:required="false" />
 
   <application
-    android:name=".Application"
+    android:name="dev.msfjarvis.aps.Application"
     android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
@@ -31,23 +31,23 @@
     tools:ignore="GoogleAppIndexingWarning">
 
     <activity
-      android:name=".ui.passwords.PasswordStore"
+      android:name="dev.msfjarvis.aps.ui.passwords.PasswordStore"
       android:configChanges="orientation|screenSize" />
 
     <activity
-      android:name=".ui.onboarding.activity.OnboardingActivity"
+      android:name="dev.msfjarvis.aps.ui.onboarding.activity.OnboardingActivity"
       android:configChanges="orientation|screenSize" />
 
     <activity
-      android:name=".ui.proxy.ProxySelectorActivity"
+      android:name="dev.msfjarvis.aps.ui.proxy.ProxySelectorActivity"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.crypto.DecryptActivityV2"
+      android:name="dev.msfjarvis.aps.ui.crypto.DecryptActivityV2"
       android:exported="true" />
 
     <activity
-      android:name=".ui.main.LaunchActivity"
+      android:name="dev.msfjarvis.aps.ui.main.LaunchActivity"
       android:configChanges="orientation|screenSize"
       android:exported="true"
       android:theme="@style/NoBackgroundThemeM3">
@@ -66,54 +66,54 @@
       tools:node="replace" />
 
     <activity
-      android:name=".ui.git.config.GitServerConfigActivity"
+      android:name="dev.msfjarvis.aps.ui.git.config.GitServerConfigActivity"
       android:label="@string/title_activity_git_clone"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.git.config.GitConfigActivity"
+      android:name="dev.msfjarvis.aps.ui.git.config.GitConfigActivity"
       android:label="@string/title_activity_git_config"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.git.log.GitLogActivity"
+      android:name="dev.msfjarvis.aps.ui.git.log.GitLogActivity"
       android:label="@string/title_activity_git_log" />
 
     <activity
-      android:name=".ui.settings.SettingsActivity"
+      android:name="dev.msfjarvis.aps.ui.settings.SettingsActivity"
       android:label="@string/action_settings"
       android:parentActivityName=".ui.passwords.PasswordStore" />
 
     <activity
-      android:name=".ui.settings.DirectorySelectionActivity"
+      android:name="dev.msfjarvis.aps.ui.settings.DirectorySelectionActivity"
       android:theme="@style/NoBackgroundThemeM3" />
 
     <activity
-      android:name=".ui.crypto.PasswordCreationActivity"
+      android:name="dev.msfjarvis.aps.ui.crypto.PasswordCreationActivity"
       android:label="@string/new_password_title"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.crypto.PasswordCreationActivityV2"
+      android:name="dev.msfjarvis.aps.ui.crypto.PasswordCreationActivityV2"
       android:label="@string/new_password_title"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.crypto.DecryptActivity"
+      android:name="dev.msfjarvis.aps.ui.crypto.DecryptActivity"
       android:windowSoftInputMode="adjustResize" />
 
     <activity
-      android:name=".ui.crypto.GetKeyIdsActivity"
+      android:name="dev.msfjarvis.aps.ui.crypto.GetKeyIdsActivity"
       android:theme="@style/NoBackgroundThemeM3" />
 
     <service
-      android:name=".util.services.ClipboardService"
+      android:name="dev.msfjarvis.aps.util.services.ClipboardService"
       android:process=":clipboard_service_process" />
     <service
-      android:name=".util.services.PasswordExportService"
+      android:name="dev.msfjarvis.aps.util.services.PasswordExportService"
       android:process=":password_export_service_process" />
     <service
-      android:name=".util.services.OreoAutofillService"
+      android:name="dev.msfjarvis.aps.util.services.OreoAutofillService"
       android:exported="true"
       android:permission="android.permission.BIND_AUTOFILL_SERVICE">
       <intent-filter>
@@ -124,40 +124,40 @@
         android:resource="@xml/oreo_autofill_service" />
     </service>
 
-    <activity android:name=".ui.folderselect.SelectFolderActivity" />
+    <activity android:name="dev.msfjarvis.aps.ui.folderselect.SelectFolderActivity" />
     <activity
-      android:name=".ui.sshkeygen.SshKeyImportActivity"
+      android:name="dev.msfjarvis.aps.ui.sshkeygen.SshKeyImportActivity"
       android:theme="@style/NoBackgroundThemeM3"
       android:windowSoftInputMode="adjustResize" />
     <activity
-      android:name=".ui.sshkeygen.SshKeyGenActivity"
+      android:name="dev.msfjarvis.aps.ui.sshkeygen.SshKeyGenActivity"
       android:label="@string/pref_ssh_keygen_title"
       android:windowSoftInputMode="adjustResize" />
     <activity
-      android:name=".ui.autofill.AutofillDecryptActivity"
+      android:name="dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivity"
       android:theme="@style/NoBackgroundThemeM3" />
     <activity
-      android:name=".ui.autofill.AutofillDecryptActivityV2"
+      android:name="dev.msfjarvis.aps.ui.autofill.AutofillDecryptActivityV2"
       android:theme="@style/NoBackgroundThemeM3" />
     <activity
-      android:name=".ui.autofill.AutofillFilterView"
+      android:name="dev.msfjarvis.aps.ui.autofill.AutofillFilterView"
       android:configChanges="orientation|keyboardHidden"
       android:theme="@style/DialogLikeThemeM3"
       android:windowSoftInputMode="adjustNothing" />
     <activity
-      android:name=".ui.autofill.AutofillSaveActivity"
+      android:name="dev.msfjarvis.aps.ui.autofill.AutofillSaveActivity"
       android:theme="@style/NoBackgroundThemeM3" />
     <activity
-      android:name=".autofill.oreo.ui.AutofillSmsActivity"
+      android:name="dev.msfjarvis.aps.autofill.oreo.ui.AutofillSmsActivity"
       android:configChanges="orientation"
       android:theme="@style/DialogLikeThemeM3"
       android:windowSoftInputMode="adjustNothing" />
     <activity
-      android:name=".ui.autofill.AutofillPublisherChangedActivity"
+      android:name="dev.msfjarvis.aps.ui.autofill.AutofillPublisherChangedActivity"
       android:configChanges="orientation|keyboardHidden"
       android:theme="@style/DialogLikeThemeM3"
       android:windowSoftInputMode="adjustNothing" />
-    <activity android:name=".ui.pgp.PGPKeyImportActivity"
+    <activity android:name="dev.msfjarvis.aps.ui.pgp.PGPKeyImportActivity"
       android:theme="@style/NoBackgroundThemeM3" />
   </application>
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Switches classes in the app manifest to use their full canonical path. This was regressed in #1805 as manifest rewriting by the namespace parameter changes the manifest to point to `dev.msfjarvis.aps.debug.*` while the classes are still at `dev.msfjarvis.aps.*`.

Also adds a note to `CONTRIBUTING` about Gradle CC related failures.

## :bulb: Motivation and Context

Fixes #1821
Fixes #1822

## :green_heart: How did you test it?

Installed the debug APK with `gradle iNFD` and tested that it launches correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [ ] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
