### PR TITLE
Workaround AGP and Dokka conflict

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,4 +20,5 @@ plugins {
   id("com.github.android-password-store.git-hooks")
   id("com.github.android-password-store.spotless")
   alias(libs.plugins.hilt) apply false
+  alias(libs.plugins.dokka) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidx_activity = "1.4.0"
 androidx_test = "1.4.1-alpha05"
 compose = "1.2.0-alpha08"
 coroutines = "1.6.1"
+dokka = "1.6.21"
 flowbinding = "1.2.0"
 hilt = "2.41"
 kotlin = "1.6.21"
@@ -11,6 +12,7 @@ leakcanary = "2.9.1"
 lifecycle = "2.4.1"
 
 [plugins]
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 
 [libraries]
@@ -41,7 +43,7 @@ aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embe
 
 build-agp = "com.android.tools.build:gradle:7.1.3"
 build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0"
-build-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
+build-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 build-download = "de.undercouch:gradle-download-task:5.0.5"
 build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
 build-mavenpublish = "com.vanniktech:gradle-maven-publish-plugin:0.19.0"


### PR DESCRIPTION
AGP 7.1.x includes an older version of Dokka which results in build failures when publishing libraries. Override it at root level so that the Dokka version from AGP can be transitively upgraded to match the rest of the build.