### PR TITLE
Disable sentry autoinstall

### DIFF
--- a/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.sentry.gradle.kts
+++ b/build-logic/android-plugins/src/main/kotlin/com.github.android-password-store.sentry.gradle.kts
@@ -33,4 +33,5 @@ sentry {
     enabled.set(true)
     features.set(setOf(InstrumentationFeature.FILE_IO))
   }
+  autoInstallation.enabled.set(false)
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Sentry's Gradle Plugin attempts to install the SDK to free flavor builds which already ship stubs and thus fails compilation.

## :bulb: Motivation and Context
Fixes snapshots

## :green_heart: How did you test it?

`gradle iFR`
