### PR TITLE
Upgrade AGP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.
 aps-sublimeFuzzy = "com.github.android-password-store:sublime-fuzzy:2.1.0"
 aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embedded:4.2.1"
 
-build-agp = "com.android.tools.build:gradle:7.2.0"
+build-agp = "com.android.tools.build:gradle:7.2.1"
 build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.10.0"
 build-download = "de.undercouch:gradle-download-task:5.1.0"
 build-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"


### PR DESCRIPTION
Upgrade AGP to 7.2.1 to fix a bug with packaging baseline profiles in app bundles.
