### PR TITLE
Improve Kotlin build caching

### DIFF
--- a/.github/workflows/deploy_github_releases.yml
+++ b/.github/workflows/deploy_github_releases.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build release binaries
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache :app:assembleFreeRelease :app:assembleNonFreeRelease :app:bundleNonFreeRelease
+        arguments: :app:assembleFreeRelease :app:assembleNonFreeRelease :app:bundleNonFreeRelease
       env:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 

--- a/.github/workflows/deploy_library_releases.yml
+++ b/.github/workflows/deploy_library_releases.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Upload binaries
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache :${{ steps.task-select.outputs.PROJECT }}:publishAllPublicationsToMavenCentralRepository
+        arguments: :${{ steps.task-select.outputs.PROJECT }}:publishAllPublicationsToMavenCentralRepository
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
@@ -42,7 +42,7 @@ jobs:
     - name: Close and release repository
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache closeAndReleaseRepository
+        arguments: closeAndReleaseRepository
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -35,7 +35,7 @@ jobs:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       with:
-        arguments: --no-configuration-cache collectFreeReleaseApks collectNonFreeReleaseApks -PsentryUploadMappings
+        arguments: collectFreeReleaseApks collectNonFreeReleaseApks -PsentryUploadMappings
 
     - name: Clean secrets
       run: scripts/signing-cleanup.sh

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -69,9 +69,9 @@ jobs:
           # that the version number is already correct, and we only need to drop the
           # -SNAPSHOT suffix.
           if [[ "${CHECKOUT_REF}" == "develop" ]]; then
-            ./gradlew --no-configuration-cache --no-daemon clearPreRelease
+            ./gradlew --no-daemon clearPreRelease
           else
-            ./gradlew --no-configuration-cache --no-daemon bumpPatch
+            ./gradlew --no-daemon bumpPatch
           fi
 
           # Commit changes to the versioning

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,6 +44,13 @@ jobs:
       with:
         arguments: spotlessCheck
 
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -85,6 +92,13 @@ jobs:
           name: Test report
           path: app/build/reports
 
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/
+
   build-apks:
     runs-on: ubuntu-latest
     steps:
@@ -118,6 +132,13 @@ jobs:
       uses: gradle/gradle-build-action@v2.2.0
       with:
         arguments: assembleFreeDebug assembleNonFreeDebug
+
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/
 
   check-api:
     runs-on: ubuntu-latest
@@ -153,6 +174,13 @@ jobs:
       with:
         arguments: apiCheck
 
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/
+
   lint-debug:
     runs-on: ubuntu-latest
     steps:
@@ -187,6 +215,13 @@ jobs:
       with:
         arguments: lintDebug
 
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/
+
   assemble-release-apks:
     runs-on: ubuntu-latest
     steps:
@@ -220,3 +255,10 @@ jobs:
       uses: gradle/gradle-build-action@v2.2.0
       with:
         arguments: aNFR
+
+    - name: Upload Kotlin build report
+      if: "${{ always() }}"
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: Build report
+          path: build/reports/kotlin-build/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache spotlessCheck
+        arguments: spotlessCheck
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache test -PslimTests
+        arguments: test -PslimTests
 
     - name: (Fail-only) Upload test report
       if: "${{ failure() }}"
@@ -117,7 +117,7 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache assembleFreeDebug assembleNonFreeDebug
+        arguments: assembleFreeDebug assembleNonFreeDebug
 
   check-api:
     runs-on: ubuntu-latest
@@ -151,7 +151,7 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache apiCheck
+        arguments: apiCheck
 
   lint-debug:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache lintDebug
+        arguments: lintDebug
 
   assemble-release-apks:
     runs-on: ubuntu-latest
@@ -219,4 +219,4 @@ jobs:
       if: "${{ steps.service-changed.outputs.result == 'true' }}"
       uses: gradle/gradle-build-action@v2.2.0
       with:
-        arguments: --no-configuration-cache aNFR
+        arguments: aNFR

--- a/.github/workflows/shadow_job.yml
+++ b/.github/workflows/shadow_job.yml
@@ -44,4 +44,4 @@ jobs:
       env:
         GRADLE_VERSION_OVERRIDE_com_android_tools_build_gradle: ${{ matrix.agp-version }}
       with:
-        arguments: --no-configuration-cache check
+        arguments: check

--- a/.github/workflows/sync_crowdin.yml
+++ b/.github/workflows/sync_crowdin.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download new translations from Crowdin
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: --no-configuration-cache crowdin
+          arguments: crowdin
         env:
           CROWDIN_LOGIN: ${{ secrets.CROWDIN_LOGIN }}
           CROWDIN_PROJECT_KEY: ${{ secrets.CROWDIN_PROJECT_KEY }}

--- a/.github/workflows/update_publicsuffix_data.yml
+++ b/.github/workflows/update_publicsuffix_data.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download new publicsuffix data
         uses: gradle/gradle-build-action@v2.2.0
         with:
-          arguments: --no-configuration-cache updatePSL
+          arguments: updatePSL
 
       - name: Compare list changes
         run: if [[ $(git diff --binary --stat) != "" ]]; then echo "UPDATED=true" >> $GITHUB_ENV; fi
@@ -29,7 +29,7 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.0
         if: "${{ env.UPDATED == 'true' }}"
         with:
-          arguments: --no-configuration-cache :autofill-parser:test -PslimTests
+          arguments: :autofill-parser:test -PslimTests
 
       - name: Create Pull Request
         id: cpr

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,9 @@ kapt.include.compile.classpath=false
 kotlin.incremental.useClasspathSnapshot=true
 kotlin.build.report.output=file
 
+# Disable Gradle task that breaks configuration caching
+kotlin.mpp.enableKotlinToolingMetadataArtifact=false
+
 # Use R8 instead of ProGuard for code shrinking.
 android.enableR8.fullMode=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,10 @@ kapt.incremental.apt=true
 # Turn off AP discovery in compile path to enable compile avoidance
 kapt.include.compile.classpath=false
 
+# New incremental compilation for Kotlin
+kotlin.incremental.useClasspathSnapshot=true
+kotlin.build.report.output=file
+
 # Use R8 instead of ProGuard for code shrinking.
 android.enableR8.fullMode=true
 


### PR DESCRIPTION
Opt into new incremental compilation backend, enable Kotlin build reports and workaround configuration cache bugs from Kotlin 1.7.
