### PR TITLE
Misc cleanups

### DIFF
--- a/.github/workflows/shadow_job.yml
+++ b/.github/workflows/shadow_job.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Run checks
       uses: gradle/gradle-build-action@v2.2.0
       env:
-        GRADLE_VERSION_OVERRIDE_com_android_tools_build_gradle: ${{ matrix.agp-version }}
+        DEP_OVERRIDE: true
+        DEP_OVERRIDE_agp: ${{ matrix.agp-version }}
       with:
         arguments: check

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - [Mull](https://f-droid.org/packages/us.spotco.fennec_dos/) is now supported as an Autofill-capable browser.
+- Raise target SDK to 31 
 
 ## [1.1.0]
 

--- a/autofill-parser/src/main/AndroidManifest.xml
+++ b/autofill-parser/src/main/AndroidManifest.xml
@@ -3,4 +3,13 @@
   ~ SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
   -->
 
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
+  </queries>
+</manifest>

--- a/build-logic/android-plugins/build.gradle.kts
+++ b/build-logic/android-plugins/build.gradle.kts
@@ -59,17 +59,3 @@ dependencies {
   implementation(libs.build.semver)
   implementation(libs.build.sentry)
 }
-
-configurations.all {
-  resolutionStrategy.eachDependency {
-    val overrideName =
-      "GRADLE_VERSION_OVERRIDE_${requested.group.replace('.', '_')}_${requested.name}"
-    val overridenVersion = System.getenv(overrideName)
-    if (!overridenVersion.isNullOrEmpty()) {
-      project.logger.lifecycle(
-        "Overriding dependency ${requested.group}:${requested.name} to version $overridenVersion"
-      )
-      useVersion(overridenVersion)
-    }
-  }
-}

--- a/build-logic/android-plugins/src/main/kotlin/dev/msfjarvis/aps/gradle/versioning/VersioningTask.kt
+++ b/build-logic/android-plugins/src/main/kotlin/dev/msfjarvis/aps/gradle/versioning/VersioningTask.kt
@@ -39,6 +39,10 @@ abstract class VersioningTask : DefaultTask() {
     }
   }
 
+  override fun getGroup(): String {
+    return "versioning"
+  }
+
   @TaskAction
   fun execute() {
     propertyFile.get().asFile.writeText(Semver(semverString.get()).toPropFileText())

--- a/build-logic/kotlin-plugins/build.gradle.kts
+++ b/build-logic/kotlin-plugins/build.gradle.kts
@@ -59,17 +59,3 @@ dependencies {
   implementation(libs.build.kotlin)
   implementation(libs.build.spotless)
 }
-
-configurations.all {
-  resolutionStrategy.eachDependency {
-    val overrideName =
-      "GRADLE_VERSION_OVERRIDE_${requested.group.replace('.', '_')}_${requested.name}"
-    val overridenVersion = System.getenv(overrideName)
-    if (!overridenVersion.isNullOrEmpty()) {
-      project.logger.lifecycle(
-        "Overriding dependency ${requested.group}:${requested.name} to version $overridenVersion"
-      )
-      useVersion(overridenVersion)
-    }
-  }
-}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -27,7 +27,19 @@ dependencyResolutionManagement {
     }
     mavenCentral()
   }
-  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+  versionCatalogs {
+    maybeCreate("libs").apply {
+      from(files("../gradle/libs.versions.toml"))
+      if (System.getenv("DEP_OVERRIDE") == "true") {
+        val overrides = System.getenv().filterKeys { it.startsWith("DEP_OVERRIDE_") }
+        for ((key, value) in overrides) {
+          val catalogKey = key.removePrefix("DEP_OVERRIDE_").toLowerCase()
+          println("Overriding $catalogKey with $value")
+          version(catalogKey, value)
+        }
+      }
+    }
+  }
 }
 
 include("android-plugins")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
-# Centralized versions for dependencies that share versions
 [versions]
+agp = "7.2.1"
 androidx_activity = "1.5.0-rc01"
 compose = "1.2.0-alpha08"
 coroutines = "1.6.2"
@@ -38,7 +38,7 @@ androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.
 aps-sublimeFuzzy = "com.github.android-password-store:sublime-fuzzy:2.2.0"
 aps-zxingAndroidEmbedded = "com.github.android-password-store:zxing-android-embedded:4.2.1"
 
-build-agp = "com.android.tools.build:gradle:7.2.1"
+build-agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 build-binarycompat = "org.jetbrains.kotlinx:binary-compatibility-validator:0.10.0"
 build-download = "de.undercouch:gradle-download-task:5.1.0"
 build-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
- Update our shadow jobs logic to override versions from the catalog instead of modifying configuration resolution, taken from [slack-gradle-plugin](https://github.com/slackhq/slack-gradle-plugin/blob/be41e7ecdbf0790316fd2c26ded445c7a0d75c38/settings.gradle.kts#L17-L27)
- Add the `<queries>` tag to `autofill-parser` for proper API 31 support
- Updates versioning plugin to set a description and group, workaround AGP 7.4 deprecations and use an `AtomicBoolean` to signal plugin application (taken from [app-versioning](https://github.com/ReactiveCircus/app-versioning/blob/891a5c2bbff70ae1eefc434bb9654806dd613e92/src/main/kotlin/io/github/reactivecircus/appversioning/AppVersioningPlugin.kt#L64-L66))