### PR TITLE
Add a toggle for ASCII armored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 -   Introduce crash reporting backed by Sentry
 -   TOTP field now shows the remaining time for which it is valid
 -   Allow customizing the timeout for decrypted password screen
+-   Allow toggling ASCII armored output
 
 ### Fixed
 

--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -6,6 +6,8 @@
 package app.passwordstore.data.crypto
 
 import app.passwordstore.crypto.GpgIdentifier
+import app.passwordstore.crypto.PGPDecryptOptions
+import app.passwordstore.crypto.PGPEncryptOptions
 import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.crypto.PGPainlessCryptoHandler
 import app.passwordstore.crypto.errors.CryptoHandlerException
@@ -42,8 +44,9 @@ constructor(
     message: ByteArrayInputStream,
     out: ByteArrayOutputStream,
   ): Result<Unit, CryptoHandlerException> {
+    val decryptionOptions = PGPDecryptOptions.Builder().build()
     val keys = pgpKeyManager.getAllKeys().unwrap()
-    return pgpCryptoHandler.decrypt(keys, password, message, out)
+    return pgpCryptoHandler.decrypt(keys, password, message, out, decryptionOptions)
   }
 
   private suspend fun encryptPgp(
@@ -51,11 +54,13 @@ constructor(
     content: ByteArrayInputStream,
     out: ByteArrayOutputStream,
   ): Result<Unit, CryptoHandlerException> {
+    val encryptionOptions = PGPEncryptOptions.Builder().build()
     val keys = identities.map { id -> pgpKeyManager.getKeyById(id) }.getAll()
     return pgpCryptoHandler.encrypt(
       keys,
       content,
       out,
+      encryptionOptions,
     )
   }
 }

--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -5,12 +5,15 @@
 
 package app.passwordstore.data.crypto
 
+import android.content.SharedPreferences
 import app.passwordstore.crypto.GpgIdentifier
 import app.passwordstore.crypto.PGPDecryptOptions
 import app.passwordstore.crypto.PGPEncryptOptions
 import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.crypto.PGPainlessCryptoHandler
 import app.passwordstore.crypto.errors.CryptoHandlerException
+import app.passwordstore.injection.prefs.SettingsPreferences
+import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getAll
 import com.github.michaelbull.result.unwrap
@@ -25,6 +28,7 @@ class CryptoRepository
 constructor(
   private val pgpKeyManager: PGPKeyManager,
   private val pgpCryptoHandler: PGPainlessCryptoHandler,
+  @SettingsPreferences private val settings: SharedPreferences,
 ) {
 
   suspend fun decrypt(
@@ -54,7 +58,10 @@ constructor(
     content: ByteArrayInputStream,
     out: ByteArrayOutputStream,
   ): Result<Unit, CryptoHandlerException> {
-    val encryptionOptions = PGPEncryptOptions.Builder().build()
+    val encryptionOptions =
+      PGPEncryptOptions.Builder()
+        .withAsciiArmor(settings.getBoolean(PreferenceKeys.ASCII_ARMOR, false))
+        .build()
     val keys = identities.map { id -> pgpKeyManager.getKeyById(id) }.getAll()
     return pgpCryptoHandler.encrypt(
       keys,

--- a/app/src/main/java/app/passwordstore/ui/settings/PGPSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/PGPSettings.kt
@@ -9,9 +9,11 @@ import androidx.fragment.app.FragmentActivity
 import app.passwordstore.ui.pgp.PGPKeyImportActivity
 import app.passwordstore.ui.pgp.PGPKeyListActivity
 import app.passwordstore.util.extensions.launchActivity
+import app.passwordstore.util.settings.PreferenceKeys
 import de.Maxr1998.modernpreferences.PreferenceScreen
 import de.Maxr1998.modernpreferences.helpers.onClick
 import de.Maxr1998.modernpreferences.helpers.pref
+import de.Maxr1998.modernpreferences.helpers.switch
 
 class PGPSettings(private val activity: FragmentActivity) : SettingsProvider {
 
@@ -32,6 +34,10 @@ class PGPSettings(private val activity: FragmentActivity) : SettingsProvider {
           activity.launchActivity(PGPKeyListActivity::class.java)
           false
         }
+      }
+      switch(PreferenceKeys.ASCII_ARMOR) {
+        title = "Encrypt in ASCII armor mode"
+        persistent = true
       }
     }
   }

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -85,4 +85,5 @@ object PreferenceKeys {
   const val DICEWARE_SEPARATOR = "diceware_separator"
   const val DICEWARE_LENGTH = "diceware_length"
   const val DISABLE_SYNC_ACTION = "disable_sync_action"
+  const val ASCII_ARMOR = "pgpainless_ascii_armor"
 }

--- a/crypto-common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
+++ b/crypto-common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
@@ -11,7 +11,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 /** Generic interface to implement cryptographic operations on top of. */
-public interface CryptoHandler<Key> {
+public interface CryptoHandler<Key, EncOpts : CryptoOptions, DecryptOpts : CryptoOptions> {
 
   /**
    * Decrypt the given [ciphertextStream] using a set of potential [keys] and [passphrase], and
@@ -24,6 +24,7 @@ public interface CryptoHandler<Key> {
     passphrase: String,
     ciphertextStream: InputStream,
     outputStream: OutputStream,
+    options: DecryptOpts,
   ): Result<Unit, CryptoHandlerException>
 
   /**
@@ -35,6 +36,7 @@ public interface CryptoHandler<Key> {
     keys: List<Key>,
     plaintextStream: InputStream,
     outputStream: OutputStream,
+    options: EncOpts,
   ): Result<Unit, CryptoHandlerException>
 
   /** Given a [fileName], return whether this instance can handle it. */

--- a/crypto-common/src/main/kotlin/app/passwordstore/crypto/CryptoOptions.kt
+++ b/crypto-common/src/main/kotlin/app/passwordstore/crypto/CryptoOptions.kt
@@ -1,0 +1,8 @@
+package app.passwordstore.crypto
+
+/** Defines the contract for a grab-bag of options for individual cryptographic operations. */
+public interface CryptoOptions {
+
+  /** Returns a [Boolean] indicating if the [option] is enabled for this operation. */
+  public fun isOptionEnabled(option: String): Boolean
+}

--- a/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPDecryptOptions.kt
+++ b/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPDecryptOptions.kt
@@ -1,0 +1,21 @@
+package app.passwordstore.crypto
+
+/** [CryptoOptions] implementation for PGPainless decrypt operations. */
+public class PGPDecryptOptions
+private constructor(
+  private val values: Map<String, Boolean>,
+) : CryptoOptions {
+
+  override fun isOptionEnabled(option: String): Boolean {
+    return values.getOrDefault(option, false)
+  }
+
+  /** Implementation of a builder pattern for [PGPDecryptOptions]. */
+  public class Builder {
+
+    /** Build the final [PGPDecryptOptions] object. */
+    public fun build(): PGPDecryptOptions {
+      return PGPDecryptOptions(emptyMap())
+    }
+  }
+}

--- a/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPEncryptOptions.kt
+++ b/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPEncryptOptions.kt
@@ -1,0 +1,35 @@
+package app.passwordstore.crypto
+
+/** [CryptoOptions] implementation for PGPainless encrypt operations. */
+public class PGPEncryptOptions
+private constructor(
+  private val values: Map<String, Boolean>,
+) : CryptoOptions {
+
+  internal companion object {
+    const val ASCII_ARMOR = "ASCII_ARMOR"
+  }
+
+  override fun isOptionEnabled(option: String): Boolean {
+    return values.getOrDefault(option, false)
+  }
+
+  /** Implementation of a builder pattern for [PGPEncryptOptions]. */
+  public class Builder {
+    private val optionsMap = mutableMapOf<String, Boolean>()
+
+    /**
+     * Toggle whether the encryption operation output will be ASCII armored or in OpenPGP's binary
+     * format.
+     */
+    public fun withAsciiArmor(enabled: Boolean): Builder {
+      optionsMap[ASCII_ARMOR] = enabled
+      return this
+    }
+
+    /** Build the final [PGPEncryptOptions] object. */
+    public fun build(): PGPEncryptOptions {
+      return PGPEncryptOptions(optionsMap)
+    }
+  }
+}

--- a/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -27,13 +27,15 @@ import org.pgpainless.exception.WrongPassphraseException
 import org.pgpainless.key.protection.SecretKeyRingProtector
 import org.pgpainless.util.Passphrase
 
-public class PGPainlessCryptoHandler @Inject constructor() : CryptoHandler<PGPKey> {
+public class PGPainlessCryptoHandler @Inject constructor() :
+  CryptoHandler<PGPKey, PGPEncryptOptions, PGPDecryptOptions> {
 
   public override fun decrypt(
     keys: List<PGPKey>,
     passphrase: String,
     ciphertextStream: InputStream,
     outputStream: OutputStream,
+    options: PGPDecryptOptions,
   ): Result<Unit, CryptoHandlerException> =
     runCatching {
         if (keys.isEmpty()) throw NoKeysProvided("No keys provided for encryption")
@@ -63,6 +65,7 @@ public class PGPainlessCryptoHandler @Inject constructor() : CryptoHandler<PGPKe
     keys: List<PGPKey>,
     plaintextStream: InputStream,
     outputStream: OutputStream,
+    options: PGPEncryptOptions,
   ): Result<Unit, CryptoHandlerException> =
     runCatching {
         if (keys.isEmpty()) throw NoKeysProvided("No keys provided for encryption")

--- a/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto-pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -83,7 +83,9 @@ public class PGPainlessCryptoHandler @Inject constructor() :
         require(publicKeyRings.isNotEmpty()) { "No public keys to encrypt message to" }
         val publicKeyRingCollection = PGPPublicKeyRingCollection(publicKeyRings)
         val encryptionOptions = EncryptionOptions().addRecipients(publicKeyRingCollection)
-        val producerOptions = ProducerOptions.encrypt(encryptionOptions).setAsciiArmor(false)
+        val producerOptions =
+          ProducerOptions.encrypt(encryptionOptions)
+            .setAsciiArmor(options.isOptionEnabled(PGPEncryptOptions.ASCII_ARMOR))
         val encryptor =
           PGPainless.encryptAndOrSign().onOutputStream(outputStream).withOptions(producerOptions)
         plaintextStream.copyTo(encryptor)

--- a/crypto-pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
@@ -13,6 +13,7 @@ import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import java.io.ByteArrayOutputStream
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
@@ -79,6 +80,23 @@ class PGPainlessCryptoHandlerTest {
       )
     assertIs<Err<Throwable>>(result)
     assertIs<IncorrectPassphraseException>(result.getError())
+  }
+
+  @Test
+  fun encryptAsciiArmored() {
+    val ciphertextStream = ByteArrayOutputStream()
+    val encryptRes =
+      cryptoHandler.encrypt(
+        encryptionKey.keySet,
+        CryptoConstants.PLAIN_TEXT.byteInputStream(Charsets.UTF_8),
+        ciphertextStream,
+        PGPEncryptOptions.Builder().withAsciiArmor(true).build(),
+      )
+    assertIs<Ok<Unit>>(encryptRes)
+    val ciphertext = ciphertextStream.toString(Charsets.UTF_8)
+    assertContains(ciphertext, "Version: PGPainless")
+    assertContains(ciphertext, "-----BEGIN PGP MESSAGE-----")
+    assertContains(ciphertext, "-----END PGP MESSAGE-----")
   }
 
   @Test

--- a/crypto-pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
+++ b/crypto-pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
@@ -41,6 +41,7 @@ class PGPainlessCryptoHandlerTest {
         encryptionKey.keySet,
         CryptoConstants.PLAIN_TEXT.byteInputStream(Charsets.UTF_8),
         ciphertextStream,
+        PGPEncryptOptions.Builder().build(),
       )
     assertIs<Ok<Unit>>(encryptRes)
     val plaintextStream = ByteArrayOutputStream()
@@ -50,6 +51,7 @@ class PGPainlessCryptoHandlerTest {
         CryptoConstants.KEY_PASSPHRASE,
         ciphertextStream.toByteArray().inputStream(),
         plaintextStream,
+        PGPDecryptOptions.Builder().build(),
       )
     assertIs<Ok<Unit>>(decryptRes)
     assertEquals(CryptoConstants.PLAIN_TEXT, plaintextStream.toString(Charsets.UTF_8))
@@ -63,6 +65,7 @@ class PGPainlessCryptoHandlerTest {
         encryptionKey.keySet,
         CryptoConstants.PLAIN_TEXT.byteInputStream(Charsets.UTF_8),
         ciphertextStream,
+        PGPEncryptOptions.Builder().build(),
       )
     assertIs<Ok<Unit>>(encryptRes)
     val plaintextStream = ByteArrayOutputStream()
@@ -72,6 +75,7 @@ class PGPainlessCryptoHandlerTest {
         "very incorrect passphrase",
         ciphertextStream.toByteArray().inputStream(),
         plaintextStream,
+        PGPDecryptOptions.Builder().build(),
       )
     assertIs<Err<Throwable>>(result)
     assertIs<IncorrectPassphraseException>(result.getError())


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Adds a switch to PGP settings that allows toggling ASCII armored output

## :bulb: Motivation and Context

Fixes #2189 

## :green_heart: How did you test it?

Included unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
