### PR TITLE
Add mail as username heuristic term

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FormField.kt
@@ -138,6 +138,7 @@ internal class FormField(
         "benutzername",
         "e-mail",
         "email",
+        "mail",
         "login",
         "user",
       )


### PR DESCRIPTION
This adds `mail` as username heuristic term, which I use in my store.

This is already supported in other places, see:

https://github.com/android-password-store/Android-Password-Store/blob/2fbad7ef6b42cc30c5eac79d5d166bba7cba42a4/format-common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt#L218