### PR TITLE
Backport "disable pull-to-sync" feature

### DIFF
--- a/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/PasswordFragment.kt
@@ -258,6 +258,11 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
         }
     }
 
+    override fun onResume() {
+	super.onResume()
+        binding.swipeRefresher.isEnabled = !settings.getBoolean(PreferenceKeys.DISABLE_SYNC_ACTION, false)
+    }
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         runCatching {

--- a/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
+++ b/app/src/main/java/com/zeapo/pwdstore/utils/PreferenceKeys.kt
@@ -62,6 +62,7 @@ object PreferenceKeys {
     const val REPO_CHANGED = "repo_changed"
     const val SEARCH_ON_START = "search_on_start"
     const val SHOW_EXTRA_CONTENT = "show_extra_content"
+    const val DISABLE_SYNC_ACTION = "disable_sync_action"
 
     @Deprecated(
         message = "Use SHOW_HIDDEN_CONTENTS instead",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
     <string name="ssh_key_success_dialog_title">SSH-key imported</string>
     <string name="ssh_key_error_dialog_title">Key import error</string>
     <string name="ssh_key_error_dialog_text">Message : \n</string>
+    <string name="pref_disable_sync_action">Disable pull-to-sync</string>
+    <string name="pref_disable_sync_action_hint">Prevents git syncing when swiping down</string>
     <string name="pref_recursive_filter">Recursive filtering</string>
     <string name="pref_recursive_filter_hint">Recursively find passwords of the current directory.</string>
     <string name="pref_sort_order_title">Password sort order</string>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -119,6 +119,11 @@
             app:summary="%s"
             app:title="@string/pref_sort_order_title" />
         <CheckBoxPreference
+            app:defaultValue="false"
+            app:key="disable_sync_action"
+            app:summary="@string/pref_disable_sync_action_hint"
+            app:title="@string/pref_disable_sync_action" />
+        <CheckBoxPreference
             app:defaultValue="true"
             app:key="filter_recursively"
             app:summary="@string/pref_recursive_filter_hint"


### PR DESCRIPTION
Backports #1922 
Additionally allows users to use app in read-only mode (#1982).

Please bump version to 1.13.6. Users will rejoice seeing update after 1.5 years ;-)
What they don't know is awesome 2.0 is coming.

Thanks @msfjarvis for continuous work. Tried the latest snapshot, feels like breath of fresh air. Daily driving it now.