### PR TITLE
Support Mull browser from divestos.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
--   Add [Mull (divestos.org)](https://divestos.org/pages/our_apps#mull) to supported browsers list for Autofill
-
 ### Added
 
 -   On Android 11, Autofill will use the new [inline autofill](https://developer.android.com/guide/topics/text/ime-autofill#configure-provider) UI that integrates Autofill results into your keyboard app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+-   Add [Mull (divestos.org)](https://divestos.org/pages/our_apps#mull) to supported browsers list for Autofill
+
 ### Added
 
 -   On Android 11, Autofill will use the new [inline autofill](https://developer.android.com/guide/topics/text/ime-autofill#configure-provider) UI that integrates Autofill results into your keyboard app.

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -10,9 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1.2]
 
+### Added
+
 - [Vivaldi](https://play.google.com/store/apps/details?id=com.vivaldi.browser) is now supported as an Autofill-capable browser.
 - [Vanadium](https://github.com/GrapheneOS/Vanadium) is now supported as an Autofill-capable browser.
 - `mail` is now included in the heuristics for username fields
+
+### Changed
+
 - Dependency updates
     - `androidx.core:core-ktx:1.10.1`
     - `androidx.autofill:autofill:1.2.0-beta01`

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -6,12 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- [Mull](https://divestos.org/pages/our_apps#mull) is now supported as an Autofill-capable browser when installed from the divestos.org [repo](https://divestos.org/fdroid/official/).
+
 ## [1.1.2]
 
 - [Vivaldi](https://play.google.com/store/apps/details?id=com.vivaldi.browser) is now supported as an Autofill-capable browser.
 - [Vanadium](https://github.com/GrapheneOS/Vanadium) is now supported as an Autofill-capable browser.
 - `mail` is now included in the heuristics for username fields
-- [Mull (divestos.org)](https://divestos.org/pages/our_apps#mull) is now supported as an Autofill-capable browser.
 - Dependency updates
     - `androidx.core:core-ktx:1.10.1`
     - `androidx.autofill:autofill:1.2.0-beta01`

--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - [Vivaldi](https://play.google.com/store/apps/details?id=com.vivaldi.browser) is now supported as an Autofill-capable browser.
 - [Vanadium](https://github.com/GrapheneOS/Vanadium) is now supported as an Autofill-capable browser.
 - `mail` is now included in the heuristics for username fields
+- [Mull (divestos.org)](https://divestos.org/pages/our_apps#mull) is now supported as an Autofill-capable browser.
 - Dependency updates
     - `androidx.core:core-ktx:1.10.1`
     - `androidx.autofill:autofill:1.2.0-beta01`

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -81,8 +81,11 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "org.ungoogled.chromium.extensions.stable" to
       arrayOf("29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk="),
     "com.kiwibrowser.browser" to arrayOf("wGnqlmMy6R4KDDzFd+b1Cf49ndr3AVrQxcXvj9o/hig="),
-    "us.spotco.fennec_dos" to arrayOf("Jg4KSWeMeLcMAtZTet07bcChcXG73oznX9QCaoo+GNI="),
-    "us.spotco.fennec_dos_fdroid" to arrayOf("/4H1vlY5ZZTu5w/vKDIlbhUhQSLiupzt0mAF/9S8qqg="),
+    "us.spotco.fennec_dos" to
+      arrayOf(
+        "Jg4KSWeMeLcMAtZTet07bcChcXG73oznX9QCaoo+GNI=",
+        "/4H1vlY5ZZTu5w/vKDIlbhUhQSLiupzt0mAF/9S8qqg="
+      ),
     "com.vivaldi.browser" to arrayOf("6KeFRGVbqMCYF/cydo9WibFmLsSyvFoLwOwTjTPKPR4="),
     "app.vanadium.browser" to arrayOf("xq24uDxtTBfSkq/eVv1IilHTFv+PLBHFQQIjv/in27M="),
   )
@@ -127,7 +130,6 @@ private val BROWSER_MULTI_ORIGIN_METHOD =
     "org.mozilla.klar" to BrowserMultiOriginMethod.Field,
     "org.torproject.torbrowser" to BrowserMultiOriginMethod.WebView,
     "us.spotco.fennec_dos" to BrowserMultiOriginMethod.Field,
-    "us.spotco.fennec_dos_fdroid" to BrowserMultiOriginMethod.Field,
   )
 
 private fun getBrowserMultiOriginMethod(appPackage: String): BrowserMultiOriginMethod =

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -81,7 +81,8 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "org.ungoogled.chromium.extensions.stable" to
       arrayOf("29UOO5cXoxO/e/hH3hOu6bbtg1My4tK6Eik2Ym5Krtk="),
     "com.kiwibrowser.browser" to arrayOf("wGnqlmMy6R4KDDzFd+b1Cf49ndr3AVrQxcXvj9o/hig="),
-    "us.spotco.fennec_dos" to arrayOf("/4H1vlY5ZZTu5w/vKDIlbhUhQSLiupzt0mAF/9S8qqg="),
+    "us.spotco.fennec_dos" to arrayOf("Jg4KSWeMeLcMAtZTet07bcChcXG73oznX9QCaoo+GNI="),
+    "us.spotco.fennec_dos_fdroid" to arrayOf("/4H1vlY5ZZTu5w/vKDIlbhUhQSLiupzt0mAF/9S8qqg="),
     "com.vivaldi.browser" to arrayOf("6KeFRGVbqMCYF/cydo9WibFmLsSyvFoLwOwTjTPKPR4="),
     "app.vanadium.browser" to arrayOf("xq24uDxtTBfSkq/eVv1IilHTFv+PLBHFQQIjv/in27M="),
   )
@@ -126,6 +127,7 @@ private val BROWSER_MULTI_ORIGIN_METHOD =
     "org.mozilla.klar" to BrowserMultiOriginMethod.Field,
     "org.torproject.torbrowser" to BrowserMultiOriginMethod.WebView,
     "us.spotco.fennec_dos" to BrowserMultiOriginMethod.Field,
+    "us.spotco.fennec_dos_fdroid" to BrowserMultiOriginMethod.Field,
   )
 
 private fun getBrowserMultiOriginMethod(appPackage: String): BrowserMultiOriginMethod =


### PR DESCRIPTION
Currently the app supports this source for the mull browser: https://f-droid.org/repo/us.spotco.fennec_dos_21150020.apk

It would be nice if it supported the upstream one too, as it is updated faster: https://divestos.org/fdroid/official/us.spotco.fennec_dos_21152120.apk