### PR TITLE
fix: temporarily disable pre-launch biometric auth

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/main/LaunchActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/main/LaunchActivity.kt
@@ -25,14 +25,14 @@ class LaunchActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val prefs = sharedPrefs
-    if (prefs.getBoolean(PreferenceKeys.BIOMETRIC_AUTH, false)) {
+    if (prefs.getBoolean(PreferenceKeys.BIOMETRIC_AUTH_2, false)) {
       BiometricAuthenticator.authenticate(this) { result ->
         when (result) {
           is Result.Success -> {
             startTargetActivity(false)
           }
           is Result.HardwareUnavailableOrDisabled -> {
-            prefs.edit { remove(PreferenceKeys.BIOMETRIC_AUTH) }
+            prefs.edit { remove(PreferenceKeys.BIOMETRIC_AUTH_2) }
             startTargetActivity(false)
           }
           is Result.Failure,

--- a/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
@@ -65,14 +65,15 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
         defaultValue = false
       }
 
-      val canAuthenticate = BiometricAuthenticator.canAuthenticate(activity)
-      switch(PreferenceKeys.BIOMETRIC_AUTH) {
+      // val canAuthenticate = BiometricAuthenticator.canAuthenticate(activity)
+      switch(PreferenceKeys.BIOMETRIC_AUTH_2) {
         titleRes = R.string.pref_biometric_auth_title
         defaultValue = false
-        enabled = canAuthenticate
-        summaryRes =
-          if (canAuthenticate) R.string.pref_biometric_auth_summary
-          else R.string.pref_biometric_auth_summary_error
+        enabled = false
+        // summaryRes =
+        //   if (canAuthenticate) R.string.pref_biometric_auth_summary
+        //   else R.string.pref_biometric_auth_summary_error
+        summary = "Temporarily disabled due to a bug, see issue 2802"
         onClick {
           enabled = false
           val isChecked = checked
@@ -81,7 +82,7 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
               when (result) {
                 is Result.Success -> {
                   // Apply the changes
-                  putBoolean(PreferenceKeys.BIOMETRIC_AUTH, checked)
+                  putBoolean(PreferenceKeys.BIOMETRIC_AUTH_2, checked)
                   enabled = true
                 }
                 is Result.Retry -> {}
@@ -89,7 +90,7 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
                   // If any error occurs, revert back to the previous
                   // state. This
                   // catch-all clause includes the cancellation case.
-                  putBoolean(PreferenceKeys.BIOMETRIC_AUTH, !checked)
+                  putBoolean(PreferenceKeys.BIOMETRIC_AUTH_2, !checked)
                   checked = !isChecked
                   enabled = true
                 }

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -10,6 +10,7 @@ object PreferenceKeys {
   const val APP_THEME = "app_theme"
   const val AUTOFILL_ENABLE = "autofill_enable"
   const val BIOMETRIC_AUTH = "biometric_auth"
+  const val BIOMETRIC_AUTH_2 = "biometric_auth_delete_soon_please"
   @Deprecated(
     message = "Use CLEAR_CLIPBOARD_HISTORY instead",
     replaceWith = ReplaceWith("PreferenceKeys.CLEAR_CLIPBOARD_HISTORY"),

--- a/build-logic/src/main/kotlin/app/passwordstore/gradle/LintConfig.kt
+++ b/build-logic/src/main/kotlin/app/passwordstore/gradle/LintConfig.kt
@@ -40,6 +40,8 @@ object LintConfig {
       disable += "FragmentFieldInjection"
       // Too pedantic
       disable += "ArgInFormattedQuantityStringRes"
+      // Biometric strings are temporarily unused due to issue 2802
+      disable += "UnusedResources"
     }
     baseline = project.file("lint-baseline.xml")
   }


### PR DESCRIPTION
Completely broken right now and prevents users from opening the app.

Updates #2802