### PR TITLE
Add snackbar error message when .gpg-id contains a short hex id

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -170,7 +170,9 @@ open class BasePGPActivity : AppCompatActivity() {
               if (line.isEmpty()) return@run
               // Apparently `gpg-id` being the first line is also acceptable?
               if (line == "gpg-id") return@run
-              if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex()).not()) {
+              if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {
+                snackbar(message = resources.getString(R.string.short_gpg_id))
+              } else {
                 snackbar(message = resources.getString(R.string.invalid_gpg_id))
               }
               return null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
   <string name="otp_import_failure_no_selection">No image file was selected</string>
   <string name="exporting_passwords">Exporting passwords…</string>
   <string name="invalid_gpg_id">Found .gpg-id, but it contains an invalid key ID, fingerprint or user ID</string>
+  <string name="short_gpg_id">Found .gpg-id, but it contains a short hex ID, which is not supported</string>
   <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
   <string name="directory_hint">Directory</string>
   <string name="new_folder_set_gpg_key">Set GPG key for directory</string>


### PR DESCRIPTION
I used the first version of Android-Password-Store several years ago with a .gpg-id containing a short 8-digit hex id, and this worked fine. When I installed the latest snapshot, it didn't work: when I went to decrypt any password, nothing would show up.
It turns out that Android-Password-Store doesn't support short hex ids, but there is no user feedback when this problem arises.

Add an error message when a .gpg-id file with a short hex id is found.