### PR TITLE
Autofill: add support for Cromite 

### DIFF
--- a/autofill-parser/CHANGELOG.md
+++ b/autofill-parser/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - [Mull](https://divestos.org/pages/our_apps#mull) is now supported as an Autofill-capable browser when installed from the divestos.org [repo](https://divestos.org/fdroid/official/).
+- [Cromite](https://github.com/uazo/cromite) is now supported as an Autofill-capable browser.
 
 ## [1.1.2]
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -67,6 +67,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "com.opera.mini.native.beta" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.touch" to arrayOf("qtjiBNJNF3k0yc0MY8xqo4779CxKaVcJfiIQ9X+qZ6o="),
     "org.bromite.bromite" to arrayOf("4e5c0HbXsNyEyytF+3i4bfLrOaO2xWuj3CkqXgw7lQQ="),
+    "org.cromite.cromite" to arrayOf("Yz+kHYIR1tCRaoGbiWaMbekuZCMtpn+dFv2Bw7fpI/8="),
     "org.gnu.icecat" to arrayOf("wi2iuVvK/WYZUzd2g0Qzn9ef3kAisQURZ8U1WSMTkcM="),
     "org.mozilla.fenix" to arrayOf("UAR3kIjn+YjVvFzF+HmP6/T4zQhKGypG79TI7krq8hE="),
     "org.mozilla.fenix.nightly" to arrayOf("d+rEzu02r++6dheZMd1MwZWrDNVLrzVdIV57vdKOQCo="),
@@ -164,6 +165,7 @@ private val BROWSER_SAVE_FLAG_IF_NO_ACCESSIBILITY =
     "com.chrome.canary" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "com.chrome.dev" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "org.bromite.bromite" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
+    "org.cromite.cromite" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
     "org.ungoogled.chromium.stable" to SaveInfo.FLAG_SAVE_ON_ALL_VIEWS_INVISIBLE,
   )
 


### PR DESCRIPTION
As mentioned in #2628 , Cromite now seems to be stable enough to allow for Autofill like Bitwarden also already has.

I just rebased @C0unt-zero's commit to the current state of develop. If I understood #2628 correctly that's all that needed doing.