### PR TITLE
Update BasePGPActivity.kt with Clip extra sensitive description

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -6,6 +6,7 @@
 package app.passwordstore.ui.crypto
 
 import android.content.ClipData
+import android.content.ClipDescription
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
@@ -94,8 +95,13 @@ open class BasePGPActivity : AppCompatActivity() {
   ) {
     val clipboard = clipboard ?: return
     val clip = ClipData.newPlainText("pgp_handler_result_pm", text)
-    clip.description.extras =
-      PersistableBundle().apply { putBoolean("android.content.extra.IS_SENSITIVE", true) }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      clip.description.extras =
+        PersistableBundle().apply { putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true) }
+    } else {
+      clip.description.extras =
+        PersistableBundle().apply { putBoolean("android.content.extra.IS_SENSITIVE", true) }
+    }
     clipboard.setPrimaryClip(clip)
     if (showSnackbar && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
       snackbar(message = resources.getString(snackbarTextRes))


### PR DESCRIPTION
My passwords were shown as plaintext in the "snackbar" this change fixes the issue.

This small change makes use of the "new" recommendation for sensitive data: https://developer.android.com/develop/ui/views/touch-and-input/copy-paste

Backward SDK level compatibility should still work.

Change has been tested on device emulator with Android 14.0 API 34