### PR TITLE
feat(pgpainless): add detection for passphrase-less messages

### DIFF
--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -45,8 +45,9 @@ constructor(
     out: ByteArrayOutputStream,
   ) = withContext(dispatcherProvider.io()) { decryptPgp(password, identities, message, out) }
 
-  fun isPasswordProtected(message: ByteArrayInputStream): Boolean {
-    return pgpCryptoHandler.isPassphraseProtected(message)
+  suspend fun isPasswordProtected(identifiers: List<PGPIdentifier>): Boolean {
+    val keys = identifiers.map { pgpKeyManager.getKeyById(it) }.filterValues()
+    return pgpCryptoHandler.isPassphraseProtected(keys)
   }
 
   suspend fun encrypt(

--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -45,6 +45,10 @@ constructor(
     out: ByteArrayOutputStream,
   ) = withContext(dispatcherProvider.io()) { decryptPgp(password, identities, message, out) }
 
+  fun isPasswordProtected(message: ByteArrayInputStream): Boolean {
+    return pgpCryptoHandler.isPassphraseProtected(message)
+  }
+
   suspend fun encrypt(
     identities: List<PGPIdentifier>,
     content: ByteArrayInputStream,

--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
@@ -131,12 +131,16 @@ class AutofillDecryptActivity : BasePGPActivity() {
     }
   }
 
-  private fun askPassphrase(
+  private suspend fun askPassphrase(
     filePath: String,
     identifiers: List<PGPIdentifier>,
     clientState: Bundle,
     action: AutofillAction,
   ) {
+    if (!repository.isPasswordProtected(identifiers)) {
+      decryptWithPassphrase(File(filePath), identifiers, clientState, action, password = "")
+      return
+    }
     val dialog = PasswordDialog()
     dialog.show(supportFragmentManager, "PASSWORD_DIALOG")
     dialog.setFragmentResultListener(PasswordDialog.PASSWORD_RESULT_KEY) { key, bundle ->

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -189,9 +189,7 @@ class DecryptActivity : BasePGPActivity() {
     } else {
       finish()
     }
-    val passFileContents =
-      withContext(dispatcherProvider.io()) { File(fullPath).readBytes().inputStream() }
-    if (!repository.isPasswordProtected(passFileContents)) {
+    if (!repository.isPasswordProtected(gpgIdentifiers)) {
       decryptWithPassphrase(passphrase = "", gpgIdentifiers, authResult)
       return
     }

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -179,7 +179,7 @@ class DecryptActivity : BasePGPActivity() {
     }
   }
 
-  private fun askPassphrase(
+  private suspend fun askPassphrase(
     isError: Boolean,
     gpgIdentifiers: List<PGPIdentifier>,
     authResult: BiometricResult,
@@ -188,6 +188,12 @@ class DecryptActivity : BasePGPActivity() {
       retries += 1
     } else {
       finish()
+    }
+    val passFileContents =
+      withContext(dispatcherProvider.io()) { File(fullPath).readBytes().inputStream() }
+    if (!repository.isPasswordProtected(passFileContents)) {
+      decryptWithPassphrase(passphrase = "", gpgIdentifiers, authResult)
+      return
     }
     val dialog = PasswordDialog()
     if (isError) {

--- a/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
+++ b/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
@@ -43,8 +43,7 @@ public interface CryptoHandler<Key, EncOpts : CryptoOptions, DecryptOpts : Crypt
   public fun canHandle(fileName: String): Boolean
 
   /**
-   * Inspects the given encrypted [message] to notify user if a passphrase is necessary to decrypt
-   * it.
+   * Inspects the given [keys] and returns `false` if none of them require a passphrase to decrypt.
    */
-  public fun isPassphraseProtected(message: InputStream): Boolean
+  public fun isPassphraseProtected(keys: List<Key>): Boolean
 }

--- a/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
+++ b/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
@@ -41,4 +41,10 @@ public interface CryptoHandler<Key, EncOpts : CryptoOptions, DecryptOpts : Crypt
 
   /** Given a [fileName], return whether this instance can handle it. */
   public fun canHandle(fileName: String): Boolean
+
+  /**
+   * Inspects the given encrypted [message] to notify user if a passphrase is necessary to decrypt
+   * it.
+   */
+  public fun isPassphraseProtected(message: InputStream): Boolean
 }

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -23,6 +23,7 @@ import org.bouncycastle.openpgp.PGPSecretKeyRingCollection
 import org.bouncycastle.util.io.Streams
 import org.pgpainless.PGPainless
 import org.pgpainless.decryption_verification.ConsumerOptions
+import org.pgpainless.decryption_verification.MessageInspector
 import org.pgpainless.encryption_signing.EncryptionOptions
 import org.pgpainless.encryption_signing.ProducerOptions
 import org.pgpainless.exception.MessageNotIntegrityProtectedException
@@ -139,5 +140,10 @@ public class PGPainlessCryptoHandler @Inject constructor() :
   /** Runs a naive check on the extension for the given [fileName] to check if it is a PGP file. */
   public override fun canHandle(fileName: String): Boolean {
     return fileName.substringAfterLast('.', "") == "gpg"
+  }
+
+  public override fun isPassphraseProtected(message: InputStream): Boolean {
+    val info = MessageInspector.determineEncryptionInfoForMessage(message)
+    return info.isPassphraseEncrypted
   }
 }

--- a/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
+++ b/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandlerTest.kt
@@ -14,15 +14,19 @@ import com.github.michaelbull.result.getError
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import java.io.ByteArrayOutputStream
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import org.bouncycastle.util.io.Streams
 import org.junit.runner.RunWith
 import org.pgpainless.PGPainless
 import org.pgpainless.decryption_verification.MessageInspector
+import org.pgpainless.encryption_signing.EncryptionOptions
+import org.pgpainless.encryption_signing.ProducerOptions
 
 @Suppress("Unused") // Test runner handles it internally
 enum class EncryptionKey(val keySet: List<PGPKey>) {
@@ -153,6 +157,43 @@ class PGPainlessCryptoHandlerTest {
       )
     assertTrue(res.isErr)
     assertIs<NonStandardAEAD>(res.error, message = "${res.error.cause}")
+  }
+
+  @Test
+  fun detectsKeysWithoutPassphrase() {
+    val plaintextInputStream = "hunter2".byteInputStream()
+    val ciphertextStream = ByteArrayOutputStream()
+    val secretKeyring =
+      PGPainless.generateKeyRing().modernKeyRing("John Doe <john.doe@example.org>")
+    val publicKeyring = PGPainless.extractCertificate(secretKeyring)
+    val encryptionStream =
+      PGPainless.encryptAndOrSign()
+        .onOutputStream(ciphertextStream)
+        .withOptions(
+          ProducerOptions.encrypt(EncryptionOptions.encryptDataAtRest().addRecipient(publicKeyring))
+        )
+    Streams.pipeAll(plaintextInputStream, encryptionStream)
+    encryptionStream.close()
+    assertFalse(cryptoHandler.isPassphraseProtected(ciphertextStream.toByteArray().inputStream()))
+  }
+
+  @Test
+  @Ignore("Doesn't work correctly")
+  fun detectsKeysWithPassphrase() {
+    val plaintextInputStream = "hunter2".byteInputStream()
+    val ciphertextStream = ByteArrayOutputStream()
+    val secretKeyring =
+      PGPainless.generateKeyRing().modernKeyRing("John Doe <john.doe@example.org>", "hunter2")
+    val publicKeyring = PGPainless.extractCertificate(secretKeyring)
+    val encryptionStream =
+      PGPainless.encryptAndOrSign()
+        .onOutputStream(ciphertextStream)
+        .withOptions(
+          ProducerOptions.encrypt(EncryptionOptions.encryptDataAtRest().addRecipient(publicKeyring))
+        )
+    Streams.pipeAll(plaintextInputStream, encryptionStream)
+    encryptionStream.close()
+    assertTrue(cryptoHandler.isPassphraseProtected(ciphertextStream.toByteArray().inputStream()))
   }
 
   @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description
Inspect incoming PGP messages to identify if they need passphrases to decrypt and skip the prompt if not.

## :bulb: Motivation and Context
Fixes #2836

## :green_heart: How did you test it?
Unit tests are included.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I formatted the code `./gradlew spotlessApply`
- [x] I reviewed submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable
