### PR TITLE
clear passphrase cache, fix application crash on auto screen-off

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -11,6 +11,7 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
+import app.passwordstore.Application.Companion.screenWasOff
 import app.passwordstore.R
 import app.passwordstore.crypto.PGPIdentifier
 import app.passwordstore.crypto.errors.CryptoHandlerException
@@ -167,6 +168,11 @@ class DecryptActivity : BasePGPActivity() {
           askPassphrase(isError, gpgIdentifiers, authResult)
         //
         is BiometricResult.Success -> {
+          // clear passphrase cache on first use after application startup or if screen was off
+          if (screenWasOff && settings.getBoolean(PreferenceKeys.CLEAR_PASSPHRASE_CACHE, false)) {
+            passphraseCache.clearAllCachedPassphrases(this@DecryptActivity)
+            screenWasOff = false
+          }
           val cachedPassphrase =
             passphraseCache.retrieveCachedPassphrase(this@DecryptActivity, gpgIdentifiers.first())
           if (cachedPassphrase != null) {

--- a/app/src/main/java/app/passwordstore/ui/settings/PGPSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/PGPSettings.kt
@@ -65,6 +65,22 @@ class PGPSettings(
         titleRes = R.string.pref_passphrase_cache_auto_clear_title
         summaryRes = R.string.pref_passphrase_cache_auto_clear_summary
         defaultValue = false
+        /* clear cache once when unchecking; this is to prevent a malicious user
+         * from bypassing cache clearing via the settings */
+        onCheckedChange { checked ->
+          if (!checked && BiometricAuthenticator.canAuthenticate(activity)) {
+            BiometricAuthenticator.authenticate(
+              activity,
+              R.string.pref_passphrase_cache_authenticate_clear,
+            ) {
+              if (it is BiometricAuthenticator.Result.Success)
+                activity.lifecycleScope.launch {
+                  passphraseCache.clearAllCachedPassphrases(activity)
+                }
+            }
+          }
+          true
+        }
       }
     }
   }


### PR DESCRIPTION
The passphrase cache is now cleared on the first decryption activity after a fresh application start or whenever the phone screen was previously shut off manually or automatically. Also, clearance of the passphrase cache is ensured after a forced application stop. Fixes #3053.
