### PR TITLE
enabling pgp passphrase cache with authentication

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -168,8 +168,9 @@ class DecryptActivity : BasePGPActivity() {
           askPassphrase(isError, gpgIdentifiers, authResult)
         //
         is BiometricResult.Success -> {
-          // clear passphrase cache on first use after application startup or if screen was off
-          if (screenWasOff && settings.getBoolean(PreferenceKeys.CLEAR_PASSPHRASE_CACHE, false)) {
+          /* clear passphrase cache on first use after application startup or if screen was off;
+          also make sure to purge a stale cache after caching has been disabled via PGP settings */
+          if (screenWasOff && settings.getBoolean(PreferenceKeys.CLEAR_PASSPHRASE_CACHE, true)) {
             passphraseCache.clearAllCachedPassphrases(this@DecryptActivity)
             screenWasOff = false
           }

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -120,7 +120,7 @@
   <string name="pref_pgp_ascii_armor_title">Cifrar co modo ASCII armor</string>
   <string name="pref_passphrase_cache_title">Permitir usar a caché para frase de paso</string>
   <string name="pref_passphrase_cache_summary">AVISO: esta característica funciona ben pero é experimental. Require que a pantalla estea bloqueada.</string>
-  <string name="pref_passphrase_cache_authenticate_clear">Autenticarse para poder baleirar a cache</string>
+  <string name="pref_passphrase_cache_authenticate_enable">Autenticarse para activar a caché</string>
   <string name="pref_passphrase_cache_auto_clear_title">Limpar automáticamente a frase de paso da caché</string>
   <string name="pref_passphrase_cache_auto_clear_summary">Retira automáticamente a frase de paso da caché ao apagarse a pantalla</string>
   <!-- PasswordGenerator fragment -->

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -116,7 +116,7 @@
   <string name="pref_pgp_key_manager_title">Menedżer kluczy</string>
   <string name="pref_pgp_ascii_armor_title">Szyfruj w trybie ASCII-armor</string>
   <string name="pref_passphrase_cache_summary">UWAGA: ta funkcjonalność powinna działać poprawnie, ale jest bardzo eksperymentalna. Wymaga aktywnej blokady ekranu.</string>
-  <string name="pref_passphrase_cache_authenticate_clear">Uwierzytelnij aby wyczyścić pamięć podręczną</string>
+  <string name="pref_passphrase_cache_authenticate_enable">Uwierzytelnij aby włączyć pamięć podręczną</string>
   <string name="pref_passphrase_cache_auto_clear_title">Automatycznie wyczyść pamięć podręczną haseł</string>
   <string name="pref_passphrase_cache_auto_clear_summary">Czyści pamięć podręczną haseł po wyłączeniu ekranu</string>
   <!-- PasswordGenerator fragment -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,7 +137,7 @@
   <string name="pref_pgp_ascii_armor_title">Encrypt in ASCII armor mode</string>
   <string name="pref_passphrase_cache_title">Enable passphrase caching</string>
   <string name="pref_passphrase_cache_summary">WARNING: this feature is functional but very experimental. Requires an active screen lock.</string>
-  <string name="pref_passphrase_cache_authenticate_clear">Authenticate to clear cache</string>
+  <string name="pref_passphrase_cache_authenticate_enable">Authenticate to enable cache</string>
   <string name="pref_passphrase_cache_auto_clear_title">Automatically clear passphrase cache</string>
   <string name="pref_passphrase_cache_auto_clear_summary">Clears the passphrase cache when the screen is turned off</string>
 


### PR DESCRIPTION
Passphrase caching lowers app security. Therefore, and since caching requires an active screen lock, it makes more sense to require user authentication via screen lock when *enabling* the cache, rather than when disabling it. 

Also, the cached passphrase should be automatically cleared when disabling the cache in the PGP settings and this should not require additional user authentication.

This PR addresses these considerations. 