### PR TITLE
Fix application crash when disabling cache auto-clear option and potential attack vector

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
   <string name="pref_passphrase_cache_title">Enable passphrase caching</string>
   <string name="pref_passphrase_cache_summary">WARNING: this feature is functional but very experimental. Requires an active screen lock.</string>
   <string name="pref_passphrase_cache_authenticate_enable">Authenticate to enable cache</string>
+  <string name="pref_passphrase_cache_auto_clear_authenticate_disable">Authenticate to disable cache clearing</string>
   <string name="pref_passphrase_cache_auto_clear_title">Automatically clear passphrase cache</string>
   <string name="pref_passphrase_cache_auto_clear_summary">Clears the passphrase cache when the screen is turned off</string>
 


### PR DESCRIPTION
When disabling the passphrase cache auto-clear setting, the cache needs to be cleared once in order to prevent a malicious user (someone knowing the screen-lock pin but not knowing the correct passphrase) from bypassing the auto-clearing after waking up/unlocking the device, followed by disabling the auto-clearing option in the settings.

However, clearing `EncryptedSharedPreferences` requires authentication, otherwise the app crashes. Currently, a crash can be provoked as follows:

1. Open APS, make sure that passphrase caching and auto-clear option are both enabled.
2. Decrypt some entry in the store with the correct passphrase.
3. Switch off the screen.
4. Unlock the device again and keep it awake for one minute or two by doing something within another app, e.g. browsing the internet.       
5. Switch to APS, go directly to the PGP settings screen and disable the auto-clear option.
6. APS crashes and immediately reloads automatically.

APS crashes because the user authentication has expired in the meantime and clearing the passphrase from `EncryptedSharedPreferences` is attempted.

After the crash, the auto-clear option is disabled but the passphrase is still present in the cache. From now, the bad user is given access to any store entry by just entering the correct screen-lock pin, without the need to also enter the PGP passphrase. In this way, that user successfully bypassed and disabled the cache auto-clearing.

This PR 
1. restores `BiometricAuthenticator` before clearing the passphrase from `EncryptedSharedPreferences`. This prevents app crashing  
2. enforces the auto-clearing option to stay enabled in the case of failed authentication (caused by dismissing the authentication dialog). This prevents the attempt of bypassing cache auto-clearing.
