### PR TITLE
fix null pointer exception when using public only keys (#3143)

### DIFF
--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -54,7 +54,7 @@ public class PGPainlessCryptoHandler @Inject constructor() :
         }
         val keyringCollection =
           keys
-            .map { key -> PGPainless.readKeyRing().secretKeyRing(key.contents) }
+            .mapNotNull { key -> PGPainless.readKeyRing().secretKeyRing(key.contents) }
             .run(::PGPSecretKeyRingCollection)
         val protector = SecretKeyRingProtector.unlockAnyKeyWith(Passphrase.fromPassword(passphrase))
         val decryptionStream =


### PR DESCRIPTION
Don't call PGPSecretKeyRingCollection for public only keys