### PR TITLE
enable per-app language setting (Android-13+)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,8 @@ android {
   buildFeatures { compose = true }
   composeOptions { useLiveLiterals = false }
 
+  androidResources { generateLocaleConfig = true }
+
   packaging { resources.excludes.add("META-INF/versions/**") }
 }
 

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en


### PR DESCRIPTION
This rather small addition allows configuring the application's language via the device settings (Language option added):

device Settings --> Apps --> all apps --> Password Store --> Language

or via the App info shortcut --> Language.

This feature is available since [Android-13](https://developer.android.com/guide/topics/resources/app-languages#auto-localeconfig).