### PR TITLE
add user ID input field (password creation/edit), may fix #1458

### DIFF
--- a/app/src/main/java/app/passwordstore/Application.kt
+++ b/app/src/main/java/app/passwordstore/Application.kt
@@ -147,5 +147,6 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
 
     lateinit var instance: Application
     var screenWasOff: Boolean = true
+    var otpLabelFormat: String = ""
   }
 }

--- a/app/src/main/java/app/passwordstore/Application.kt
+++ b/app/src/main/java/app/passwordstore/Application.kt
@@ -147,6 +147,5 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
 
     lateinit var instance: Application
     var screenWasOff: Boolean = true
-    var otpLabelFormat: String = ""
   }
 }

--- a/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
+++ b/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
@@ -7,31 +7,45 @@ package app.passwordstore.data.password
 
 import app.passwordstore.data.passfile.Totp
 
-class FieldItem(val key: String, val value: String, val action: ActionType) {
+class FieldItem
+private constructor(
+  val type: ItemType,
+  val label: String,
+  val value: String,
+  val action: ActionType,
+) {
   enum class ActionType {
     COPY,
     HIDE,
   }
 
-  enum class ItemType(val type: String, val label: String) {
-    USERNAME("Username", "User ID"),
-    PASSWORD("Password", "Password"),
-    OTP("OTP", "OTP (expires in %ds)"),
+  enum class ItemType() {
+    USERNAME,
+    PASSWORD,
+    OTP,
+    FREEFORM,
   }
 
   companion object {
-
-    // Extra helper methods
-    fun createOtpField(totp: Totp, label: String): FieldItem {
-      return FieldItem(label.format(totp.remainingTime.inWholeSeconds), totp.value, ActionType.COPY)
+    fun createOtpField(label: String, totp: Totp): FieldItem {
+      return FieldItem(
+        ItemType.OTP,
+        label.format(totp.remainingTime.inWholeSeconds),
+        totp.value,
+        ActionType.COPY,
+      )
     }
 
-    fun createPasswordField(password: String, label: String): FieldItem {
-      return FieldItem(label, password, ActionType.HIDE)
+    fun createPasswordField(label: String, password: String): FieldItem {
+      return FieldItem(ItemType.PASSWORD, label, password, ActionType.HIDE)
     }
 
-    fun createUsernameField(username: String, label: String): FieldItem {
-      return FieldItem(label, username, ActionType.COPY)
+    fun createUsernameField(label: String, username: String): FieldItem {
+      return FieldItem(ItemType.USERNAME, label, username, ActionType.COPY)
+    }
+
+    fun createFreeformField(label: String, content: String): FieldItem {
+      return FieldItem(ItemType.FREEFORM, label, content, ActionType.COPY)
     }
   }
 }

--- a/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
+++ b/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
@@ -14,7 +14,7 @@ class FieldItem(val key: String, val value: String, val action: ActionType) {
   }
 
   enum class ItemType(val type: String, val label: String) {
-    USERNAME("Username", "Username"),
+    USERNAME("Username", "User ID"),
     PASSWORD("Password", "Password"),
     OTP("OTP", "OTP (expires in %ds)"),
   }
@@ -22,20 +22,16 @@ class FieldItem(val key: String, val value: String, val action: ActionType) {
   companion object {
 
     // Extra helper methods
-    fun createOtpField(totp: Totp): FieldItem {
-      return FieldItem(
-        ItemType.OTP.label.format(totp.remainingTime.inWholeSeconds),
-        totp.value,
-        ActionType.COPY,
-      )
+    fun createOtpField(totp: Totp, label: String): FieldItem {
+      return FieldItem(label.format(totp.remainingTime.inWholeSeconds), totp.value, ActionType.COPY)
     }
 
-    fun createPasswordField(password: String): FieldItem {
-      return FieldItem(ItemType.PASSWORD.label, password, ActionType.HIDE)
+    fun createPasswordField(password: String, label: String): FieldItem {
+      return FieldItem(label, password, ActionType.HIDE)
     }
 
-    fun createUsernameField(username: String): FieldItem {
-      return FieldItem(ItemType.USERNAME.label, username, ActionType.COPY)
+    fun createUsernameField(username: String, label: String): FieldItem {
+      return FieldItem(label, username, ActionType.COPY)
     }
   }
 }

--- a/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
-import app.passwordstore.Application.Companion.otpLabelFormat
 import app.passwordstore.R
 import app.passwordstore.data.passfile.Totp
 import app.passwordstore.data.password.FieldItem
@@ -39,13 +38,13 @@ class FieldItemAdapter(
     return fieldItemList.size
   }
 
-  fun updateOTPCode(totp: Totp) {
+  fun updateOTPCode(totp: Totp, labelFormat: String) {
     var otpItemPosition = -1
     fieldItemList =
       fieldItemList.mapIndexed { position, item ->
-        if (item.key.startsWith(FieldItem.ItemType.OTP.type, true)) {
+        if (item.type == FieldItem.ItemType.OTP) {
           otpItemPosition = position
-          return@mapIndexed FieldItem.createOtpField(totp, otpLabelFormat)
+          return@mapIndexed FieldItem.createOtpField(labelFormat, totp)
         }
 
         return@mapIndexed item
@@ -59,8 +58,8 @@ class FieldItemAdapter(
 
     fun bind(fieldItem: FieldItem, showPassword: Boolean, copyTextToClipboard: (String?) -> Unit) {
       with(binding) {
-        itemText.hint = fieldItem.key
-        itemTextContainer.hint = fieldItem.key
+        itemText.hint = fieldItem.label
+        itemTextContainer.hint = fieldItem.label
         itemText.setText(fieldItem.value)
 
         when (fieldItem.action) {
@@ -85,7 +84,7 @@ class FieldItemAdapter(
                 } else {
                   null
                 }
-              if (fieldItem.key == FieldItem.ItemType.PASSWORD.type) {
+              if (fieldItem.type == FieldItem.ItemType.PASSWORD) {
                 typeface =
                   ResourcesCompat.getFont(
                     binding.root.context,

--- a/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
+import app.passwordstore.Application.Companion.otpLabelFormat
 import app.passwordstore.R
 import app.passwordstore.data.passfile.Totp
 import app.passwordstore.data.password.FieldItem
@@ -44,7 +45,7 @@ class FieldItemAdapter(
       fieldItemList.mapIndexed { position, item ->
         if (item.key.startsWith(FieldItem.ItemType.OTP.type, true)) {
           otpItemPosition = position
-          return@mapIndexed FieldItem.createOtpField(totp)
+          return@mapIndexed FieldItem.createOtpField(totp, otpLabelFormat)
         }
 
         return@mapIndexed item

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -12,6 +12,7 @@ import android.view.MenuItem
 import androidx.core.content.edit
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
+import app.passwordstore.Application.Companion.otpLabelFormat
 import app.passwordstore.Application.Companion.screenWasOff
 import app.passwordstore.R
 import app.passwordstore.crypto.PGPIdentifier
@@ -136,8 +137,12 @@ class DecryptActivity : BasePGPActivity() {
     intent.putExtra("FILE_PATH", relativeParentPath)
     intent.putExtra("REPO_PATH", repoPath)
     intent.putExtra(PasswordCreationActivity.EXTRA_FILE_NAME, name)
+    intent.putExtra(PasswordCreationActivity.EXTRA_USERNAME, passwordEntry?.username)
     intent.putExtra(PasswordCreationActivity.EXTRA_PASSWORD, passwordEntry?.password)
-    intent.putExtra(PasswordCreationActivity.EXTRA_EXTRA_CONTENT, passwordEntry?.extraContentString)
+    intent.putExtra(
+      PasswordCreationActivity.EXTRA_EXTRA_CONTENT,
+      passwordEntry?.extraContentWithoutUsername,
+    )
     intent.putExtra(PasswordCreationActivity.EXTRA_EDITING, true)
     startActivity(intent)
     finish()
@@ -279,18 +284,19 @@ class DecryptActivity : BasePGPActivity() {
 
       val items = arrayListOf<FieldItem>()
       if (!entry.password.isNullOrBlank()) {
-        items.add(FieldItem.createPasswordField(entry.password!!))
+        items.add(FieldItem.createPasswordField(entry.password!!, getString(R.string.password)))
         if (settings.getBoolean(PreferenceKeys.COPY_ON_DECRYPT, false)) {
           copyPasswordToClipboard(entry.password)
         }
       }
 
+      otpLabelFormat = getString(R.string.otp_label_format)
       if (entry.hasTotp()) {
-        items.add(FieldItem.createOtpField(entry.totp.first()))
+        items.add(FieldItem.createOtpField(entry.totp.first(), otpLabelFormat))
       }
 
       if (!entry.username.isNullOrBlank()) {
-        items.add(FieldItem.createUsernameField(entry.username!!))
+        items.add(FieldItem.createUsernameField(entry.username!!, getString(R.string.username)))
       }
 
       entry.extraContent.forEach { (key, value) ->

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -211,7 +211,7 @@ class PasswordCreationActivity : BasePGPActivity() {
         AutofillPreferences.directoryStructure(this@PasswordCreationActivity) ==
           DirectoryStructure.EncryptedUsername || suggestedUsername != null
       ) {
-        usernameInputLayout.apply { visibility = View.VISIBLE }
+        usernameInputLayout.visibility = View.VISIBLE
         if (suggestedUsername != null) username.setText(suggestedUsername)
         else if (suggestedName != null) username.requestFocus()
       }

--- a/app/src/main/res/layout/password_creation_activity.xml
+++ b/app/src/main/res/layout/password_creation_activity.xml
@@ -55,6 +55,26 @@
         android:layout_height="wrap_content"
         android:imeOptions="actionNext"
         android:inputType="textNoSuggestions"
+        android:nextFocusForward="@id/username" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+      android:visibility="gone"
+      tools:visibility="visible"
+      android:id="@+id/username_input_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="8dp"
+      android:hint="@string/crypto_username_hint"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/name_input_layout">
+
+      <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/username"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:imeOptions="actionNext"
+        android:inputType="textNoSuggestions"
         android:nextFocusForward="@id/password" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -66,7 +86,7 @@
       android:hint="@string/crypto_pass_label"
       app:endIconMode="password_toggle"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/name_input_layout">
+      app:layout_constraintTop_toBottomOf="@id/username_input_layout">
 
       <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/password"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
 
   <!-- PGP Handler -->
   <string name="crypto_name_hint">Name</string>
+  <string name="crypto_username_hint">User ID</string>
   <string name="crypto_pass_label">Password</string>
   <string name="crypto_extra_label">Extra content</string>
   <string name="crypto_encrypt_username_label">Encrypt username</string>
@@ -87,7 +88,8 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Search</string>
   <string name="password">Password</string>
-  <string name="username">Username</string>
+  <string name="username">User ID</string>
+  <string name="otp_label_format">OTP (expires in %ds)</string>
   <string name="copy_label">Copy</string>
   <string name="edit_password">Edit password</string>
   <string name="copy_password">Copy password</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
 
   <!-- PGP Handler -->
   <string name="crypto_name_hint">Name</string>
-  <string name="crypto_username_hint">User ID</string>
+  <string name="crypto_username_hint">Username</string>
   <string name="crypto_pass_label">Password</string>
   <string name="crypto_extra_label">Extra content</string>
   <string name="crypto_encrypt_username_label">Encrypt username</string>
@@ -88,7 +88,7 @@
   <!-- DECRYPT Layout -->
   <string name="action_search">Search</string>
   <string name="password">Password</string>
-  <string name="username">User ID</string>
+  <string name="username">Username</string>
   <string name="otp_label_format">OTP (expires in %ds)</string>
   <string name="copy_label">Copy</string>
   <string name="edit_password">Edit password</string>

--- a/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
+++ b/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
@@ -80,6 +80,9 @@ constructor(
       return otp.value.value
     }
 
+  /** String representation of [extraContent] but with usernames stripped. */
+  public val extraContentWithoutUsername: String
+
   /**
    * String representation of [extraContent] but with authentication related data such as TOTP URIs
    * and usernames stripped.
@@ -91,6 +94,7 @@ constructor(
     val (foundPassword, passContent) = findAndStripPassword(content.split("\n".toRegex()))
     password = foundPassword
     extraContentString = passContent.joinToString("\n")
+    extraContentWithoutUsername = generateExtraContentWithoutUsername()
     extraContentWithoutAuthData = generateExtraContentWithoutAuthData()
     extraContent = generateExtraContentPairs()
     username = findUsername()
@@ -121,7 +125,7 @@ constructor(
     return Pair(passContent[0], passContent.minus(passContent[0]))
   }
 
-  private fun generateExtraContentWithoutAuthData(): String {
+  private fun generateExtraContentWithoutUsername(): String {
     var foundUsername = false
     return extraContentString
       .lineSequence()
@@ -132,6 +136,19 @@ constructor(
             foundUsername = true
             false
           }
+          else -> {
+            true
+          }
+        }
+      }
+      .joinToString(separator = "\n")
+  }
+
+  private fun generateExtraContentWithoutAuthData(): String {
+    return generateExtraContentWithoutUsername()
+      .lineSequence()
+      .filter { line ->
+        return@filter when {
           TotpFinder.TOTP_FIELDS.any { prefix -> line.startsWith(prefix, ignoreCase = true) } -> {
             false
           }


### PR DESCRIPTION
If PW file organization is set to `EncryptedUsername` (work/example.org(.gpg)), the username can only be set via the "Extra content" input field, see issue #1458. This PR inserts a `username` input field in the `PasswordCreationActivity` if `EncryptedUsername` is set, or if the "Encrypt username" switch is switched on with the other PW file organization options.

Similarly, when editing an existing PW entry, the username input box is shown, if a username is present in the stored entry, or if `EncryptedUsername` is enabled in the settings.

Maybe, the PW file organization setting should be moved into the "General options", as it is not only relevant for autofill, but for the password store as a whole, e. g. when adding a new password via the "Add" button.  