### PR TITLE
fix blocking createPasswordUI() when OTP is displayed

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -302,7 +302,7 @@ class DecryptActivity : BasePGPActivity() {
       binding.recyclerView.itemAnimator = null
 
       if (entry.hasTotp()) {
-        entry.totp.collect(adapter::updateOTPCode)
+        lifecycleScope.launch { entry.totp.collect(adapter::updateOTPCode) }
       }
     }
 


### PR DESCRIPTION
If the decrypted entry in the store contains an OTP, function `createPasswordUI()` becomes a blocking function. In this case, `startAutoDismissTimer()` and `onSuccess()` that come after `createPasswordUI()` in function `decryptWithPassphrase()` are not reached and executed. As a consequence, passphrase caching is not carried out and the passphrase must be entered again in order to decrypt another entry in the store.

The bug can be reproduced as follows:

1. Start APS, ensure that passphrase caching and auto-clean on screen-off are enabled.
2. Select a store entry with an OTP, unlock the cache with the screen-lock PIN and decrypt the entry with your passphrase
3. Select another (or the same) entry from the password list
4. Enter the PIN --> APS asks again for your passphrase, which should not be necessary if the previously entered passphrase were cached properly.

This PR tries to fix the issue.