### PR TITLE
directory structure setting moved to general settings

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
@@ -26,10 +26,10 @@ import app.passwordstore.util.auth.BiometricAuthenticator
 import app.passwordstore.util.auth.BiometricAuthenticator.Result as BiometricResult
 import app.passwordstore.util.autofill.AutofillPreferences
 import app.passwordstore.util.autofill.AutofillResponseBuilder
-import app.passwordstore.util.autofill.DirectoryStructure
 import app.passwordstore.util.extensions.asLog
 import app.passwordstore.util.features.Feature.EnablePGPPassphraseCache
 import app.passwordstore.util.features.Features
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.androidpasswordstore.autofillparser.AutofillAction
 import com.github.androidpasswordstore.autofillparser.Credentials

--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillFilterView.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillFilterView.kt
@@ -27,9 +27,9 @@ import app.passwordstore.data.password.PasswordItem
 import app.passwordstore.databinding.ActivityOreoAutofillFilterBinding
 import app.passwordstore.util.autofill.AutofillMatcher
 import app.passwordstore.util.autofill.AutofillPreferences
-import app.passwordstore.util.autofill.DirectoryStructure
 import app.passwordstore.util.coroutines.DispatcherProvider
 import app.passwordstore.util.extensions.viewBinding
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.viewmodel.FilterMode
 import app.passwordstore.util.viewmodel.ListMode
 import app.passwordstore.util.viewmodel.SearchMode

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -30,7 +30,6 @@ import app.passwordstore.ui.dialogs.DicewarePasswordGeneratorDialogFragment
 import app.passwordstore.ui.dialogs.OtpImportDialogFragment
 import app.passwordstore.ui.dialogs.PasswordGeneratorDialogFragment
 import app.passwordstore.util.autofill.AutofillPreferences
-import app.passwordstore.util.autofill.DirectoryStructure
 import app.passwordstore.util.extensions.asLog
 import app.passwordstore.util.extensions.base64
 import app.passwordstore.util.extensions.commitChange
@@ -39,6 +38,7 @@ import app.passwordstore.util.extensions.isInsideRepository
 import app.passwordstore.util.extensions.snackbar
 import app.passwordstore.util.extensions.unsafeLazy
 import app.passwordstore.util.extensions.viewBinding
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess

--- a/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import app.passwordstore.BuildConfig
 import app.passwordstore.R
-import app.passwordstore.util.autofill.DirectoryStructure
 import app.passwordstore.util.extensions.autofillManager
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.androidpasswordstore.autofillparser.BrowserAutofillSupportLevel
@@ -24,10 +23,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.Maxr1998.modernpreferences.PreferenceScreen
 import de.Maxr1998.modernpreferences.helpers.editText
 import de.Maxr1998.modernpreferences.helpers.onClick
-import de.Maxr1998.modernpreferences.helpers.singleChoice
 import de.Maxr1998.modernpreferences.helpers.switch
 import de.Maxr1998.modernpreferences.preferences.SwitchPreference
-import de.Maxr1998.modernpreferences.preferences.choice.SelectionItem
 
 class AutofillSettings(private val activity: FragmentActivity) : SettingsProvider {
 
@@ -100,16 +97,6 @@ class AutofillSettings(private val activity: FragmentActivity) : SettingsProvide
           }
           false
         }
-      }
-      val values =
-        activity.resources.getStringArray(R.array.oreo_autofill_directory_structure_values)
-      val titles =
-        activity.resources.getStringArray(R.array.oreo_autofill_directory_structure_entries)
-      val items = values.zip(titles).map { SelectionItem(it.first, it.second, null) }
-      singleChoice(PreferenceKeys.OREO_AUTOFILL_DIRECTORY_STRUCTURE, items) {
-        initialSelection = DirectoryStructure.DEFAULT.value
-        dependency = PreferenceKeys.AUTOFILL_ENABLE
-        titleRes = R.string.oreo_autofill_preference_directory_structure
       }
       editText(PreferenceKeys.OREO_AUTOFILL_DEFAULT_USERNAME) {
         dependency = PreferenceKeys.AUTOFILL_ENABLE

--- a/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
@@ -35,10 +35,8 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
         titleRes = R.string.pref_app_theme_title
       }
 
-      val values =
-        activity.resources.getStringArray(R.array.directory_structure_values)
-      val titles =
-        activity.resources.getStringArray(R.array.directory_structure_entries)
+      val values = activity.resources.getStringArray(R.array.directory_structure_values)
+      val titles = activity.resources.getStringArray(R.array.directory_structure_entries)
       val items = values.zip(titles).map { SelectionItem(it.first, it.second, null) }
       singleChoice(PreferenceKeys.DIRECTORY_STRUCTURE, items) {
         initialSelection = DirectoryStructure.DEFAULT.value

--- a/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
@@ -14,6 +14,7 @@ import app.passwordstore.R
 import app.passwordstore.util.auth.BiometricAuthenticator
 import app.passwordstore.util.auth.BiometricAuthenticator.Result
 import app.passwordstore.util.extensions.sharedPrefs
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.settings.PreferenceKeys
 import de.Maxr1998.modernpreferences.PreferenceScreen
 import de.Maxr1998.modernpreferences.helpers.onClick
@@ -32,6 +33,16 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
       singleChoice(PreferenceKeys.APP_THEME, themeItems) {
         initialSelection = activity.resources.getString(R.string.app_theme_def)
         titleRes = R.string.pref_app_theme_title
+      }
+
+      val values =
+        activity.resources.getStringArray(R.array.directory_structure_values)
+      val titles =
+        activity.resources.getStringArray(R.array.directory_structure_entries)
+      val items = values.zip(titles).map { SelectionItem(it.first, it.second, null) }
+      singleChoice(PreferenceKeys.DIRECTORY_STRUCTURE, items) {
+        initialSelection = DirectoryStructure.DEFAULT.value
+        titleRes = R.string.pref_directory_structure
       }
 
       val sortValues = activity.resources.getStringArray(R.array.sort_order_values)

--- a/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
+++ b/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
@@ -9,124 +9,15 @@ import app.passwordstore.data.passfile.PasswordEntry
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.sharedPrefs
 import app.passwordstore.util.services.getDefaultUsername
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.androidpasswordstore.autofillparser.Credentials
 import java.io.File
-import java.nio.file.Paths
-
-enum class DirectoryStructure(val value: String) {
-  EncryptedUsername("encrypted_username"),
-  FileBased("file"),
-  DirectoryBased("directory");
-
-  /**
-   * Returns the username associated to [file], following the convention of the current
-   * [DirectoryStructure].
-   *
-   * Examples:
-   * - * --> null (EncryptedUsername)
-   * - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
-   * - work/example.org/john@doe.org/password.gpg --> john@doe.org (DirectoryBased)
-   * - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
-   */
-  fun getUsernameFor(file: File): String? =
-    when (this) {
-      EncryptedUsername -> null
-      FileBased -> file.nameWithoutExtension
-      DirectoryBased -> file.parentFile?.name ?: file.nameWithoutExtension
-    }
-
-  /**
-   * Returns the origin identifier associated to [file], following the convention of the current
-   * [DirectoryStructure].
-   *
-   * At least one of [DirectoryStructure.getIdentifierFor] and
-   * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
-   *
-   * Examples:
-   * - work/example.org.gpg --> example.org (EncryptedUsername)
-   * - work/example.org/john@doe.org.gpg --> example.org (FileBased)
-   * - example.org.gpg --> example.org (FileBased, fallback)
-   * - work/example.org/john@doe.org/password.gpg --> example.org (DirectoryBased)
-   * - Temporary PIN.gpg --> null (DirectoryBased)
-   */
-  fun getIdentifierFor(file: File): String? =
-    when (this) {
-      EncryptedUsername -> file.nameWithoutExtension
-      FileBased -> file.parentFile?.name ?: file.nameWithoutExtension
-      DirectoryBased -> file.parentFile?.parent
-    }
-
-  /**
-   * Returns the path components of [file] until right before the component that contains the origin
-   * identifier according to the current [DirectoryStructure].
-   *
-   * Examples:
-   * - work/example.org.gpg --> work (EncryptedUsername)
-   * - work/example.org/john@doe.org.gpg --> work (FileBased)
-   * - example.org/john@doe.org.gpg --> null (FileBased)
-   * - john@doe.org.gpg --> null (FileBased)
-   * - work/example.org/john@doe.org/password.gpg --> work (DirectoryBased)
-   * - example.org/john@doe.org/password.gpg --> null (DirectoryBased)
-   */
-  fun getPathToIdentifierFor(file: File): String? =
-    when (this) {
-      EncryptedUsername -> file.parent
-      FileBased -> file.parentFile?.parent
-      DirectoryBased -> file.parentFile?.parentFile?.parent
-    }
-
-  /**
-   * Returns the path component of [file] following the origin identifier according to the current
-   * [DirectoryStructure](without file extension).
-   *
-   * At least one of [DirectoryStructure.getIdentifierFor] and
-   * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
-   *
-   * Examples:
-   * - * --> null (EncryptedUsername)
-   * - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
-   * - example.org.gpg --> null (FileBased, fallback)
-   * - work/example.org/john@doe.org/password.gpg --> john@doe.org/password (DirectoryBased)
-   * - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
-   */
-  fun getAccountPartFor(file: File): String? =
-    when (this) {
-      EncryptedUsername -> null
-      FileBased -> file.nameWithoutExtension.takeIf { file.parentFile != null }
-      DirectoryBased ->
-        file.parentFile?.let { parentFile -> "${parentFile.name}/${file.nameWithoutExtension}" }
-          ?: file.nameWithoutExtension
-    }
-
-  fun getSaveFolderName(sanitizedIdentifier: String, username: String?) =
-    when (this) {
-      EncryptedUsername -> "/"
-      FileBased -> sanitizedIdentifier
-      DirectoryBased -> Paths.get(sanitizedIdentifier, username ?: "username").toString()
-    }
-
-  fun getSaveFileName(username: String?, identifier: String) =
-    when (this) {
-      EncryptedUsername -> identifier
-      FileBased -> username
-      DirectoryBased -> "password"
-    }
-
-  companion object {
-
-    val DEFAULT = FileBased
-
-    private val reverseMap = entries.associateBy { it.value }
-
-    fun fromValue(value: String?) = if (value != null) reverseMap[value] ?: DEFAULT else DEFAULT
-  }
-}
 
 object AutofillPreferences {
 
   fun directoryStructure(context: Context): DirectoryStructure {
-    val value = context.sharedPrefs.getString(PreferenceKeys.OREO_AUTOFILL_DIRECTORY_STRUCTURE)
+    val value = context.sharedPrefs.getString(PreferenceKeys.DIRECTORY_STRUCTURE)
     return DirectoryStructure.fromValue(value)
   }
 

--- a/app/src/main/java/app/passwordstore/util/settings/DirectoryStructure.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/DirectoryStructure.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2014-2024 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.passwordstore.util.settings
+
+import java.io.File
+import java.nio.file.Paths
+
+enum class DirectoryStructure(val value: String) {
+  EncryptedUsername("encrypted_username"),
+  FileBased("file"),
+  DirectoryBased("directory");
+
+  /**
+   * Returns the username associated to [file], following the convention of the current
+   * [DirectoryStructure].
+   *
+   * Examples:
+   * - * --> null (EncryptedUsername)
+   * - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
+   * - work/example.org/john@doe.org/password.gpg --> john@doe.org (DirectoryBased)
+   * - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
+   */
+  fun getUsernameFor(file: File): String? =
+    when (this) {
+      EncryptedUsername -> null
+      FileBased -> file.nameWithoutExtension
+      DirectoryBased -> file.parentFile?.name ?: file.nameWithoutExtension
+    }
+
+  /**
+   * Returns the origin identifier associated to [file], following the convention of the current
+   * [DirectoryStructure].
+   *
+   * At least one of [DirectoryStructure.getIdentifierFor] and
+   * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
+   *
+   * Examples:
+   * - work/example.org.gpg --> example.org (EncryptedUsername)
+   * - work/example.org/john@doe.org.gpg --> example.org (FileBased)
+   * - example.org.gpg --> example.org (FileBased, fallback)
+   * - work/example.org/john@doe.org/password.gpg --> example.org (DirectoryBased)
+   * - Temporary PIN.gpg --> null (DirectoryBased)
+   */
+  fun getIdentifierFor(file: File): String? =
+    when (this) {
+      EncryptedUsername -> file.nameWithoutExtension
+      FileBased -> file.parentFile?.name ?: file.nameWithoutExtension
+      DirectoryBased -> file.parentFile?.parent
+    }
+
+  /**
+   * Returns the path components of [file] until right before the component that contains the origin
+   * identifier according to the current [DirectoryStructure].
+   *
+   * Examples:
+   * - work/example.org.gpg --> work (EncryptedUsername)
+   * - work/example.org/john@doe.org.gpg --> work (FileBased)
+   * - example.org/john@doe.org.gpg --> null (FileBased)
+   * - john@doe.org.gpg --> null (FileBased)
+   * - work/example.org/john@doe.org/password.gpg --> work (DirectoryBased)
+   * - example.org/john@doe.org/password.gpg --> null (DirectoryBased)
+   */
+  fun getPathToIdentifierFor(file: File): String? =
+    when (this) {
+      EncryptedUsername -> file.parent
+      FileBased -> file.parentFile?.parent
+      DirectoryBased -> file.parentFile?.parentFile?.parent
+    }
+
+  /**
+   * Returns the path component of [file] following the origin identifier according to the current
+   * [DirectoryStructure](without file extension).
+   *
+   * At least one of [DirectoryStructure.getIdentifierFor] and
+   * [DirectoryStructure.getAccountPartFor] will always return a non-null result.
+   *
+   * Examples:
+   * - * --> null (EncryptedUsername)
+   * - work/example.org/john@doe.org.gpg --> john@doe.org (FileBased)
+   * - example.org.gpg --> null (FileBased, fallback)
+   * - work/example.org/john@doe.org/password.gpg --> john@doe.org/password (DirectoryBased)
+   * - Temporary PIN.gpg --> Temporary PIN (DirectoryBased, fallback)
+   */
+  fun getAccountPartFor(file: File): String? =
+    when (this) {
+      EncryptedUsername -> null
+      FileBased -> file.nameWithoutExtension.takeIf { file.parentFile != null }
+      DirectoryBased ->
+        file.parentFile?.let { parentFile -> "${parentFile.name}/${file.nameWithoutExtension}" }
+          ?: file.nameWithoutExtension
+    }
+
+  fun getSaveFolderName(sanitizedIdentifier: String, username: String?) =
+    when (this) {
+      EncryptedUsername -> "/"
+      FileBased -> sanitizedIdentifier
+      DirectoryBased -> Paths.get(sanitizedIdentifier, username ?: "username").toString()
+    }
+
+  fun getSaveFileName(username: String?, identifier: String) =
+    when (this) {
+      EncryptedUsername -> identifier
+      FileBased -> username
+      DirectoryBased -> "password"
+    }
+
+  companion object {
+
+    val DEFAULT = FileBased
+
+    private val reverseMap = entries.associateBy { it.value }
+
+    fun fromValue(value: String?) = if (value != null) reverseMap[value] ?: DEFAULT else DEFAULT
+  }
+}

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -56,7 +56,7 @@ object PreferenceKeys {
   const val LENGTH = "length"
   const val OREO_AUTOFILL_CUSTOM_PUBLIC_SUFFIXES = "oreo_autofill_custom_public_suffixes"
   const val OREO_AUTOFILL_DEFAULT_USERNAME = "oreo_autofill_default_username"
-  const val OREO_AUTOFILL_DIRECTORY_STRUCTURE = "oreo_autofill_directory_structure"
+  const val DIRECTORY_STRUCTURE = "directory_structure"
   const val PREF_KEY_PWGEN_TYPE = "pref_key_pwgen_type"
   const val REPOSITORY_INITIALIZED = "repository_initialized"
   const val REPO_CHANGED = "repo_changed"

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -56,7 +56,7 @@ object PreferenceKeys {
   const val LENGTH = "length"
   const val OREO_AUTOFILL_CUSTOM_PUBLIC_SUFFIXES = "oreo_autofill_custom_public_suffixes"
   const val OREO_AUTOFILL_DEFAULT_USERNAME = "oreo_autofill_default_username"
-  const val DIRECTORY_STRUCTURE = "directory_structure"
+  const val DIRECTORY_STRUCTURE = "oreo_autofill_directory_structure"
   const val PREF_KEY_PWGEN_TYPE = "pref_key_pwgen_type"
   const val REPOSITORY_INITIALIZED = "repository_initialized"
   const val REPO_CHANGED = "repo_changed"

--- a/app/src/main/java/app/passwordstore/util/viewmodel/SearchableRepositoryViewModel.kt
+++ b/app/src/main/java/app/passwordstore/util/viewmodel/SearchableRepositoryViewModel.kt
@@ -25,9 +25,9 @@ import app.passwordstore.data.password.PasswordItem
 import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.util.autofill.AutofillPreferences
-import app.passwordstore.util.autofill.DirectoryStructure
 import app.passwordstore.util.checkMainThread
 import app.passwordstore.util.coroutines.DispatcherProvider
+import app.passwordstore.util.settings.DirectoryStructure
 import app.passwordstore.util.settings.PasswordSortOrder
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.androidpasswordstore.sublimefuzzy.Fuzzy

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -91,6 +91,7 @@
   <string name="ssh_key_error_dialog_text">Nachricht : \n</string>
   <string name="pref_recursive_filter_title">Suche in Unterordnern</string>
   <string name="pref_recursive_filter_summary">Findet Passwörter auch in Unterordnern.</string>
+  <string name="pref_directory_structure">Passwort-Datei-Organisation</string>
   <string name="pref_sort_order_title">Passwortsortierung</string>
   <string name="pref_folder_first_sort_order">Ordner zuerst</string>
   <string name="pref_file_first_sort_order">Dateien zuerst</string>
@@ -190,7 +191,6 @@
   <string name="oreo_autofill_password_fill_support">Passwörter ausfüllen</string>
   <string name="oreo_autofill_flaky_fill_support">Passwörter ausfüllen (kann manchmal sein, dass Sie den Browser neu starten müssen)</string>
   <string name="oreo_autofill_no_support">Kein Support</string>
-  <string name="oreo_autofill_preference_directory_structure">Passwort-Datei-Organisation</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store kann das Ausfüllen von Anmeldeformularen und sogar das Speichern von Anmeldedaten in Apps oder auf Webseiten übernehmen.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Um diese Funktion zu aktivieren, tippen Sie auf OK, um zu Autofill-Einstellungen zu gelangen. Dort wählen Sie \"Password Store\" aus der Liste und bestätigen Sie die Bestätigungsaufforderung mit \"OK\".</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Autofill-Unterstützung mit installierten Browsern:</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,6 +95,7 @@
   <string name="ssh_key_error_dialog_text">Message : \n</string>
   <string name="pref_recursive_filter_title">Filtrage récursif</string>
   <string name="pref_recursive_filter_summary">Cherche le mot de passe dans tous les sous-répertoires du répertoire actuel.</string>
+  <string name="pref_directory_structure">Organisation des fichiers de mot de passe</string>
   <string name="pref_sort_order_title">Ordre de tri des mots de passe</string>
   <string name="pref_folder_first_sort_order">Dossiers en premier</string>
   <string name="pref_file_first_sort_order">Fichiers en premier</string>
@@ -194,7 +195,6 @@
   <string name="oreo_autofill_password_fill_support">Remplir le mot de passe</string>
   <string name="oreo_autofill_flaky_fill_support">Remplir les mots de passe (peut nécessiter un redémarrage du navigateur de temps à autre)</string>
   <string name="oreo_autofill_no_support">Pas de support</string>
-  <string name="oreo_autofill_preference_directory_structure">Organisation des fichiers de mot de passe</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store vous permet de remplir des formulaires de connexion ainsi que d\'enregistrer vos identifiants d\'applications ou de sites Web.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Pour activer cette fonctionnalité, appuyez sur OK pour aller dans les paramètres de saisie automatique, sélectionnez Password Store dans la liste puis confirmez avec OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Prise en charge du remplissage automatique avec les navigateurs installés:</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -97,6 +97,7 @@
   <string name="ssh_key_error_dialog_text">Mensaxe : \n</string>
   <string name="pref_recursive_filter_title">Filtro recursivo</string>
   <string name="pref_recursive_filter_summary">Atopa as chaves de xeito recursivo no directorio actual.</string>
+  <string name="pref_directory_structure">Organización dos contrasinais</string>
   <string name="pref_sort_order_title">Orde para mostrar contrasinais</string>
   <string name="pref_folder_first_sort_order">Primeiro cartafoles</string>
   <string name="pref_file_first_sort_order">Primeiro ficheiros</string>
@@ -207,7 +208,6 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="oreo_autofill_password_fill_support">Completar contrasinais</string>
   <string name="oreo_autofill_flaky_fill_support">Completa as credenciais (poderías ter que reiniciar o navegador de cando en vez)</string>
   <string name="oreo_autofill_no_support">Sen soporte</string>
-  <string name="oreo_autofill_preference_directory_structure">Organización dos contrasinais</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store pode ofrecerche completar formularios e incluso gardar contrasinais que escribes en apps e sitios web.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Para habilitar esta característica toca en OK e vaite ós axustes de autocompletado. Alí, escolle Password Store da lista e confirma a solicitude premendo no OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Soporte de autocompletado cos navegadores:</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -95,6 +95,7 @@
   <string name="ssh_key_error_dialog_text">Messaggio : \n</string>
   <string name="pref_recursive_filter_title">Filtro ricorsivo</string>
   <string name="pref_recursive_filter_summary">Trova ricorsivamente le password della directory corrente.</string>
+  <string name="pref_directory_structure">Organizzazione dei file di password</string>
   <string name="pref_sort_order_title">Ordine password</string>
   <string name="pref_folder_first_sort_order">Prima le cartelle</string>
   <string name="pref_file_first_sort_order">Prima i file</string>
@@ -189,7 +190,6 @@
   <string name="oreo_autofill_password_fill_support">Compila le password</string>
   <string name="oreo_autofill_flaky_fill_support">Compila le password (potrebbe richiedere il riavvio del browser di tanto in tanto)</string>
   <string name="oreo_autofill_no_support">Nessun supporto</string>
-  <string name="oreo_autofill_preference_directory_structure">Organizzazione dei file di password</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store può offrire di compilare i moduli di accesso e persino di salvare le credenziali che inserisci in app o su siti web.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Per abilitare questa funzionalità, tocca OK per andare alle impostazioni di Auto-Compilazione. Lì, seleziona Password Store dall\'elenco e conferma la richiesta di conferma con OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Supporto all\'auto-compilazione con i browser installati:</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -95,6 +95,7 @@
   <string name="ssh_key_error_dialog_text">메시지 : \n</string>
   <string name="pref_recursive_filter_title">순환 필터링</string>
   <string name="pref_recursive_filter_summary">현재 위치의 모든 하위 디렉토리에서 암호를 찾습니다.</string>
+  <string name="pref_directory_structure">암허 파일 정리</string>
   <string name="pref_sort_order_title">암호 정렬 순서</string>
   <string name="pref_folder_first_sort_order">폴더 우선</string>
   <string name="pref_file_first_sort_order">파일 우선</string>
@@ -201,7 +202,6 @@
   <string name="oreo_autofill_password_fill_support">암호 입력</string>
   <string name="oreo_autofill_flaky_fill_support">비밀번호 채우기 (때때로 브라우저를 다시 시작해야 할 수 있음)</string>
   <string name="oreo_autofill_no_support">지원하지 않음</string>
-  <string name="oreo_autofill_preference_directory_structure">암허 파일 정리</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store는 로그인 양식을 작성하고 앱이나 웹사이트에 입력한 자격 증명을 저장하는 기능도 제공합니다.</string>
   <string name="oreo_autofill_enable_dialog_instructions">이 기능을 사용하려면 확인을 탭하여 자동 완성 설정으로 이동합니다. 목록에서 암호 저장을 선택하고 확인으로 확인 메시지를 확인합니다.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">자동 완성 지원 하는 설치된 브라우저:</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -94,6 +94,7 @@
   <string name="ssh_key_error_dialog_text">Wiadomość: \n</string>
   <string name="pref_recursive_filter_title">Filtrowanie rekurencyjne</string>
   <string name="pref_recursive_filter_summary">Rekurencyjnie znajdź hasła aktualnego katalogu.</string>
+  <string name="pref_directory_structure">Organizacja plików haseł</string>
   <string name="pref_sort_order_title">Kolejność sortowania haseł</string>
   <string name="pref_folder_first_sort_order">Najpierw foldery</string>
   <string name="pref_file_first_sort_order">Najpierw pliki</string>
@@ -200,7 +201,6 @@
   <string name="oreo_autofill_password_fill_support">Wypełnij hasła</string>
   <string name="oreo_autofill_flaky_fill_support">Wypełnij hasła (może wymagać ponownego uruchomienia przeglądarki od czasu do czasu)</string>
   <string name="oreo_autofill_no_support">Brak wsparcia</string>
-  <string name="oreo_autofill_preference_directory_structure">Organizacja plików haseł</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store może zaoferować wypełnianie formularzy logowania, a nawet zapisywanie danych logowania, które wpisujesz w aplikacjach lub na stronach internetowych.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Aby włączyć tę funkcję, naciśnij przycisk OK, aby przejść do ustawień autouzupełniania. Następnie wybierz Password Store z listy i potwierdź przyciskiem OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Obsługa autouzupełniania w zainstalowanych przeglądarkach:</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -95,6 +95,7 @@
   <string name="ssh_key_error_dialog_text">Mensagem : \n</string>
   <string name="pref_recursive_filter_title">Filtragem recursiva</string>
   <string name="pref_recursive_filter_summary">Encontrar senhas do diretório corrente recursivamente.</string>
+  <string name="pref_directory_structure">Organização do arquivo de senha</string>
   <string name="pref_sort_order_title">Ordenação da Senha</string>
   <string name="pref_folder_first_sort_order">Pastas primeiro</string>
   <string name="pref_file_first_sort_order">Arquivos primeiro</string>
@@ -199,7 +200,6 @@
   <string name="oreo_autofill_password_fill_support">Preencher as senhas</string>
   <string name="oreo_autofill_flaky_fill_support">Preencher senhas (pode ser necessário reiniciar o navegador de vez em quando)</string>
   <string name="oreo_autofill_no_support">Sem suporte</string>
-  <string name="oreo_autofill_preference_directory_structure">Organização do arquivo de senha</string>
   <string name="oreo_autofill_enable_dialog_description">O Password Store pode oferecer para preencher formulários de login e até mesmo salvar credenciais inseridas em aplicativos ou em sites.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Para ativar esse recurso, toque em OK para ir para as configurações de preenchimento automático. Lá, selecione Password Store na lista e confirme na tela confirmação com OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Suporte ao preenchimento automático com navegadores instalados:</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -100,6 +100,7 @@
   <string name="ssh_key_error_dialog_text">Сообщение: \n</string>
   <string name="pref_recursive_filter_title">Рекурсивная фильтрация</string>
   <string name="pref_recursive_filter_summary">Рекурсивный поиск паролей в текущей директории</string>
+  <string name="pref_directory_structure">Организация файла паролей</string>
   <string name="pref_sort_order_title">Порядок сортировки паролей</string>
   <string name="pref_folder_first_sort_order">Сначала папки</string>
   <string name="pref_file_first_sort_order">Сначала файлы</string>
@@ -199,7 +200,6 @@
   <string name="oreo_autofill_password_fill_support">Заполнить пароли</string>
   <string name="oreo_autofill_flaky_fill_support">Заполнить учетные данные (время от времени может требоваться перезапуск браузера)</string>
   <string name="oreo_autofill_no_support">Не поддерживается</string>
-  <string name="oreo_autofill_preference_directory_structure">Организация файла паролей</string>
   <string name="oreo_autofill_enable_dialog_description">Хранилище паролей может предложить заполнить формы входа и даже сохранить учетные данные в приложениях или на веб-сайтах.</string>
   <string name="oreo_autofill_enable_dialog_instructions">Чтобы включить эту функцию, нажмите ОК, чтобы перейти к настройкам автозаполнения. Там выберите Password Store из списка и подтвердите запрос подтверждения, нажав ОК.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Поддержка автозаполнения установленными браузерами:</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -96,6 +96,7 @@
   <string name="ssh_key_error_dialog_text">消息: </string>
   <string name="pref_recursive_filter_title">递归过滤</string>
   <string name="pref_recursive_filter_summary">递归式寻找当前目录的密码</string>
+  <string name="pref_directory_structure">密码文件组</string>
   <string name="pref_sort_order_title">密码排序顺序</string>
   <string name="pref_folder_first_sort_order">目录优先</string>
   <string name="pref_file_first_sort_order">文件优先</string>
@@ -208,7 +209,6 @@
   <string name="oreo_autofill_password_fill_support">填写密码</string>
   <string name="oreo_autofill_flaky_fill_support">填充密码 (可能需要偶尔重启浏览器)</string>
   <string name="oreo_autofill_no_support">无支持</string>
-  <string name="oreo_autofill_preference_directory_structure">密码文件组</string>
   <string name="oreo_autofill_enable_dialog_description">密码仓库可以填写登录表单,甚至可以保存您在应用程序或网站上输入的凭据</string>
   <string name="oreo_autofill_enable_dialog_instructions">要启用此功能,请点击确定转到自动填充设置 在那里,从列表中选择密码存储并使用确认确认提示</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">已安装支持自动填充的浏览器:</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -24,12 +24,12 @@
     <item>classic</item>
     <item>diceware</item>
   </string-array>
-  <string-array name="oreo_autofill_directory_structure_entries">
+  <string-array name="directory_structure_entries">
     <item>work/example.org(.gpg)</item>
     <item>work/example.org/john@doe.org(.gpg)</item>
     <item>work/example.org/john@doe.org/password(.gpg)</item>
   </string-array>
-  <string-array name="oreo_autofill_directory_structure_values">
+  <string-array name="directory_structure_values">
     <item>encrypted_username</item>
     <item>file</item>
     <item>directory</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
   <string name="ssh_key_error_dialog_text">Message : \n</string>
   <string name="pref_recursive_filter_title">Recursive filtering</string>
   <string name="pref_recursive_filter_summary">Recursively find passwords of the current directory.</string>
+  <string name="pref_directory_structure">Password file organization</string>
   <string name="pref_sort_order_title">Password sort order</string>
   <string name="pref_folder_first_sort_order">Folders first</string>
   <string name="pref_file_first_sort_order">Files first</string>
@@ -236,7 +237,6 @@
   <string name="oreo_autofill_password_fill_support">Fill passwords</string>
   <string name="oreo_autofill_flaky_fill_support">Fill passwords (may require restarting the browser from time to time)</string>
   <string name="oreo_autofill_no_support">No support</string>
-  <string name="oreo_autofill_preference_directory_structure">Password file organization</string>
   <string name="oreo_autofill_enable_dialog_description">Password Store can offer to fill login forms and even save credentials you enter in apps or on websites.</string>
   <string name="oreo_autofill_enable_dialog_instructions">To enable this feature, tap OK to go to Autofill settings. There, select Password Store from the list and confirm the confirmation prompt with OK.</string>
   <string name="oreo_autofill_enable_dialog_installed_browsers">Autofill support with installed browsers:</string>


### PR DESCRIPTION
The directory structure in which password entries are stored is of general significance, not just for autofill purposes. A user might prefer encryption of the login-id together with the password for more privacy, without actually using the autofill feature but using the "Add" button on the password list in general.

This PR moves the "Password file organisation" setting from the Autofill to the General Settings and makes it independent from the former's activation.